### PR TITLE
Adds an endpoint for dashboard analytics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.1.8] - 2018-06-29
+--------------------
+* Introduce endpoint for returning summary data about enterprise enrollments.
+
 [0.1.7] - 2018-06-28
 --------------------
 * Make the enterprise enrollment schema match the field changes made in the pipeline.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/urls.py
+++ b/enterprise_data/api/urls.py
@@ -4,12 +4,8 @@ URL definitions for enterprise data API endpoint.
 """
 from __future__ import absolute_import, unicode_literals
 
-from rest_framework.urlpatterns import format_suffix_patterns
-
 from django.conf.urls import include, url
 
 urlpatterns = [
     url(r'^v0/', include('enterprise_data.api.v0.urls', 'v0'), name='api_v0'),
 ]
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/enterprise_data/api/v0/urls.py
+++ b/enterprise_data/api/v0/urls.py
@@ -4,12 +4,15 @@ URL definitions for enterprise data api version 1 endpoint.
 """
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import url
+from rest_framework.routers import DefaultRouter
 
 from enterprise_data.api.v0 import views
 
-urlpatterns = [
-    url(r'^enterprise/(?P<enterprise_id>.+)/enrollments/$',
-        views.EnterpriseEnrollmentsView.as_view(),
-        name='enterprise_enrollments'),
-]
+router = DefaultRouter()  # pylint: disable=invalid-name
+router.register(
+    r'enterprise/(?P<enterprise_id>.+)/enrollments',
+    views.EnterpriseEnrollmentsViewSet,
+    'enterprise-enrollments',
+)
+
+urlpatterns = router.urls

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -4,27 +4,130 @@ Views for enterprise api version 0 endpoint.
 """
 from __future__ import absolute_import, unicode_literals
 
+from datetime import date, timedelta
+from logging import getLogger
+
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from edx_rest_framework_extensions.paginators import DefaultPagination
-from rest_framework import generics
+from rest_framework import viewsets
+from rest_framework.decorators import list_route
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
 
 from enterprise_data.api.v0 import serializers
 from enterprise_data.filters import ConsentGrantedFilterBackend
 from enterprise_data.models import EnterpriseEnrollment
 from enterprise_data.permissions import IsStaffOrEnterpriseUser
 
+LOGGER = getLogger(__name__)
 
-class EnterpriseEnrollmentsView(generics.ListAPIView):
+
+class EnterpriseViewSet(viewsets.ViewSet):
     """
