### PR TITLE
ENT-833 Support multiple emails in the delivery logic

### DIFF
--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -165,7 +165,7 @@ class EmailDeliveryMethod(object):
     REPORT_EMAIL_FROM_EMAIL = os.environ.get('SEND_EMAIL_FROM')
 
     def __init__(self, email, password, enteprise_customer_name):
-        self.email = email
+        self.email = email if isinstance(email, list) else [email] # convert to list if it's not already
         self.password = password
         self.enterprise_customer_name = enteprise_customer_name
 
@@ -181,7 +181,7 @@ class EmailDeliveryMethod(object):
             enterprise_name=self.enterprise_customer_name
         )
 
-        # email the file to the email address in the configuration
+        # email the file to the email address(es) in the configuration
         LOGGER.info('Sending encrypted data to {}'.format(self.enterprise_customer_name))
         try:
             send_email_with_attachment(
@@ -192,7 +192,7 @@ class EmailDeliveryMethod(object):
                 data_report_zip_name
             )
             LOGGER.info('Email report with encrypted zip successfully sent to {} for {}'.format(
-                self.email,
+                ', '.join(self.email),
                 self.enterprise_customer_name
             ))
         except SMTPException:

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -73,7 +73,7 @@ def send_email_with_attachment(subject, body, from_email, to_email, filename):
     client = boto3.client('ses', region_name=AWS_REGION)
 
     # and send the message
-    result = client.send_raw_email(RawMessage={'Data': msg.as_string()}, Source=msg['From'], Destinations=[msg['To']])
+    result = client.send_raw_email(RawMessage={'Data': msg.as_string()}, Source=msg['From'], Destinations=msg['To'])
     LOGGER.debug(result)
 
 


### PR DESCRIPTION
**Description:** Support sending to multiple emails by allowing the `email` field to be either a string (like it is was before) or a list (how it will be moving forward). If the `email` field is a string, we convert it to a list. This is so that it is a non-breaking change. [Related PR](https://github.com/edx/edx-enterprise/pull/290) for `edx-enterprise`.

**JIRA:** [ENT-833](https://openedx.atlassian.net/browse/ENT-833)