### PR TITLE
Specify futures should only be installed on Python 2.7.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,3 +11,4 @@ boto3==1.4.7
 cryptography==1.9
 paramiko==2.4
 Django==1.8.18
+futures==3.2.0; python_version == "2.7"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 first==2.0.1              # via pip-tools
 future==0.16.0            # via vertica-python
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 idna==2.6                 # via cryptography
 ipaddress==1.0.19         # via cryptography
 jmespath==0.9.3           # via boto3, botocore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 first==2.0.1              # via pip-tools
 future==0.16.0            # via vertica-python
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 idna==2.6                 # via cryptography
 ipaddress==1.0.19         # via cryptography
 jmespath==0.9.3           # via boto3, botocore


### PR DESCRIPTION
`s3tranfer` required by `boto` wants to install `futures`, but it doesn't work on Python 3. See https://pypi.python.org/pypi/futures/3.2.0.