### PR TITLE
Enable sorting on all model fields for enrollments viewset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[0.2.4] - 2018-08-09
+--------------------
+* Enable ordering for all model fields in `EnterpriseEnrollmentsViewSet`.
+
 [0.2.3] - 2018-08-07
 --------------------
 * Fixed migrations for enterprise_user table

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -52,11 +52,7 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
     """
     serializer_class = serializers.EnterpriseEnrollmentSerializer
     filter_backends = (ConsentGrantedFilterBackend, filters.OrderingFilter,)
-    FIELDS = (
-        'user_email', 'course_title', 'enrollment_created_timestamp', 'passed_timestamp',
-        'user_current_enrollment_mode', 'course_price', 'coupon_name', 'offer',
-    )
-    ordering_fields = FIELDS
+    ordering_fields = '__all__'
     ordering = ('user_email',)
 
     def get_queryset(self):

--- a/enterprise_reporting/__init__.py
+++ b/enterprise_reporting/__init__.py
@@ -4,4 +4,4 @@ Enterprise data report scripts. These scripts are used by jenkins jobs to delive
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"


### PR DESCRIPTION
To fix the issue where some columns are not sortable in the admin dashboard, we need to enable ordering on the appropriate fields. Here, I am enabling ordering for all model fields. The other option is to restrict the ordering to specific fields and just add the appropriate ones, but I figured it would be less maintenance to just enable them all.