-    The EnterpriseEnrollments view returns all learner enrollment records for a given enterprise
+    Base class for all Enterprise view sets.
     """
-    serializer_class = serializers.EnterpriseEnrollmentSerializer
-    pagination_class = DefaultPagination
     authentication_classes = (JwtAuthentication,)
-    permission_classes = (IsStaffOrEnterpriseUser,)
     filter_backends = (ConsentGrantedFilterBackend,)
+    pagination_class = DefaultPagination
+    permission_classes = (IsStaffOrEnterpriseUser,)
     CONSENT_GRANTED_FILTER = 'consent_granted'
 
+    def filter_queryset(self, queryset):
+        """
+        Filters queryset to only return consenting learners.
+        """
+        return ConsentGrantedFilterBackend().filter_queryset(self.request, queryset, view=self)
+
+    def ensure_data_exists(self, request, data, error_message=None):
+        """
+        Ensure that the API response brings us valid data. If not, raise an error and log it.
+        """
+        if not data:
+            error_message = (
+                error_message or "Unable to fetch API response from endpoint '{}'.".format(request.get_full_path())
+            )
+            LOGGER.error(error_message)
+            raise NotFound(error_message)
+
+
+class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+    """
+    Viewset for routes related to Enterprise course enrollments.
+    """
+    serializer_class = serializers.EnterpriseEnrollmentSerializer
+
     def get_queryset(self):
+        """
+        Returns all learner enrollment records for a given enterprise.
+        """
         enterprise_id = self.kwargs['enterprise_id']
-        return EnterpriseEnrollment.objects.filter(enterprise_id=enterprise_id)
+        enrollments = EnterpriseEnrollment.objects.filter(enterprise_id=enterprise_id)
+        enrollments = self.filter_queryset(enrollments)
+        self.ensure_data_exists(
+            self.request,
+            enrollments,
+            error_message=(
+                "No course enrollments are associated with Enterprise {enterprise_id} from endpoint '{path}'."
+                .format(
+                    enterprise_id=enterprise_id,
+                    path=self.request.get_full_path()
+                )
+            )
+        )
+        return enrollments
+
+    def filter_distinct_learners(self, queryset):
+        """
+        Filters queryset to include enrollments with a distinct `enterprise_user_id`.
+        """
+        return queryset.values_list('enterprise_user_id', flat=True).distinct()
+
+    def filter_active_learners(self, queryset, last_activity_date):
+        """
+        Filters queryset to include enrollments more recent than the specified `last_activity_date`.
+        """
+        return self.filter_distinct_learners(
+            queryset.filter(last_activity_date__gte=last_activity_date)
+        )
+
+    def filter_course_completions(self, queryset):
+        """
+        Filters queryset to include only enrollments that are passing (i.e., completion).
+        """
+        return queryset.filter(has_passed=1)
+
+    def subtract_one_month(self, original_date):
+        """
+        Returns a date exactly one month prior to the passed in date.
+        """
+        one_day = timedelta(days=1)
+        one_month_earlier = original_date - one_day
+        while one_month_earlier.month == original_date.month or one_month_earlier.day > original_date.day:
+            one_month_earlier -= one_day
+        return one_month_earlier
+
+    @list_route()
+    def overview(self, request, **kwargs):  # pylint: disable=unused-argument
+        """
+        Returns the following data:
+            - # of enrolled learners;
+            - # of active learners in the past week/month;
+            - # of course completions.
+        """
+        enrollments = self.get_queryset()
+        course_completions = self.filter_course_completions(enrollments)
+        distinct_learners = self.filter_distinct_learners(enrollments)
+        past_week_date = date.today() - timedelta(weeks=1)
+        past_month_date = self.subtract_one_month(date.today())
+        active_learners_week = self.filter_active_learners(enrollments, past_week_date)
+        active_learners_month = self.filter_active_learners(enrollments, past_month_date)
+
+        content = {
+            'enrolled_learners': distinct_learners.count(),
+            'active_learners': {
+                'past_week': active_learners_week.count(),
+                'past_month': active_learners_month.count(),
+            },
+            'course_completions': course_completions.count(),
+        }
+        return Response(content)

--- a/enterprise_data/fixtures/enterprise_enrollment.json
+++ b/enterprise_data/fixtures/enterprise_enrollment.json
@@ -109,5 +109,42 @@
       "course_price": 200.00,
       "discount_price": 120.00
     }
+  },
+  {
+    "model": "enterprise_data.EnterpriseEnrollment",
+    "pk": 4,
+    "fields": {
+      "enterprise_id": "ee5e6b3a069a4947bb8dd2dbc323396c",
+      "enterprise_name": "Enterprise 1",
+      "lms_user_id": 11,
+      "enterprise_user_id": 3,
+      "course_id": "edX/Open_DemoX/edx_demo_course",
+      "enrollment_created_timestamp": "2014-06-27 16:02:38",
+      "user_current_enrollment_mode": "verified",
+      "consent_granted": 1,
+      "letter_grade": null,
+      "has_passed": 0,
+      "passed_timestamp": null,
+      "enterprise_sso_uid": "harry",
+      "course_title": "All about acceptance testing!",
+      "course_start": "2016-09-01",
+      "course_end": "2016-12-01",
+      "course_pacing_type": "instructor_paced",
+      "course_duration_weeks": "8",
+      "course_min_effort": 2,
+      "course_max_effort": 4,
+      "user_account_creation_timestamp": "2015-02-12 23:14:35",
+      "user_email": "test@example.com",
+      "user_username": "test_user",
+      "course_key": "edX/Open_DemoX",
+      "user_country_code": "US",
+      "last_activity_date": "2017-06-23",
+      "coupon_name": "Enterprise Entitlement Coupon",
+      "coupon_code": "PIPNJSUK33P7PTZH",
+      "offer": "Percentage, 100 (#1234)",
+      "current_grade": 0.80,
+      "course_price": 200.00,
+      "discount_price": 120.00
+    }
   }
 ]

--- a/enterprise_data/tests/test_filters.py
+++ b/enterprise_data/tests/test_filters.py
@@ -22,7 +22,7 @@ class TestConsentGrantedFilterBackend(APITestCase):
         super(TestConsentGrantedFilterBackend, self).setUp()
         self.user = UserFactory(is_staff=True)
         self.client.force_authenticate(user=self.user)
-        self.url = reverse('v0:enterprise_enrollments',
+        self.url = reverse('v0:enterprise-enrollments-list',
                            kwargs={'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'})
 
     def test_filter_for_list(self):
@@ -33,6 +33,6 @@ class TestConsentGrantedFilterBackend(APITestCase):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        # Fixture data for enterprise 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c' contains 2 objects but only 1 with consent
-        assert EnterpriseEnrollment.objects.filter(enterprise_id='ee5e6b3a-069a-4947-bb8d-d2dbc323396c').count() == 2
-        assert len(data['results']) == 1
+        # Fixture data for enterprise 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c' contains 3 objects but only 3 with consent
+        assert EnterpriseEnrollment.objects.filter(enterprise_id='ee5e6b3a-069a-4947-bb8d-d2dbc323396c').count() == 3
+        assert len(data['results']) == 2

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -13,22 +13,22 @@ from test_utils import UserFactory
 
 
 @mark.django_db
-class TestEnterpriseEnrollmentsView(APITestCase):
+class TestEnterpriseEnrollmentsViewSet(APITestCase):
     """
