### PR TITLE
[ENT-765] Report subject line now includes enterprise name

### DIFF
--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -44,7 +44,7 @@ class EnterpriseReportSender(object):
         'user_current_enrollment_mode',
     )
     REPORT_FILE_NAME_FORMAT = "{path}/{enterprise_id}_{date}.{extension}"
-    REPORT_EMAIL_SUBJECT = 'edX Learner Report'
+    REPORT_EMAIL_SUBJECT = '{enterprise_name} edX Learner Data'
     REPORT_EMAIL_BODY = ''
     REPORT_EMAIL_FROM_EMAIL = os.environ.get('SEND_EMAIL_FROM')
 
@@ -86,11 +86,15 @@ class EnterpriseReportSender(object):
             decrypt_string(self.reporting_config['password'], self.reporting_config['initialization_vector'])
         )
 
+        data_report_subject = self.REPORT_EMAIL_SUBJECT.format(
+            enterprise_name=enterprise_customer_name
+        )
+
         # email the file to the email address in the configuration
         LOGGER.debug('Sending encrypted data to {}'.format(enterprise_customer_name))
         try:
             send_email_with_attachment(
-                self.REPORT_EMAIL_SUBJECT,
+                data_report_subject,
                 self.REPORT_EMAIL_BODY,
                 self.REPORT_EMAIL_FROM_EMAIL,
                 self.reporting_config['email'],

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -45,7 +45,12 @@ class EnterpriseReportSender(object):
     )
     REPORT_FILE_NAME_FORMAT = "{path}/{enterprise_id}_{date}.{extension}"
     REPORT_EMAIL_SUBJECT = '{enterprise_name} edX Learner Data'
-    REPORT_EMAIL_BODY = ''
+    REPORT_EMAIL_BODY ="""
+Please find attached employee progress data for courses on edX.
+For any questions or concerns, please contact your edX sales representative.
+Thanks,
+The edX for Business Team
+"""
     REPORT_EMAIL_FROM_EMAIL = os.environ.get('SEND_EMAIL_FROM')
 
     FILE_WRITE_DIRECTORY = '/tmp'


### PR DESCRIPTION
<img width="627" alt="screen shot 2017-11-20 at 4 21 40 pm" src="https://user-images.githubusercontent.com/1643389/33042210-fe070304-ce0e-11e7-8c2f-088043288efe.png">

Verified here: https://tools-edx-jenkins.edx.org/job/enterprise/job/enterprise-data-reporting/706/

Sender name change will come PR to jenkins-job-dsl-internal repo (https://github.com/edx/jenkins-job-dsl-internal/pull/145)