### PR TITLE
upgrade django to support edx-analytics-data-api.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@ awscli==1.11.178                        # for assuming aws roles for sending ema
 boto3==1.4.7
 cryptography==1.9
 paramiko==2.4
-Django==1.11.5
+Django==1.11.15
 django-fernet-fields==0.5
 futures==3.2.0; python_version == "2.7"
 six==1.11.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,28 +18,31 @@ click==6.7                # via pip-tools
 colorama==0.3.7           # via awscli
 cryptography==1.9
 django-fernet-fields==0.5
-django==1.11.5
+django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3  # via edx-drf-extensions
 docutils==0.14            # via awscli, botocore
 edx-drf-extensions==1.2.4
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 first==2.0.1              # via pip-tools
 future==0.16.0            # via vertica-python
+futures==3.2.0 ; python_version == "2.7"
 idna==2.7                 # via cryptography
+ipaddress==1.0.22         # via cryptography
 jmespath==0.9.3           # via boto3, botocore
 kombu==3.0.37             # via celery
 paramiko==2.4
 pip-tools==2.0.2
-pluggy==0.6.0             # via tox
+pluggy==0.7.1             # via tox
 py==1.5.4                 # via tox
-pyasn1==0.4.3             # via paramiko, rsa
+pyasn1==0.4.4             # via paramiko, rsa
 pycparser==2.18           # via cffi
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pyminizip==0.2.1
 pynacl==1.2.1             # via paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, vertica-python
-pytz==2018.4              # via celery, django, vertica-python
+pytz==2018.5              # via celery, django, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 rsa==3.4.2                # via awscli

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
+astroid==1.5.2            # via edx-lint, pylint, pylint-celery
 awscli==1.11.178
-backports.functools-lru-cache==1.5  # via caniusepython3
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 bcrypt==3.1.4             # via paramiko
 billiard==3.3.0.23        # via celery
 boto3==1.4.7
@@ -21,22 +21,26 @@ cffi==1.11.5              # via bcrypt, cryptography, pynacl
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 colorama==0.3.7           # via awscli
+configparser==3.5.0       # via pydocstyle, pylint
 cryptography==1.9
-diff-cover==1.0.3
+diff-cover==1.0.4
 distlib==0.2.7            # via caniusepython3
 django-fernet-fields==0.5
-django==1.11.5
+django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3  # via edx-drf-extensions
 docutils==0.14            # via awscli, botocore
 edx-drf-extensions==1.2.4
-edx-i18n-tools==0.4.6
+edx-i18n-tools==0.4.7
 edx-lint==0.5.5
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via astroid, cryptography
 first==2.0.1              # via pip-tools
 future==0.16.0            # via vertica-python
+futures==3.2.0 ; python_version == "2.7"
 idna==2.7                 # via cryptography
-inflect==0.3.1            # via jinja2-pluralize
+inflect==1.0.0            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography
 isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
@@ -51,10 +55,10 @@ paramiko==2.4
 path.py==11.0.1           # via edx-i18n-tools
 pip-tools==2.0.2
 pkginfo==1.4.2            # via twine
-pluggy==0.6.0             # via tox
+pluggy==0.7.1             # via tox
 polib==1.1.0              # via edx-i18n-tools
 py==1.5.4                 # via tox
-pyasn1==0.4.3             # via paramiko, rsa
+pyasn1==0.4.4             # via paramiko, rsa
 pycodestyle==2.4.0
 pycparser==2.18           # via cffi
 pydocstyle==2.1.1
@@ -62,25 +66,26 @@ pygments==2.2.0           # via diff-cover
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyminizip==0.2.1
 pynacl==1.2.1             # via paramiko
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, vertica-python
-pytz==2018.4              # via celery, django, vertica-python
+pytz==2018.5              # via celery, django, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
+singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 testfixtures==6.2.0
 tox-battery==0.5
 tox==3.0.0
-tqdm==4.23.4              # via twine
+tqdm==4.24.0              # via twine
 twine==1.11.0
 unicodecsv==0.14.1
 vertica-python==0.7.3

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,11 +8,11 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
+astroid==1.5.2            # via edx-lint, pylint, pylint-celery
 atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via pytest
 awscli==1.11.178
