### PR TITLE
ENT-1185 - Update Course Catalog CSV flat file to have only one single header and a line of rows.

### DIFF
--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from enterprise_reporting.clients.enterprise import EnterpriseAPIClient, EnterpriseDataApiClient
 from enterprise_reporting.clients.vertica import VerticaClient
 from enterprise_reporting.delivery_method import SFTPDeliveryMethod, SMTPDeliveryMethod
-from enterprise_reporting.utils import decrypt_string, flatten_dict
+from enterprise_reporting.utils import decrypt_string, generate_data
 
 LOGGER = logging.getLogger(__name__)
 NOW = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -180,10 +180,13 @@ class EnterpriseReportSender(object):
         for content_type, grouped_items in grouped_content_metadata.items():
             with open(self.data_report_file_name_with.format(content_type), 'w') as data_report_file:
                 writer = csv.writer(data_report_file)
+                if grouped_items:
+                    # Write single row of headers in csv.
+                    writer.writerow(generate_data(grouped_items[0], target='key'))
+
                 for item in grouped_items:
-                    writer.writerow(flatten_dict(item, target='key'))
-                    writer.writerow(flatten_dict(item, target='value'))
-                    writer.writerow([])
+                    writer.writerow(generate_data(item, target='value'))
+
                 files.append(data_report_file)
         return files
 

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -193,3 +193,24 @@ def flatten_dict(d, target='key' or 'value'):
         else:
             flattened.append(key if target_is_key else value)
     return flattened
+
+
+def generate_data(item, target='key' or 'value'):
+    """
+    Either return a list of JSON data objects or
+    List of headers depends upon the target.
+    """
+    data = []
+    target_is_key = target == 'key'
+    for key, value in OrderedDict(sorted(item.items())).items():
+        if target_is_key:
+            data.append(key)
+            continue
+
+        # For empty list we are just writing an empty string ''.
+        if isinstance(value, list) and not len(value):
+            value = ''
+
+        data.append(value)
+
+    return data


### PR DESCRIPTION
[ENT-1185](https://openedx.atlassian.net/browse/ENT-1185)

Update Course Catalog CSV flat file format to have only one single header and a line of rows.

#### NOTE: 
Implemented a suggested solution of putting all of the values as is into the column, even for simple arrays, in the form of JSON objects. This would also likely be the easiest to implement. In the example the column would have the possible value of:

> transcript_languages

`
 ['English', 'Hindi', 'Dutch', 'Chinese - Mandarin']  
`
