### PR TITLE
Update pgp files to include base extension

### DIFF
--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -53,7 +53,7 @@ def _get_encrypted_file(zipfile, pgp_key):
     """
     rsa_pub, _ = pgpy.PGPKey.from_blob(pgp_key)
     message = pgpy.PGPMessage.new(zipfile, file=True)
-    pgpfile = re.sub(r'(_(\w+))?\.(\w+)$', '.pgp', zipfile)
+    pgpfile = '{}.pgp'.format(zipfile)
     encrypted_message = rsa_pub.encrypt(message)
     with open(pgpfile, 'wb') as encrypted_file:
         encrypted_file.write(encrypted_message.__bytes__())


### PR DESCRIPTION
Rather than replace the current extension, this tacks on .pgp to the end. This will give a better indication of the file type to our customers after it has been decrypted.