### PR TITLE
ENT-1336. Handle case when pgp_key is empty string

### DIFF
--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -34,13 +34,13 @@ FREQUENCY_TYPE_WEEKLY = 'weekly'
 AWS_REGION = 'us-east-1'
 
 
-def compress_and_encrypt(files, password=None, pgp_key=None):
+def compress_and_encrypt(files, password=None, pgp_key=''):
     """
     Given file(s) and a password or a PGP key,
     create a password protected or encrypted compressed file.
     Return the new filename.
     """
-    if pgp_key is not None:
+    if pgp_key:
         zipfile = _get_compressed_file(files)
         return _get_encrypted_file(zipfile, pgp_key)
     else:


### PR DESCRIPTION
The pgp_key config in the LMS is a TextField which means when it is updated the key is set to empty string ('') and not None. We were only checking for None and therefore passing along an empty pgp_key to the _get_encrypted_file method. This is fixed with this PR by doing a truthy check - of which both empty string and None will fail.

I also updated the default to better match what is getting passed in, as well as make the tests fail before fixing the problem.