-    Tests for EnterpriseEnrollmentsView
+    Tests for EnterpriseEnrollmentsViewSet
     """
     fixtures = ('enterprise_enrollment',)
 
     def setUp(self):
-        super(TestEnterpriseEnrollmentsView, self).setUp()
+        super(TestEnterpriseEnrollmentsViewSet, self).setUp()
         self.user = UserFactory(is_staff=True)
         self.client.force_authenticate(user=self.user)
-        self.url = reverse('v0:enterprise_enrollments',
-                           kwargs={'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'})
 
     def test_get_queryset_returns_enrollments(self):
+        url = reverse('v0:enterprise-enrollments-list',
+                      kwargs={'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'})
         expected_result = {
-            'count': 1,
+            'count': 2,
             'num_pages': 1,
             'current_page': 1,
             'results': [{
@@ -67,13 +67,72 @@ class TestEnterpriseEnrollmentsView(APITestCase):
                 'discount_price': '120.00',
                 'course_api_url': ('/enterprise/v1/enterprise-catalogs/ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
                                    '/courses/edX/Open_DemoX/edx_demo_course'),
+            }, {
+                'enrollment_created_timestamp': '2014-06-27T21:02:38Z',
+                'user_current_enrollment_mode': 'verified',
+                'last_activity_date': '2017-06-23',
+                'has_passed': False,
+                'course_id': 'edX/Open_DemoX/edx_demo_course',
+                'id': 4,
+                'course_min_effort': 2,
+                'course_start': '2016-09-01T05:00:00Z',
+                'enterprise_user_id': 3,
+                'user_country_code': 'US',
+                'course_title': 'All about acceptance testing!',
+                'course_duration_weeks': '8',
+                'course_pacing_type': 'instructor_paced',
+                'user_username': 'test_user',
+                'enterprise_sso_uid': 'harry',
+                'enterprise_site_id': None,
+                'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c',
+                'course_end': '2016-12-01T06:00:00Z',
+                'lms_user_id': 11,
+                'enterprise_name': 'Enterprise 1',
+                'letter_grade': None,
+                'user_account_creation_timestamp': '2015-02-13T05:14:35Z',
+                'passed_timestamp': None,
+                'course_max_effort': 4,
+                'consent_granted': True,
+                'user_email': 'test@example.com',
+                'course_key': 'edX/Open_DemoX',
+                'coupon_name': 'Enterprise Entitlement Coupon',
+                'coupon_code': 'PIPNJSUK33P7PTZH',
+                'offer': 'Percentage, 100 (#1234)',
+                'current_grade': 0.80,
+                'course_price': '200.00',
+                'discount_price': '120.00',
+                'course_api_url': ('/enterprise/v1/enterprise-catalogs/ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
+                                   '/courses/edX/Open_DemoX/edx_demo_course'),
             }],
             'next': None,
             'start': 0,
             'previous': None
         }
 
-        response = self.client.get(self.url)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert result == expected_result
+
+    def test_get_queryset_throws_error(self):
+        url = reverse('v0:enterprise-enrollments-list',
+                      kwargs={'enterprise_id': '0395b02f-6b29-42ed-9a41-45f3dff8349c'})
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_overview_returns_overview(self):
+        url = reverse('v0:enterprise-enrollments-overview',
+                      kwargs={'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'})
+        expected_result = {
+            'enrolled_learners': 2,
+            'active_learners': {
+                'past_week': 0,
+                'past_month': 0,
+            },
+            'course_completions': 1,
+        }
+
+        response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
         assert result == expected_result

--- a/enterprise_reporting/__init__.py
+++ b/enterprise_reporting/__init__.py
@@ -4,4 +4,4 @@ Enterprise data report scripts. These scripts are used by jenkins jobs to delive
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -15,13 +15,12 @@ from email.mime.text import MIMEText
 from io import open  # pylint: disable=redefined-builtin
 
 import boto3
+import pyminizip
 import pytz
 from cryptography.fernet import Fernet
 from fernet_fields.hkdf import derive_fernet_key
 
 from django.utils.encoding import force_text
-
-import pyminizip
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
For the enterprise admin dashboard project, we would like to display aggregate data about an enterprise's learners. The current endpoint in the enterprise data api returns a detailed list of all course enrollments for an enterprise but does not offer any insights into aggregate data. 

[ENT-1056](https://openedx.atlassian.net/browse/ENT-1056) describes 3 fields we would like to see in the admin dashboard for now. This PR creates a new endpoint that returns those 3 fields:
1. Number of enrolled learners;
2. Number of active learners in the:
    - Past week
    - Past month
3. Number of course completions.

Example response:
```json
{
    "active_learners": {
        "past_month": 2,
        "past_week": 1
    },
    "enrolled_learners": 3,
    "course_completions": 2
}
```
