### PR TITLE
Return number of enterprise users in overview endpoint

### DIFF
--- a/enterprise_data/fixtures/enterprise_user.json
+++ b/enterprise_data/fixtures/enterprise_user.json
@@ -1,0 +1,63 @@
+[
+    {
+      "model": "enterprise_data.EnterpriseUser",
+      "pk": 1,
+      "fields": {
+        "enterprise_id": "ee5e6b3a069a4947bb8dd2dbc323396c",
+        "lms_user_id": 11,
+        "enterprise_user_id": 1,
+        "enterprise_sso_uid": "harry",
+        "user_account_creation_timestamp": "2015-02-12 23:14:35",
+        "user_email": "test@example.com",
+        "user_username": "test_user",
+        "user_country_code": "US",
+        "last_activity_date": "2017-06-23"
+      }
+    },
+    {
+      "model": "enterprise_data.EnterpriseUser",
+      "pk": 2,
+      "fields": {
+        "enterprise_id": "ee5e6b3a069a4947bb8dd2dbc323396c",
+        "lms_user_id": 11,
+        "enterprise_user_id": 1,
+        "enterprise_sso_uid": "harry",
+        "user_account_creation_timestamp": "2015-02-12 23:14:35",
+        "user_email": "test@example.com",
+        "user_username": "test_user",
+        "user_country_code": "US",
+        "last_activity_date": "2017-06-23"
+      }
+    },
+    {
+      "model": "enterprise_data.EnterpriseUser",
+      "pk": 3,
+      "fields": {
+        "enterprise_id": "9339ad5d5363564d7b3d4efbb257384b",
+        "lms_user_id": 11,
+        "enterprise_user_id": 2,
+        "enterprise_sso_uid": "harry",
+        "user_account_creation_timestamp": "2015-02-12 23:14:35",
+        "user_email": "test2@example.com",
+        "user_username": "test_user2",
+        "user_country_code": "US",
+        "last_activity_date": "2017-06-23"
+      }
+    },
+    {
+      "model": "enterprise_data.EnterpriseUser",
+      "pk": 4,
+      "fields": {
+        "enterprise_id": "ee5e6b3a069a4947bb8dd2dbc323396c",
+        "lms_user_id": 11,
+        "enterprise_user_id": 3,
+        "enterprise_sso_uid": "harry",
+        "user_account_creation_timestamp": "2015-02-12 23:14:35",
+        "user_email": "test@example.com",
+        "user_username": "test_user",
+        "user_country_code": "US",
+        "last_activity_date": "2017-06-23"
+      }
+    }
+  ]
+  

--- a/enterprise_data/migrations/0001_initial.py
+++ b/enterprise_data/migrations/0001_initial.py
@@ -46,4 +46,24 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'Enterprise Enrollments',
             },
         ),
+        migrations.CreateModel(
+            name='EnterpriseUser',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('enterprise_id', models.CharField(max_length=32)),
+                ('lms_user_id', models.PositiveIntegerField()),
+                ('enterprise_user_id', models.PositiveIntegerField()),
+                ('enterprise_sso_uid', models.CharField(max_length=255, null=True)),
+                ('user_account_creation_timestamp', models.DateTimeField(null=True)),
+                ('user_email', models.CharField(max_length=255, null=True)),
+                ('user_username', models.CharField(max_length=255, null=True)),
+                ('user_country_code', models.CharField(max_length=2, null=True)),
+                ('last_activity_date', models.DateField(null=True)),       
+            ],
+            options={
+                'db_table': 'enterprise_user',
+                'verbose_name': 'Enterprise User',
+                'verbose_name_plural': 'Enterprise Users',
+            },
+        )
     ]

--- a/enterprise_data/models.py
+++ b/enterprise_data/models.py
@@ -15,16 +15,14 @@ LOGGER = getLogger(__name__)
 
 @python_2_unicode_compatible
 class EnterpriseEnrollment(models.Model):
-    """
-    Enterprise Enrollment is the learner details for a specific course enrollment.
+    """Enterprise Enrollment is the learner details for a specific course enrollment.
 
     This information includes a mix of the learners meta data (email, username, etc), the enterprise they are
     associated with (enterprise_id, enterprise_name, etc), and their status in the course (course_id,
-    letter_grade, has_passed, etc)
-
+    letter_grade, has_passed, etc).
     This is meant to closely mirror the data the Enterprises recieve in the automated report (see enterprise_reporting
     folder in this repo), with the exception of some data that is only calculated in Vertica as this data is pulled from
