### PR TITLE
ENT-599 Fixing mixup between dash and underscore

### DIFF
--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -27,6 +27,7 @@ class EnterpriseReportSender(object):
     VERTICA_QUERY_FIELDS = (
         'enterprise_user_id',
         'lms_user_id',
+        'uid_stripped',
         'enrollment_created_timestamp',
         'consent_granted',
         'course_id',
@@ -45,7 +46,7 @@ class EnterpriseReportSender(object):
     REPORT_FILE_NAME_FORMAT = "{path}/{enterprise_id}_{date}.{extension}"
     REPORT_EMAIL_SUBJECT = 'edX Learner Report'
     REPORT_EMAIL_BODY = ''
-    REPORT_EMAIL_FROM_EMAIL = os.environ.get('ENTERPRISE_REPORTING_FROM_ADDRESS')
+    REPORT_EMAIL_FROM_EMAIL = os.environ.get('SEND_EMAIL_FROM')
 
     FILE_WRITE_DIRECTORY = '/tmp'
 

--- a/enterprise_reporting/send_enterprise_reports.py
+++ b/enterprise_reporting/send_enterprise_reports.py
@@ -60,7 +60,7 @@ def cleanup_files(enterprise_id):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-e', '--enterprise_customer', required=False, type=str,
+    parser.add_argument('-e', '--enterprise-customer', required=False, type=str,
                         help="EnterpriseCustomer UUID.")
 
     args = parser.parse_args()

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -29,6 +29,8 @@ FREQUENCY_TYPE_DAILY = 'daily'
 FREQUENCY_TYPE_MONTHLY = 'monthly'
 FREQUENCY_TYPE_WEEKLY = 'weekly'
 
+AWS_REGION = 'us-east-1'
+
 
 def compress_and_encrypt(filename, password):
     """
@@ -69,10 +71,10 @@ def send_email_with_attachment(subject, body, from_email, to_email, filename):
     msg.attach(part)
 
     # connect to SES
-    client = boto3.client('ses')
+    client = boto3.client('ses', region_name=AWS_REGION)
 
     # and send the message
-    result = client.send_raw_email(msg.as_string(), source=msg['From'], destinations=[msg['To']])
+    result = client.send_raw_email(RawMessage={'Data': msg.as_string()}, Source=msg['From'], Destinations=[msg['To']])
     LOGGER.debug(result)
 
 


### PR DESCRIPTION
*The jenkins job is expecting the long argument to be enterprise-customer
instead of enterprise_customer, so calling with the argument fails when you
build with parameters. Fixing that here because it is easier :-)
*Adding the tpa id in the data query pull.
*Fixing reading of 'SEND_EMAIL_FROM' environment setting
*Defining the AWS region
*Fixing the SES email call