### PR TITLE
Fixed PGP encryption key issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+[1.0.7] - 2018-10-25
+--------------------
+* Fixed KeyError issue when PGP Encryption key is not found
 
 [1.0.6] - 2018-10-25
 --------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/delivery_method.py
+++ b/enterprise_reporting/delivery_method.py
@@ -27,7 +27,7 @@ class DeliveryMethod(object):
         self.data_type = reporting_config['data_type']
         self.report_type = reporting_config['report_type']
         self.password = password
-        self.pgp_encryption_key = reporting_config['pgp_encryption_key']
+        self.pgp_encryption_key = reporting_config.get('pgp_encryption_key')
 
     def send(self, files):
         """Base method for sending files, to perform common sending logic."""


### PR DESCRIPTION
This PR sets the PGP encryption key to None if the key is not found in the reporting configuration.