### PR TITLE
ENT-1344: Add "enrollment_created_date" to progress report

### DIFF
--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -23,7 +23,7 @@ class EnterpriseEnrollmentSerializer(serializers.ModelSerializer):
         )
 
     def get_enrollment_created_date(self, obj):
-        """Construct a date from the enrollment datetime"""
+        """ Construct a serializer field to represent the enrollment_created_date model property. """
         return obj.enrollment_created_date.strftime('%Y-%m-%d')
 
     class Meta:

--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -14,12 +14,17 @@ class EnterpriseEnrollmentSerializer(serializers.ModelSerializer):
     Serializer for EnterpriseEnrollment model.
     """
     course_api_url = serializers.SerializerMethodField()
+    enrollment_created_date = serializers.SerializerMethodField()
 
     def get_course_api_url(self, obj):
         """Constructs course api url"""
         return '/enterprise/v1/enterprise-catalogs/{enterprise_id}/courses/{course_id}'.format(
             enterprise_id=obj.enterprise_id, course_id=obj.course_id
         )
+
+    def get_enrollment_created_date(self, obj):
+        """Construct a date from the enrollment datetime"""
+        return obj.enrollment_created_date.strftime('%Y-%m-%d')
 
     class Meta:
         model = EnterpriseEnrollment

--- a/enterprise_data/models.py
+++ b/enterprise_data/models.py
@@ -87,7 +87,7 @@ class EnterpriseEnrollment(models.Model):
     @property
     def enrollment_created_date(self):
         """
-        Returns the date component of the enrollment created timestamp model field
+        Return the date component of the enrollment created timestamp model field.
         """
         return self.enrollment_created_timestamp.date()
 

--- a/enterprise_data/models.py
+++ b/enterprise_data/models.py
@@ -86,6 +86,9 @@ class EnterpriseEnrollment(models.Model):
 
     @property
     def enrollment_created_date(self):
+        """
+        Returns the date component of the enrollment created timestamp model field
+        """
         return self.enrollment_created_timestamp.date()
 
 

--- a/enterprise_data/models.py
+++ b/enterprise_data/models.py
@@ -84,6 +84,10 @@ class EnterpriseEnrollment(models.Model):
         """
         return self.__str__()
 
+    @property
+    def enrollment_created_date(self):
+        return self.enrollment_created_timestamp.date()
+
 
 @python_2_unicode_compatible
 class EnterpriseUser(models.Model):

--- a/enterprise_data/tests/api/v0/test_serializers.py
+++ b/enterprise_data/tests/api/v0/test_serializers.py
@@ -63,7 +63,11 @@ class TestEnterpriseEnrollmentSerializer(APITestCase):
         )
 
     def test_enrollment_serialization(self):
-        expected_serialized_data = dict(self.enrollment_data, course_api_url=self.course_api_url)
+        expected_serialized_data = dict(
+            self.enrollment_data,
+            course_api_url=self.course_api_url,
+            enrollment_created_date='2014-06-27'
+        )
 
         serializer = EnterpriseEnrollmentSerializer(data=self.enrollment_data)
         serializer.is_valid()

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -89,6 +89,7 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
                 'discount_price': '120.00',
                 'course_api_url': ('/enterprise/v1/enterprise-catalogs/ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
                                    '/courses/edX/Open_DemoX/edx_demo_course'),
+                'enrollment_created_date': '2014-06-27'
             }, {
                 'enrollment_created_timestamp': '2014-06-27T16:02:38Z',
                 'user_current_enrollment_mode': 'verified',
@@ -125,6 +126,7 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
                 'discount_price': '120.00',
                 'course_api_url': ('/enterprise/v1/enterprise-catalogs/ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
                                    '/courses/edX/Open_DemoX/edx_demo_course'),
+                'enrollment_created_date': '2014-06-27'
             }],
             'next': None,
             'start': 0,


### PR DESCRIPTION
An enterprise customer is having a hard time parsing the date component out of the "enrollment_created_timestamp" field included in the learner progress report. In order to help the integration move along we will append a new "enrollment_created_date" field to the report.