### PR TITLE
ENT-1177 Switching permission requirement for enterprise data api access

### DIFF
--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -19,7 +19,7 @@ from django.db.models import Max
 from enterprise_data.api.v0 import serializers
 from enterprise_data.filters import ConsentGrantedFilterBackend
 from enterprise_data.models import EnterpriseEnrollment, EnterpriseUser
-from enterprise_data.permissions import IsStaffOrEnterpriseUser
+from enterprise_data.permissions import HasDataAPIDjangoGroupAccess
 
 LOGGER = getLogger(__name__)
 
@@ -31,7 +31,7 @@ class EnterpriseViewSet(viewsets.ViewSet):
     authentication_classes = (JwtAuthentication,)
     filter_backends = (ConsentGrantedFilterBackend,)
     pagination_class = DefaultPagination
-    permission_classes = (IsStaffOrEnterpriseUser,)
+    permission_classes = (HasDataAPIDjangoGroupAccess,)
     CONSENT_GRANTED_FILTER = 'consent_granted'
 
     def ensure_data_exists(self, request, data, error_message=None):

--- a/enterprise_data/permissions.py
+++ b/enterprise_data/permissions.py
@@ -64,3 +64,46 @@ class IsStaffOrEnterpriseUser(permissions.BasePermission):
                            .format(request.user, enterprise_in_url))
 
         return permitted
+
+
+class HasDataAPIDjangoGroupAccess(permissions.BasePermission):
+    """
+    Permission that checks to see if the request user is part of the enterprise_data_api django group.
+
+    Also checks that the user is authorized for the request's enterprise.
+    """
+
+    def get_enterprise_with_access_to(self, auth_token, user, enterprise_id):
+        """
+        Get the enterprise customer data that the user has enterprise_data_api access to.
+
+        Returns: enterprise or None if unable to get or user is not associated with an enterprise
+        """
+        enterprise_client = EnterpriseApiClient(auth_token)
+        enterprise_data = enterprise_client.get_with_access_to(user, enterprise_id)
+        if not enterprise_data:
+            return None
+
+        return enterprise_data
+
+    def has_permission(self, request, view):
+        """
+        Verify the user is staff or the associated enterprise matches the requested enterprise.
+        """
+        enterprise_in_url = request.parser_context.get('kwargs', {}).get('enterprise_id', '')
+
+        if ('enterprises_with_access' not in request.session or
+                enterprise_in_url not in request.session['enterprises_with_access']):
+            request.session['enterprises_with_access'] = {}
+            enterprise_data = self.get_enterprise_with_access_to(request.auth, request.user, enterprise_in_url)
+            if not enterprise_data:
+                request.session['enterprises_with_access'][enterprise_in_url] = False
+            else:
+                request.session['enterprises_with_access'][enterprise_in_url] = True
+
+        permitted = request.session['enterprises_with_access'][enterprise_in_url]
+        if not permitted:
+            LOGGER.warning('User {} denied access to EnterpriseEnrollments for enterprise {}'
+                           .format(request.user, enterprise_in_url))
+
+        return permitted

--- a/enterprise_data/tests/test_clients.py
+++ b/enterprise_data/tests/test_clients.py
@@ -19,6 +19,7 @@ class TestEnterpriseApiClient(TestCase):
 
     def setUp(self):
         self.user = UserFactory()
