### PR TITLE
ENT-1325 | Updating enrollment_count and course_completion_count logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[1.0.6] - 2018-10-25
+--------------------
+* Updating enrollment_count and course_completion_count computations to restrict to consent_granted=True enrollments
+
 [1.0.5] - 2018-10-25
 --------------------
 * Ability to PGP encrypt report files sent via email and SFTP

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -7,8 +7,10 @@ from rest_framework import filters
 
 from django.db.models import Q
 
-# Q filters
-CONSENT_TRUE_OR_NONE_Q = Q(enrollments__consent_granted=True) | Q(enrollments__consent_granted=None)
+# Admittedly this is sort of hacky because the use of "|" with 2 Q objects
+# forces the ORM to use a LEFT OUTER JOIN, which is needed to return a user
+# that has multiple enrollments where at least one has consent_granted=True
+CONSENT_TRUE_OR_NOENROLL_Q = Q(enrollments__consent_granted=True) | Q(enrollments__isnull=True)
 
 
 class ConsentGrantedFilterBackend(filters.BaseFilterBackend):


### PR DESCRIPTION
ENT-1325 | Updating enrollment_count and course_completion_count computations to restrict to consent_granted=True enrollments

What I've done here:

- In EnterpriseUsersViewSet, I've changed the original filter of users to no longer include enrollments with `consent_granted=None`.
- I've also dropped the references to `CONSENT_TRUE_OR_NONE_Q` in other places within the viewset, and replaced it with a simpler Q object. Using `CONSENT_TRUE_OR_NONE_Q` everywhere added potentially redundant predicates to the SQL the ORM would create, and given the already complex nature of what we're filtering, I wanted to make sure we're doing as little filtering as possible to get what we need.
- Related to the actual ticket: `enrollment_count` is now calculated using a subquery just as `course_completion_count` is
- `course_completion_count` subquery now filters on `consent_granted=True` instead of excluding `consent_granted=False`
- I've added another test for `learner_activity_filter` as a proactive measure to verify other areas of our code are doing what we expect with respect to `consent_granted`
