### PR TITLE
ENT-1236 Add sorting for /users endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.2.14] - 2018-10-15
+---------------------
+* Add sorting for /users endpoint
+
 [0.2.13] - 2018-10-15
 ---------------------
 * Add `progress_v2` report generation in `JSON` format

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -213,6 +213,9 @@ class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
     """
     queryset = EnterpriseUser.objects.all()
     serializer_class = serializers.EnterpriseUserSerializer
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = '__all__'
+    ordering = ('user_email',)
 
     def list(self, request, **kwargs):
         """
@@ -240,6 +243,9 @@ class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
             users = users.exclude(enrollments__has_passed=False)
         elif all_enrollments_passed == 'false':
             users = users.filter(enrollments__has_passed=False)
+
+        # do the sorting
+        users = self.filter_queryset(users)
 
         # Bit to account for pagination
         page = self.paginate_queryset(users)

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -255,6 +255,7 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
         assert len(result) == 2
 
 
+@ddt.ddt
 @mark.django_db
 class TestEnterpriseUsersViewSet(APITestCase):
     """
@@ -565,6 +566,33 @@ class TestEnterpriseUsersViewSet(APITestCase):
         params = {'no_page': 'true', }
 
         response = self.client.get(url, params)
+
+    @ddt.data(
+        (
+            'id',
+            [4, 8]
+        ),
+        (
+            '-id',
+            [8, 4]
+        )
+    )
+    @ddt.unpack
+    def test_viewset_ordering(self, ordering, users):
+        """
+        EnterpriseUserViewset should order users returned if the value
+        for ordering query param is set
+        """
+        kwargs = {'enterprise_id': 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c', }
+        params = {'ordering': ordering, 'has_enrollments': 'true', }
+        url = reverse(
+            'v0:enterprise-users-list',
+            kwargs=kwargs,
+        )
+        response = self.client.get(url, params)
+        assert response.json()['count'] == 4
+        assert response.json()['results'][0]['id'] == users[0]
+        assert response.json()['results'][3]['id'] == users[1]
 
 
 class TestEnterpriseLearnerCompletedCourses(APITestCase):


### PR DESCRIPTION
Sorting for /users endpoint in edx-enterprise-data not configured
https://openedx.atlassian.net/browse/ENT-1236