+        self.enterprise_id = '0395b02f-6b29-42ed-9a41-45f3dff8349c'
         self.api_response = {
             'count': 1,
             'results': [{
@@ -38,6 +39,10 @@ class TestEnterpriseApiClient(TestCase):
             get=self.mocked_get_endpoint
         ))
 
+        setattr(self.client, 'enterprise-customer', Mock(
+            with_access_to=Mock(get=self.mocked_get_endpoint)
+        ))
+
     @mock.patch('enterprise_data.clients.EdxRestApiClient.__init__')
     def test_inits_client_with_jwt(self, mock_init):
         self.mock_client()
@@ -53,7 +58,7 @@ class TestEnterpriseApiClient(TestCase):
         self.mocked_get_endpoint = Mock(side_effect=HttpClientError)
         self.mock_client()
         with self.assertRaises(HttpClientError):
-            results = self.client.get_enterprise_learner(self.user)
+            _ = self.client.get_enterprise_learner(self.user)
 
     def test_get_enterprise_learner_returns_none_on_empty_results(self):
         self.mocked_get_endpoint = Mock(return_value={
@@ -68,7 +73,7 @@ class TestEnterpriseApiClient(TestCase):
         self.mocked_get_endpoint = Mock(return_value={})
         self.mock_client()
         with self.assertRaises(NotFound):
-            results = self.client.get_enterprise_learner(self.user)
+            _ = self.client.get_enterprise_learner(self.user)
 
     def test_get_enterprise_learner_raises_parse_error_on_multiple_results(self):
         self.mocked_get_endpoint = Mock(return_value={
@@ -77,4 +82,43 @@ class TestEnterpriseApiClient(TestCase):
         })
         self.mock_client()
         with self.assertRaises(ParseError):
-            results = self.client.get_enterprise_learner(self.user)
+            _ = self.client.get_enterprise_learner(self.user)
+
+    def test_get_with_access_to_returns_results_for_user(self):
+        self.mock_client()
+        results = self.client.get_with_access_to(self.user, self.enterprise_id)
+        self.mocked_get_endpoint.assert_called_with(
+            permissions=[EnterpriseApiClient.ENTERPRISE_DATA_API_GROUP],
+            enterprise_id=self.enterprise_id
+        )
+        assert(results == self.api_response['results'][0])
+
+    def test_get_with_access_to_raises_exception_on_error(self):
+        self.mocked_get_endpoint = Mock(side_effect=HttpClientError)
+        self.mock_client()
+        with self.assertRaises(HttpClientError):
+            _ = self.client.get_with_access_to(self.user, self.enterprise_id)
+
+    def test_get_with_access_to_returns_none_on_empty_results(self):
+        self.mocked_get_endpoint = Mock(return_value={
+            'count': 0,
+            'results': []
+        })
+        self.mock_client()
+        results = self.client.get_with_access_to(self.user, self.enterprise_id)
+        self.assertIsNone(results)
+
+    def test_get_with_access_to_raises_not_found_on_no_results(self):
+        self.mocked_get_endpoint = Mock(return_value={})
+        self.mock_client()
+        with self.assertRaises(NotFound):
+            _ = self.client.get_with_access_to(self.user, self.enterprise_id)
+
+    def test_get_with_access_to_raises_parse_error_on_multiple_results(self):
+        self.mocked_get_endpoint = Mock(return_value={
+            'count': 2,
+            'results': [{}, {}]
+        })
+        self.mock_client()
+        with self.assertRaises(ParseError):
+            _ = self.client.get_with_access_to(self.user, self.enterprise_id)

--- a/enterprise_data/tests/test_filters.py
+++ b/enterprise_data/tests/test_filters.py
@@ -4,6 +4,7 @@ Tests for filters in enterprise_data.
 """
 from __future__ import absolute_import, unicode_literals
 
+import mock
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -25,10 +26,14 @@ class TestConsentGrantedFilterBackend(APITestCase):
         self.url = reverse('v0:enterprise-enrollments-list',
                            kwargs={'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'})
 
-    def test_filter_for_list(self):
+    @mock.patch('enterprise_data.permissions.EnterpriseApiClient')
+    def test_filter_for_list(self, mock_enterprise_api_client):
         """
         Filter users through email/username if requesting user is staff, otherwise based off of request user ID.
         """
+        mock_enterprise_api_client.return_value.get_with_access_to.return_value = {
+            'uuid': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
+        }
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
         data = response.json()

--- a/enterprise_data/tests/test_permissions.py
+++ b/enterprise_data/tests/test_permissions.py
@@ -5,26 +5,22 @@ Tests for permissions
 from logging import getLogger
 
 from mock import MagicMock, patch
-from pytest import mark, raises
-from rest_framework.test import APIClient
+from pytest import mark
 
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
-from enterprise_data.permissions import IsStaffOrEnterpriseUser
+from enterprise_data.permissions import HasDataAPIDjangoGroupAccess, IsStaffOrEnterpriseUser
 from test_utils import UserFactory
 
 LOGGER = getLogger(__name__)
 
 
-@mark.django_db
-class TestIsStaffOrEnterpriseUser(TestCase):
+class PermissionsTestCase(TestCase):
     """
-    Tests of the IsStaffOrEnterpriseUser permission
+    Common logic for permissions class tests.
     """
-
     def setUp(self):
-        super(TestIsStaffOrEnterpriseUser, self).setUp()
-        self.permission = IsStaffOrEnterpriseUser()
+        super(PermissionsTestCase, self).setUp()
         self.enterprise_id = 'fake-enterprise-id'
         self.user = UserFactory()
         self.request = MagicMock(
@@ -41,6 +37,17 @@ class TestIsStaffOrEnterpriseUser(TestCase):
         enterprise_api_client = patch('enterprise_data.permissions.EnterpriseApiClient')
         self.enterprise_api_client = enterprise_api_client.start()
         self.addCleanup(enterprise_api_client.stop)
+
+
+@mark.django_db
+class TestIsStaffOrEnterpriseUser(PermissionsTestCase):
+    """
+    Tests of the IsStaffOrEnterpriseUser permission
+    """
+
+    def setUp(self):
+        super(TestIsStaffOrEnterpriseUser, self).setUp()
+        self.permission = IsStaffOrEnterpriseUser()
 
     def test_staff_access(self):
         self.user.is_staff = True
@@ -75,4 +82,37 @@ class TestIsStaffOrEnterpriseUser(TestCase):
 
     def test_no_enterprise_learner_for_user(self):
         self.enterprise_api_client.return_value.get_enterprise_learner.return_value = {}
+        self.assertFalse(self.permission.has_permission(self.request, None))
+
+
+@mark.django_db
+class TestHasDataAPIDjangoGroupAccess(PermissionsTestCase):
+    """
+    Tests of the IsStaffOrEnterpriseUser permission
+    """
+
+    def setUp(self):
+        super(TestHasDataAPIDjangoGroupAccess, self).setUp()
+        self.permission = HasDataAPIDjangoGroupAccess()
+
+    def test_staff_access_without_group_permission(self):
+        self.user.is_staff = True
+        self.enterprise_api_client.return_value.get_with_access_to.return_value = {}
+        self.assertFalse(self.permission.has_permission(self.request, None))
+
+    def test_staff_access_with_group_permission(self):
+        self.user.is_staff = True
+        self.enterprise_api_client.return_value.get_with_access_to.return_value = {
+            'uuid': self.enterprise_id
+        }
+        self.assertTrue(self.permission.has_permission(self.request, None))
+
+    def test_enterprise_user_has_access_with_group_permission(self):
+        self.enterprise_api_client.return_value.get_with_access_to.return_value = {
+            'uuid': self.enterprise_id
+        }
+        self.assertTrue(self.permission.has_permission(self.request, None))
+
+    def test_enterprise_user_without_group_permission(self):
+        self.enterprise_api_client.return_value.get_with_access_to.return_value = {}
         self.assertFalse(self.permission.has_permission(self.request, None))


### PR DESCRIPTION
Since we are restricting access for staff users based on their django group membership, this PR introduces a new permission class that accommodates the new requirements and switches the enrollments data api endpoint to use this permission class.

This PR depends on the following two PRs being merged and deployed first:
https://github.com/edx/app-permissions/pull/699
https://github.com/edx/edx-enterprise/pull/360