### PR TITLE
ENT-1126 Gate access to admin users based on group membership

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.2.0] - 2018-07-31
+--------------------
+* Add additional authorization check to enterprise data api endpoint.
+
 [0.1.9] - 2018-07-13
 --------------------
 * Add support for sorting in the `enrollments` endpoint.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.1.9"
+__version__ = "0.2.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/tests/test_permissions.py
+++ b/enterprise_data/tests/test_permissions.py
@@ -50,7 +50,8 @@ class TestIsStaffOrEnterpriseUser(TestCase):
         self.enterprise_api_client.return_value.get_enterprise_learner.return_value = {
             'enterprise_customer': {
                 'uuid': self.enterprise_id
-            }
+            },
+            'groups': ['enterprise_data_api_access'],
         }
         self.assertTrue(self.permission.has_permission(self.request, None))
 
@@ -58,6 +59,16 @@ class TestIsStaffOrEnterpriseUser(TestCase):
         self.enterprise_api_client.return_value.get_enterprise_learner.return_value = {
             'enterprise_customer': {
                 'uuid': 'some-other-enterprise-id'
-            }
+            },
+            'groups': ['enterprise_data_api_access'],
+        }
+        self.assertFalse(self.permission.has_permission(self.request, None))
+
+    def test_enterprise_learner_has_no_group_access(self):
+        self.enterprise_api_client.return_value.get_enterprise_learner.return_value = {
+            'enterprise_customer': {
+                'uuid': 'some-other-enterprise-id'
+            },
+            'groups': [],
         }
         self.assertFalse(self.permission.has_permission(self.request, None))

--- a/enterprise_reporting/__init__.py
+++ b/enterprise_reporting/__init__.py
@@ -4,4 +4,4 @@ Enterprise data report scripts. These scripts are used by jenkins jobs to delive
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"


### PR DESCRIPTION
Similar to how we gate access to the enrollment api by checking membership in a django group, this PR adds the check to the data api to restrict access only to users we have granted it to.