### PR TITLE
ENT-1235 Add filtering on audit enrollments for reporting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ----------
+
+[1.0.8] - 2018-10-29
+--------------------
+* Enable audit enrollments filtering on field `user_current_enrollment_mode` for model `EnterpriseEnrollment`
+
 [1.0.7] - 2018-10-25
 --------------------
 * Fixed KeyError issue when PGP Encryption key is not found

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -20,7 +20,11 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from enterprise_data.api.v0 import serializers
-from enterprise_data.filters import CONSENT_TRUE_OR_NOENROLL_Q, ConsentGrantedFilterBackend
+from enterprise_data.filters import (
+    CONSENT_TRUE_OR_NOENROLL_Q,
+    AuditEnrollmentsFilterBackend,
+    ConsentGrantedFilterBackend,
+)
 from enterprise_data.models import EnterpriseEnrollment, EnterpriseUser
 from enterprise_data.permissions import HasDataAPIDjangoGroupAccess
 
@@ -71,10 +75,11 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
     Viewset for routes related to Enterprise course enrollments.
     """
     serializer_class = serializers.EnterpriseEnrollmentSerializer
-    filter_backends = (ConsentGrantedFilterBackend, filters.OrderingFilter,)
+    filter_backends = (AuditEnrollmentsFilterBackend, ConsentGrantedFilterBackend, filters.OrderingFilter,)
     ordering_fields = '__all__'
     ordering = ('user_email',)
     CONSENT_GRANTED_FILTER = 'consent_granted'
+    ENROLLMENT_MODE_FILTER = 'user_current_enrollment_mode'
 
     def get_queryset(self):
         """

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -27,3 +27,26 @@ class ConsentGrantedFilterBackend(filters.BaseFilterBackend):
         """
         filter_kwargs = {view.CONSENT_GRANTED_FILTER: True}
         return queryset.filter(**filter_kwargs)
+
+
+class AuditEnrollmentsFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter backend to exclude enrollments where enrollment mode is `audit`.
+
+    This requires that `ENROLLMENT_MODE_FILTER` be set in the view as a class
+    variable, to identify the object's relationship to the
+    `user_current_enrollment_mode` field.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Filter out queryset for results where enrollment mode is `audit`.
+        """
+        enterprise_id = view.kwargs['enterprise_id']
+        enable_audit_enrollment = request.session['enable_audit_enrollment'].get(enterprise_id, False)
+
+        if not enable_audit_enrollment:
+            filter_kwargs = {view.ENROLLMENT_MODE_FILTER: 'audit'}
+            queryset = queryset.exclude(**filter_kwargs)
+
+        return queryset

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -80,3 +80,24 @@ class EnterpriseUserFactory(factory.django.DjangoModelFactory):
     user_email = factory.Sequence(u'robot+test+{0}@edx.org'.format)
     user_country_code = factory.lazy_attribute(lambda x: FAKER.country_code())
     last_activity_date = datetime(2012, 1, 1).date()
+
+
+def get_dummy_enterprise_api_data(**kwargs):
+    """
+    DRY method to get enterprise dummy data.
+
+    Get dummy data for an enterprise from `enterprise-customer` API.
+    """
+    enterprise_api_dummy_data = {
+        'uuid': kwargs.get('enterprise_id', 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'),
+        'name': 'Enterprise ABC',
+        'slug': 'enterprise_abc',
+        'active': True,
+        'enable_data_sharing_consent': kwargs.get('enable_data_sharing_consent', True),
+        'enforce_data_sharing_consent': kwargs.get('enforce_data_sharing_consent', 'at_enrollment'),
+        'branding_configuration': {},
+        'identity_provider': 'saml-ubc',
+        'enable_audit_enrollment': kwargs.get('enable_audit_enrollment', False),
+        'replace_sensitive_sso_username': False
+    }
+    return enterprise_api_dummy_data

--- a/enterprise_data/utils.py
+++ b/enterprise_data/utils.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Utility functions for Enterprise Data app.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import hashlib
+
+import six
+
+
+def update_session_with_enterprise_data(request, enterprise_id, **kwargs):
+    """
+    DRY method to set provided parameters on the request session.
+
+    Set provided parameters against the provided enterprise id.
+
+    The values will be set in session in the following format:
+    {
+        'enterprises_with_access': {'ee5e6b3a-069a-4947-bb8d-d2dbc323396c': True},
+        'enable_audit_enrollment': {'ee5e6b3a-069a-4947-bb8d-d2dbc323396c': False}
+    }
+
+    Arguments:
+        request: Http request
+        enterprise_id: UUID of enterprise
+        **kwargs: Keyword arguments that need to be present in request session
+
+    """
+    for item, value in six.iteritems(kwargs):
+        request.session[item] = {}
+        request.session.update({
+            item: {str(enterprise_id): value}
+        })
+
+
+def get_cache_key(**kwargs):
+    """
+    Get MD5 encoded cache key for given arguments.
+
+    Here is the format of key before MD5 encryption.
+        key1:value1__key2:value2 ...
+
+    Example:
+        >>> get_cache_key(site_domain="example.com", resource="enterprise_customer_users")
+        # Here is key format for above call
+        # "site_domain:example.com__resource:enterprise_customer_users"
+        a54349175618ff1659dee0978e3149ca
+
+    Arguments:
+        **kwargs: Keyword arguments that need to be present in cache key.
+
+    Returns:
+         An MD5 encoded key uniquely identified by the key word arguments.
+    """
+    key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
+
+    return hashlib.md5(key.encode('utf-8')).hexdigest()

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,7 @@ celery==3.1.18                          # Run task workers in other locations
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient
 edx-rest-api-client                     # For accessing the Enrollment API (and possibly other edX APIs)
+edx-django-utils
 edx-drf-extensions
 awscli==1.11.178                        # for assuming aws roles for sending email via SES
 boto3==1.4.7


### PR DESCRIPTION
 Enable audit data reporting flag `enable_audit_enrollment` of enterprise customers to also be recognized by the Learner Progress reporting workflow.

- Show/Hide audit enrollment in CSV reports depending on enterprise customers data reporting flag `enable_audit_enrollment`
- Use `edx-django-utils` for caching the enterprise reporting configuration for 6 hours.
```from edx_django_utils.cache import TieredCache```

**Remaining Tasks:**
- Tests coverage

**Story History and Details:**
Currently the "Enable audit data reporting" flag is only recognized by the SAP SuccessFactors reporting workflow. The flag needs to also be recognized by the Learner Progress reporting workflow. See ENT‌-1210 for more information.

1. Should not show audits in CSV reports
2. Admin Dashboard: Filter out audit learner for both overview and UI table (just enrollment data)
    1. Audit Enrollment is filtered out
    2. Users with audit enrollment included in user count but not enrolled count
3. Enterprise Customer model (Flag is in django admin)
4. Data API cache enterprise configuration for 6 hours (for reporting)

**Example:**

- Learners who are only enrolled in audit courses will not be included as “enrolled” learners.
- Count of courses a Learner is enrolled in: If enrolled in 3 audit courses - the count for courses enrolled is 0