### PR TITLE
Fixing issue with list in email headers

### DIFF
--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -51,32 +51,32 @@ def send_email_with_attachment(subject, body, from_email, to_email, filename):
 
     Adapted from https://gist.github.com/yosemitebandit/2883593
     """
-    msg = MIMEMultipart()
-    msg['Subject'] = subject
-    msg['From'] = from_email
-
-    # NOTE: msg['To'] is in the headers of the email and must be a string.
-    # The actual list of emails is used in the client.send_raw_email method below.
-    msg['To'] = ','.join(to_email)
-
-    # what a recipient sees if they don't use an email reader
-    msg.preamble = 'Multipart message.\n'
-
-    # the message body
-    part = MIMEText(body)
-    msg.attach(part)
-
-    # the attachment
-    part = MIMEApplication(open(filename, 'rb').read())
-    part.add_header('Content-Disposition', 'attachment', filename=os.path.basename(filename))
-    part.set_type('application/zip')
-    msg.attach(part)
-
     # connect to SES
     client = boto3.client('ses', region_name=AWS_REGION)
 
-    # and send the message to each email address independently
+    # the message body
+    msg_body = MIMEText(body)
+    
+    # the attachment
+    msg_attachment = MIMEApplication(open(filename, 'rb').read())
+    msg_attachment.add_header('Content-Disposition', 'attachment', filename=os.path.basename(filename))
+    msg_attachment.set_type('application/zip')
+
+    # iterate over each email in the list to send emails independently
     for email in to_email:
+        msg = MIMEMultipart()
+        msg['Subject'] = subject
+        msg['From'] = from_email
+        msg['To'] = email
+
+        # what a recipient sees if they don't use an email reader
+        msg.preamble = 'Multipart message.\n'
+
+        # attach the message body and attachment
+        msg.attach(msg_body)
+        msg.attach(msg_attachment)
+
+        # and send the message
         result = client.send_raw_email(RawMessage={'Data': msg.as_string()}, Source=msg['From'], Destinations=[email])
         LOGGER.debug(result)
 


### PR DESCRIPTION
Now that I was able to actually test the sending of reports to multiple emails, I noticed that there was an error in the build about not having an `encode` method on the `list` data type.

Upon further investigation, I learned that `msg['To']` is actually setting the email headers (which must be a string) as opposed to the `client.send_raw_email` method accepting a list.

This PR fixes this issue by converting the email list to a comma-separated string before setting the `msg['To']` header.