-backports.functools-lru-cache==1.5  # via caniusepython3
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 bcrypt==3.1.4             # via paramiko
 billiard==3.3.0.23        # via celery
 boto3==1.4.7
@@ -23,30 +23,35 @@ cffi==1.11.5              # via bcrypt, cryptography, pynacl
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 colorama==0.3.7           # via awscli
+configparser==3.5.0       # via pydocstyle, pylint
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.3
-diff-cover==1.0.3
+ddt==1.2.0
+diff-cover==1.0.4
 distlib==0.2.7            # via caniusepython3
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django==1.11.5
+django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3  # via edx-drf-extensions
 docutils==0.14            # via awscli, botocore
 edx-drf-extensions==1.2.4
-edx-i18n-tools==0.4.6
+edx-i18n-tools==0.4.7
 edx-lint==0.5.5
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via astroid, cryptography
 factory-boy==2.11.1
-faker==0.8.16             # via factory-boy
+faker==0.8.17             # via factory-boy
 first==2.0.1              # via pip-tools
 flaky==3.4.0
 freezegun==0.3.10
+funcsigs==1.0.2           # via mock, pytest
 future==0.16.0            # via vertica-python
+futures==3.2.0 ; python_version == "2.7"
 idna==2.7                 # via cryptography
-inflect==0.3.1            # via jinja2-pluralize
+inflect==1.0.0            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
 isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
@@ -56,17 +61,18 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==4.2.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via caniusepython3
 paramiko==2.4
 path.py==11.0.1           # via edx-i18n-tools
-pbr==4.0.4                # via mock
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock
 pip-tools==2.0.2
 pkginfo==1.4.2            # via twine
-pluggy==0.6.0             # via pytest, tox
+pluggy==0.7.1             # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 py==1.5.4                 # via pytest, pytest-catchlog, tox
-pyasn1==0.4.3             # via paramiko, rsa
+pyasn1==0.4.4             # via paramiko, rsa
 pycodestyle==2.4.0
 pycparser==2.18           # via cffi
 pydocstyle==2.1.1
@@ -74,23 +80,25 @@ pygments==2.2.0           # via diff-cover
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyminizip==0.2.1
 pynacl==1.2.1             # via paramiko
 pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.3.2
-pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.3.3
+pytest==3.7.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.4              # via celery, django, vertica-python
+pytz==2018.5              # via celery, django, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 responses==0.9.0
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
+scandir==1.8              # via pathlib2
+singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
@@ -98,7 +106,7 @@ testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 tox-battery==0.5
 tox==3.0.0
-tqdm==4.23.4              # via twine
+tqdm==4.24.0              # via twine
 twine==1.11.0
 unicodecsv==0.14.1
 vertica-python==0.7.3

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -1,3 +1,3 @@
-django==1.11.5                          # Application server
+django==1.11.15                          # Application server
 djangorestframework==3.6.3              # REST API extensions for Django
 edx-drf-extensions==1.2.4               # edX extensions to django rest framework

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -21,47 +21,53 @@ colorama==0.3.7           # via awscli
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.3
+ddt==1.2.0
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django==1.11.5
+django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore
 edx-drf-extensions==1.2.4
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 factory-boy==2.11.1
-faker==0.8.16             # via factory-boy
+faker==0.8.17             # via factory-boy
 first==2.0.1              # via pip-tools
 flaky==3.4.0
 freezegun==0.3.10
+funcsigs==1.0.2           # via mock, pytest
 future==0.16.0            # via vertica-python
+futures==3.2.0 ; python_version == "2.7"
 idna==2.7                 # via cryptography
+ipaddress==1.0.22         # via cryptography, faker
 jmespath==0.9.3           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==2.0.0
-more-itertools==4.2.0     # via pytest
+more-itertools==4.3.0     # via pytest
 paramiko==2.4
-pbr==4.0.4                # via mock
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock
 pip-tools==2.0.2
-pluggy==0.6.0             # via pytest, tox
+pluggy==0.7.1             # via pytest, tox
 py==1.5.4                 # via pytest, pytest-catchlog, tox
