### PR TITLE
Refactor consent filter backend & support sorting for enrollments endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.1.9] - 2018-07-13
+--------------------
+* Add support for sorting in the `enrollments` endpoint.
+* Fix broken link in `README`.
+
 [0.1.8] - 2018-06-29
 --------------------
 * Introduce endpoint for returning summary data about enterprise enrollments.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
1. Remove the need to override the `filter_queryset` in `EnterpriseViewSet`;
2. Update the `enrollments` enrollment to support sorting using the built-in ordering from `rest_framework`.

