### PR TITLE
ENT-1304 - Adding sorting capabilities to extra_fields values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+[1.0.1] - 2018-10-23
+--------------------
+* Making enterprise_user endpoint sortable on enrollment_count and course_completion_count
 
 [1.0.0] - 2018-10-16
 --------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -37,16 +37,11 @@ class EnterpriseUserSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         representation = super(EnterpriseUserSerializer, self).to_representation(instance)
-        request = self.context.get('request')
-        extra_fields = request.query_params.getlist('extra_fields')
-        if extra_fields is not None:
-            if 'enrollment_count' in extra_fields:
-                enrollments = instance.enrollments.exclude(consent_granted=False)
-                representation['enrollment_count'] = enrollments.count()
-            if 'course_completion_count' in extra_fields:
-                representation['course_completion_count'] = instance.enrollments.exclude(
-                    consent_granted=False
-                ).filter(has_passed=True).count()
+
+        if hasattr(instance, 'enrollment_count'):
+            representation['enrollment_count'] = instance.enrollment_count
+        if hasattr(instance, 'course_completion_count'):
+            representation['course_completion_count'] = instance.course_completion_count
 
         return representation
 


### PR DESCRIPTION
This PR allows the `enrollment_count` and `course_completion_count` to be sortable by doing the following:

- moves the calculation of `enrollment_count` and `course_completion_count` from the serializer to the view, because sorting must be done at the layer at which you are "grabbing all the stuff you need" from the database (aka the view's `get_queryset` method)
- annotates the EnterpriseUser queryset with the above count values if query params are passed in the request
- makes the serializer check for the appropriate query params so it knows to expose the calculated value in the object representation

