### PR TITLE
ENT-1318 | Updating course_completion_count subquery logic so it does not return

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[1.0.2] - 2018-10-24
+--------------------
+* Fixing bug with course_completion_count computation
+
 [1.0.1] - 2018-10-23
 --------------------
 * Making enterprise_user endpoint sortable on enrollment_count and course_completion_count

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -29,7 +29,7 @@ class EnterpriseEnrollmentFactory(factory.django.DjangoModelFactory):
 
         model = EnterpriseEnrollment
 
-    id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))
+    id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1, max=999999))
     enterprise_id = factory.lazy_attribute(lambda x: 'ee5e6b3a069a4947bb8dd2dbc323396c')
     lms_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))
     course_id = factory.lazy_attribute(lambda x: FAKER.slug())


### PR DESCRIPTION
Updating course_completion_count subquery logic so it does not return "1" when more than 1 course has been completed. also updated enrollmentFactory so the ids clash less for enrollment test fixtures