### PR TITLE
Add .json files to manifest so fixtures are published

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
-recursive-include enterprise_data *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
-recursive-include enterprise_reporting *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
+recursive-include enterprise_data *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt *.json
+recursive-include enterprise_reporting *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt *.json
 recursive-include requirements *.txt


### PR DESCRIPTION
Fixtures were missing from the published package because json files were not included in the manifest.