### PR TITLE
Use django-fernet-fields to derive Fernet key from secret stored in configuration.

### DIFF
--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -17,6 +17,7 @@ import boto3
 import pyminizip
 from cryptography.fernet import Fernet
 from django.utils.encoding import force_text
+from fernet_fields.hkdf import derive_fernet_key
 
 
 LOGGER = logging.getLogger(__name__)
@@ -105,5 +106,9 @@ def decrypt_string(string):
     """
     Decrypts a string that was encrypted using Fernet symmetric encryption.
     """
-    fernet = Fernet(os.environ.get('LMS_FERNET_KEY'))
+    fernet = Fernet(
+        derive_fernet_key(
+            os.environ.get('LMS_FERNET_KEY')
+        )
+    )
     return force_text(fernet.decrypt(bytes(string)))

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,4 +11,5 @@ boto3==1.4.7
 cryptography==1.9
 paramiko==2.4
 Django==1.8.18
+django-fernet-fields==0.5
 futures==3.2.0; python_version == "2.7"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,7 @@ cffi==1.11.4              # via bcrypt, cryptography, pynacl
 click==6.7                # via pip-tools
 colorama==0.3.7           # via awscli
 cryptography==1.9
+django-fernet-fields==0.5
 django==1.8.18
 docutils==0.14            # via awscli, botocore
 edx-rest-api-client==1.7.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,6 +17,7 @@ cffi==1.11.4              # via bcrypt, cryptography, pynacl
 click==6.7                # via pip-tools
 colorama==0.3.7           # via awscli
 cryptography==1.9
+django-fernet-fields==0.5
 django==1.8.18
 docutils==0.14            # via awscli, botocore
 edx-rest-api-client==1.7.1


### PR DESCRIPTION
django-fernet-fields derives the key which it uses to encrypt data from the key you provide in Django settings. We need to do the same here to decrypt to data.

https://django-fernet-fields.readthedocs.io/en/latest/#disabling-hkdf