-    the analytics result store via the analytics-data-api project
+    the analytics result store via the analytics-data-api project.
     """
 
     class Meta:
@@ -74,6 +72,45 @@ class EnterpriseEnrollment(models.Model):
         return "<Enterprise Enrollment for user {user} in {course}>".format(
             user=self.enterprise_user_id,
             course=self.course_id
+        )
+
+    def __repr__(self):
+        """
+        Return uniquely identifying string representation.
+        """
+        return self.__str__()
+
+
+@python_2_unicode_compatible
+class EnterpriseUser(models.Model):
+    """Information includes a mix of the user's meta data.
+
+    Includes (lms_user_id, username, etc), and the enterprise they are associated with (enterprise_id).
+    """
+
+    class Meta:
+        app_label = 'enterprise_data'
+        db_table = 'enterprise_user'
+        verbose_name = _("Enterprise User")
+        verbose_name_plural = _("Enterprise Users")
+
+    enterprise_id = models.UUIDField()
+    lms_user_id = models.PositiveIntegerField()
+    enterprise_user_id = models.PositiveIntegerField()
+    enterprise_sso_uid = models.CharField(max_length=255, null=True)
+    user_account_creation_timestamp = models.DateTimeField(null=True)
+    user_email = models.CharField(max_length=255, null=True)
+    user_username = models.CharField(max_length=255, null=True)
+    user_country_code = models.CharField(max_length=2, null=True)
+    last_activity_date = models.DateField(null=True)
+
+    def __str__(self):
+        """
+        Return a human-readable string representation of the object.
+        """
+        return "<Enterprise User {user} in {enterprise}>".format(
+            user=self.lms_user_id,
+            enterprise=self.enterprise_id
         )
 
     def __repr__(self):

--- a/enterprise_data/tests/test_filters.py
+++ b/enterprise_data/tests/test_filters.py
@@ -16,7 +16,7 @@ class TestConsentGrantedFilterBackend(APITestCase):
     """
     Test suite for the ``TestConsentGrantedFilterBackend`` filter.
     """
-    fixtures = ('enterprise_enrollment',)
+    fixtures = ('enterprise_enrollment', 'enterprise_user', )
 
     def setUp(self):
         super(TestConsentGrantedFilterBackend, self).setUp()

--- a/enterprise_data/tests/test_models.py
+++ b/enterprise_data/tests/test_models.py
@@ -7,7 +7,7 @@ import unittest
 import ddt
 from pytest import mark
 
-from test_utils import EnterpriseEnrollmentFactory
+from test_utils import EnterpriseEnrollmentFactory, EnterpriseUserFactory
 
 
 @mark.django_db
@@ -31,3 +31,24 @@ class TestEnterpriseEnrollment(unittest.TestCase):
         """
         expected_str = '<Enterprise Enrollment for user 1234 in course-v1:edX+DemoX+DemoCourse>'
         assert expected_str == method(self.enrollment)
+
+
+@mark.django_db
+@ddt.ddt
+class TestEnterpriseUser(unittest.TestCase):
+    """
+    Tests for Enterprise User model
+    """
+    def setUp(self):
+        enterprise_id = 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
+        lms_user_id = 1234
+        self.user = EnterpriseUserFactory(lms_user_id=lms_user_id, enterprise_id=enterprise_id)
+        super(TestEnterpriseUser, self).setUp()
+
+    @ddt.data(str, repr)
+    def test_string_conversion(self, method):
+        """
+        Test conversion to string.
+        """
+        expected_str = '<Enterprise User 1234 in ee5e6b3a-069a-4947-bb8d-d2dbc323396c>'
+        assert expected_str == method(self.user)

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -10,7 +10,7 @@ from faker import Factory as FakerFactory
 
 from django.contrib.auth.models import User
 
-from enterprise_data.models import EnterpriseEnrollment
+from enterprise_data.models import EnterpriseEnrollment, EnterpriseUser
 
 FAKER = FakerFactory.create()
 
@@ -60,3 +60,23 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_superuser = False
     last_login = datetime(2012, 1, 1)
     date_joined = datetime(2011, 1, 1)
+
+
+class EnterpriseUserFactory(factory.django.DjangoModelFactory):
+    """
+    Enterprise User Factory.
+
+    Creates an instance of Enteprise User with minimal boilerplate
+    """
+    class Meta(object):
+        model = EnterpriseUser
+
+    enterprise_id = factory.lazy_attribute(lambda x: 'ee5e6b3a069a4947bb8dd2dbc323396c')
+    lms_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))
+    enterprise_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))
+    enterprise_sso_uid = factory.lazy_attribute(lambda x: FAKER.text(max_nb_chars=255))
+    user_account_creation_timestamp = datetime(2011, 1, 1)
+    user_username = factory.Sequence(u'robot{0}'.format)
+    user_email = factory.Sequence(u'robot+test+{0}@edx.org'.format)
+    user_country_code = factory.lazy_attribute(lambda x: FAKER.country_code())
+    last_activity_date = datetime(2012, 1, 1)

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -17,7 +17,7 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
     """
     Tests for EnterpriseEnrollmentsViewSet
     """
-    fixtures = ('enterprise_enrollment',)
+    fixtures = ('enterprise_enrollment', 'enterprise_user', )
 
     def setUp(self):
         super(TestEnterpriseEnrollmentsViewSet, self).setUp()
@@ -131,6 +131,7 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
             },
             'course_completions': 1,
             'last_updated_date': '2018-08-01T04:14:35Z',
+            'number_of_users': 3,
         }
 
         response = self.client.get(url)

--- a/enterprise_reporting/export_edxapp_data.py
+++ b/enterprise_reporting/export_edxapp_data.py
@@ -34,8 +34,9 @@ import os
 import sys
 from io import open  # pylint: disable=redefined-builtin
 
-import mysql.connector
 import vertica_python
+
+import mysql.connector
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 


### PR DESCRIPTION
Added functionality so that number of users(enrolled AND not enrolled) is returned in the overview endpoint. Changed the use of user id from "enterprise_user_id" to "lms_user_id" based on what was discussed at standup