### PR TITLE
Learner activity details

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,9 @@ Change Log
 Unreleased
 ----------
 
-[0.2.9] - 2018-09-19
+[0.2.9] - 2018-09-24
 --------------------
+* Update the course catalog CSV flat file to have only one single header and a line of rows in JSON form.
 * Adding filters for Learner Activity cards. These include:
     - Active learners in past week.
     - Inactive learners in past week.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[0.2.9] - 2018-09-19
+--------------------
+* Adding filters for Learner Activity cards. These include:
+    - Active learners in past week.
+    - Inactive learners in past week.
+    - Inactive learners in past month
+
 [0.2.8] - 2018-09-12
 --------------------
 * Adding query params on /users/ enpoint for active_courses and enrollment_count

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
This PR adds some filters for Learner Activity cards. They include:
1. Active learners in past week.
2. Inactive learners in past week.
3. Inactive learners in past month.

The criterion used to determine learner activity is `last_activity_date` field.

This PR also does some refactoring.


[ENT-1166](https://openedx.atlassian.net/browse/ENT-1166)