### PR TITLE
ENT-1404 | Fixing a call to a function in report

### DIFF
--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -52,7 +52,7 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
         """Return all content metadata contained in the catalogs associated with an Enterprise Customer."""
         content_metadata = OrderedDict()
 
-        enterprise_customer_catalogs = self._extract_catalog_uuids_from_reporting_config(reporting_config)
+        enterprise_customer_catalogs = extract_catalog_uuids_from_reporting_config(reporting_config)
         if not enterprise_customer_catalogs.get('results'):
             enterprise_customer_catalogs = self._load_data(
                 self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,


### PR DESCRIPTION
I had refactored this code by pulling the method out of the class but did not remove the `self._`. You can find the function in the same file.

```
def extract_catalog_uuids_from_reporting_config(reporting_config):
```