### PR TITLE
[ENT-1026] Allow specifying a catalog UUID.

### DIFF
--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -48,10 +48,12 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
         )
 
     @EdxOAuth2APIClient.refresh_token
-    def get_content_metadata(self, enterprise_customer_uuid):
+    def get_content_metadata(self, enterprise_customer_uuid, enterprise_customer_catalog_uuid=None):
         """Return all content metadata contained in the catalogs associated with an Enterprise Customer."""
         content_metadata = OrderedDict()
-        enterprise_customer_catalogs = self._load_data(
+        enterprise_customer_catalogs = {
+            'results': ['uuid': enterprise_customer_catalog_uuid]
+        } if enterprise_customer_catalog_uuid else self._load_data(
             self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,
             should_traverse_pagination=True,
             querystring={

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -52,7 +52,7 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
         """Return all content metadata contained in the catalogs associated with an Enterprise Customer."""
         content_metadata = OrderedDict()
         enterprise_customer_catalogs = {
-            'results': ['uuid': enterprise_customer_catalog_uuid]
+            'results': [{'uuid': enterprise_customer_catalog_uuid}]
         } if enterprise_customer_catalog_uuid else self._load_data(
             self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,
             should_traverse_pagination=True,

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -64,6 +64,7 @@ class EnterpriseReportSender(object):
         self.enterprise_customer_name = reporting_config['enterprise_customer']['name']
         self.data_type = reporting_config['data_type']
         self.report_type = reporting_config['report_type']
+        self.enterprise_customer_catalog_uuid = reporting_config['_enterprise_customer_catalog_uuid']
 
     @staticmethod
     def create(reporting_config):
@@ -197,7 +198,17 @@ class EnterpriseReportSender(object):
     def __get_content_metadata(self):
         """Get content metadata from the Enterprise Customer Catalog API."""
         enterprise_api_client = EnterpriseAPIClient()
-        LOGGER.info('Gathering all catalog content metadata...')
-        content_metadata = enterprise_api_client.get_content_metadata(self.enterprise_customer_uuid)
+        info_msg = (
+            'Gathering all catalog content metadata...'
+            if not self.enterprise_customer_catalog_uuid else
+            'Looking specifically for metadata from catalog with UUID {}'.format(
+                self.enterprise_customer_catalog_uuid
+            )
+        )
+        LOGGER.info(info_msg)
+        content_metadata = enterprise_api_client.get_content_metadata(
+            self.enterprise_customer_uuid,
+            enterprise_customer_catalog_uuid=self.enterprise_customer_catalog_uuid
+        )
         LOGGER.debug('Gathered this content metadata: {}'.format(content_metadata))
         return content_metadata

--- a/enterprise_reporting/send_enterprise_reports.py
+++ b/enterprise_reporting/send_enterprise_reports.py
@@ -73,6 +73,10 @@ def process_reports():
     parser = argparse.ArgumentParser()
     parser.add_argument('-e', '--enterprise-customer', required=False, type=str,
                         help="Enterprise Customer's UUID. If specified, data delivery is forced.")
+    parser.add_argument('-c', '--enterprise-catalog', required=False, type=str,
+                        help="Enterprise Customer Catalog UUID. If specified and the data type "
+                             "for any of the customer's reporting configs is for catalogs, "
+                             "only the content metadata from the catalog with this UUID will get sent.")
     parser.add_argument('-d', '--data-type', required=False, type=str, choices=DATA_TYPES,
                         help="Data type. If specified, only this type of data for the customer(s) will be sent, "
                              "whether forced or not.")
@@ -96,6 +100,9 @@ def process_reports():
             reporting_config['data_type'],
             reporting_config['report_type'],
         ))
+
+        # Add any special arguments to be taken into account into the config.
+        reporting_config['_enterprise_customer_catalog_uuid'] = args.enterprise_catalog
 
         if should_deliver_report(args, reporting_config):
             send_data(reporting_config)


### PR DESCRIPTION
This allows us to specify an enterprise customer catalog UUID so that only that catalog has any content metadata pulled from it when the data type is `catalog` for any reporting configuration that appears.