-pyasn1==0.4.3             # via paramiko, rsa
+pyasn1==0.4.4             # via paramiko, rsa
 pycparser==2.18           # via cffi
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pyminizip==0.2.1
 pynacl==1.2.1             # via paramiko
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.3.2
-pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.3.3
+pytest==3.7.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.4              # via celery, django, vertica-python
+pytz==2018.5              # via celery, django, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 responses==0.9.0
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
+scandir==1.8              # via pathlib2
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 testfixtures==6.2.0

--- a/requirements/test-reporting.in
+++ b/requirements/test-reporting.in
@@ -1,6 +1,6 @@
 tox==3.0.0
 tox-battery==0.5.1
-pytest==3.5.1
+pytest==3.7.1
 ddt==1.1.2
 mock==2.0.0
 pytest-cov==2.5.1

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -4,17 +4,21 @@
 #
 #    pip-compile --output-file requirements/test-reporting.txt requirements/test-reporting.in
 #
+atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via pytest
 coverage==4.5.1           # via pytest-cov
 ddt==1.1.2
+funcsigs==1.0.2           # via mock, pytest
 mock==2.0.0
-more-itertools==4.2.0     # via pytest
-pbr==4.0.4                # via mock
-pluggy==0.6.0             # via pytest, tox
+more-itertools==4.3.0     # via pytest
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock
+pluggy==0.7.1             # via pytest, tox
 py==1.5.4                 # via pytest, tox
 pytest-cov==2.5.1
-pytest==3.5.1
-six==1.11.0               # via mock, more-itertools, pytest, tox
+pytest==3.7.1
+scandir==1.8              # via pathlib2
+six==1.11.0               # via mock, more-itertools, pathlib2, pytest, tox
 tox-battery==0.5.1
 tox==3.0.0
 virtualenv==16.0.0        # via tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,47 +21,53 @@ colorama==0.3.7           # via awscli
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.3
+ddt==1.2.0
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django==1.11.5
+django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3  # via edx-drf-extensions
 docutils==0.14            # via awscli, botocore
 edx-drf-extensions==1.2.4
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 factory-boy==2.11.1
-faker==0.8.16             # via factory-boy
+faker==0.8.17             # via factory-boy
 first==2.0.1              # via pip-tools
 flaky==3.4.0
 freezegun==0.3.10
+funcsigs==1.0.2           # via mock, pytest
 future==0.16.0            # via vertica-python
+futures==3.2.0 ; python_version == "2.7"
 idna==2.7                 # via cryptography
+ipaddress==1.0.22         # via cryptography, faker
 jmespath==0.9.3           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==2.0.0
-more-itertools==4.2.0     # via pytest
+more-itertools==4.3.0     # via pytest
 paramiko==2.4
-pbr==4.0.4                # via mock
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock
 pip-tools==2.0.2
-pluggy==0.6.0             # via pytest, tox
+pluggy==0.7.1             # via pytest, tox
 py==1.5.4                 # via pytest, pytest-catchlog, tox
-pyasn1==0.4.3             # via paramiko, rsa
+pyasn1==0.4.4             # via paramiko, rsa
 pycparser==2.18           # via cffi
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pyminizip==0.2.1
 pynacl==1.2.1             # via paramiko
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.3.2
-pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.3.3
+pytest==3.7.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.4              # via celery, django, vertica-python
+pytz==2018.5              # via celery, django, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 responses==0.9.0
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
+scandir==1.8              # via pathlib2
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 testfixtures==6.2.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -9,11 +9,13 @@ chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.1           # via codecov
 idna==2.7                 # via requests
-pluggy==0.6.0             # via tox
+packaging==17.1           # via tox
+pluggy==0.7.1             # via tox
 py==1.5.4                 # via tox
+pyparsing==2.2.0          # via packaging
 requests==2.19.1          # via codecov
-six==1.11.0               # via tox
+six==1.11.0               # via packaging, tox
 tox-battery==0.5.1
-tox==3.0.0
+tox==3.1.3
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox


### PR DESCRIPTION
### [EDUCATOR-3274](https://openedx.atlassian.net/browse/EDUCATOR-3274)

To upgrade the version of Django in repo **[analytics-api](https://github.com/edx/edx-analytics-data-api/blob/master/requirements/base.in#L20)** we have to upgrade the version the **edx-enterprise-data**.

_Upgrade Django and all its dependencies._

@edx/educator-escalation Can you guys please review?