### PR TITLE
ENT-1189 Add enterprise learner course completion count

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ----------
+
+[0.2.12] - 2018-10-08
+---------------------
+* Add filter `all_enrollments_passed` to filter out enterprise learners on the basis of all enrollments passed
+* Add extra field `course_completion_count` in response when "extra_fields" query param has value `course_completion_count`
+
 [0.2.11] - 2018-09-28
 ---------------------
 * Running make upgrade and installing new packages

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -38,11 +38,16 @@ class EnterpriseUserSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         representation = super(EnterpriseUserSerializer, self).to_representation(instance)
         request = self.context.get('request')
-        extra_fields = request.query_params.get('extra_fields')
+        extra_fields = request.query_params.getlist('extra_fields')
         if extra_fields is not None:
             if 'enrollment_count' in extra_fields:
                 enrollments = instance.enrollments.exclude(consent_granted=False)
                 representation['enrollment_count'] = enrollments.count()
+            if 'course_completion_count' in extra_fields:
+                representation['course_completion_count'] = instance.enrollments.exclude(
+                    consent_granted=False
+                ).filter(has_passed=True).count()
+
         return representation
 
 

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -235,6 +235,12 @@ class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
         elif active_courses == 'false':
             users = users.filter(CONSENT_TRUE_OR_NONE_Q, enrollments__course_end__lte=timezone.now())
 
+        all_enrollments_passed = request.query_params.get('all_enrollments_passed')
+        if all_enrollments_passed == 'true':
+            users = users.exclude(enrollments__has_passed=False)
+        elif all_enrollments_passed == 'false':
+            users = users.filter(enrollments__has_passed=False)
+
         # Bit to account for pagination
         page = self.paginate_queryset(users)
         if page is not None:

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -35,6 +35,7 @@ class EnterpriseEnrollmentFactory(factory.django.DjangoModelFactory):
     course_id = factory.lazy_attribute(lambda x: FAKER.slug())
     enrollment_created_timestamp = factory.lazy_attribute(lambda x: '2018-01-01')
     user_current_enrollment_mode = factory.lazy_attribute(lambda x: 'verified')
+    has_passed = False
 
 
 class UserFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
[ENT-1189](https://openedx.atlassian.net/browse/ENT-1189)

* Allow for extra field `course_completion_count` to be added to response when "extra_fields" query param is provided that includes the text "`course_completion_count`".
* Allow a new query param `all_enrollments_passed` to filter out enterprise learners on the basis of all enrollments passed or not.
* Consider `extra_fields` as a list of parameters, e.g. `'extra_fields': ['enrollment_count', 'course_completion_count']`

**Expected URL for ENT-1189:**
http://localhost:18000/enterprise/api/v0/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/users/?extra_fields=enrollment_count&extra_fields=course_completion_count&has_enrollments=true&active_courses=false&all_enrollments_passed=true&page_size=50