### PR TITLE
ENT-1455: return empty list if no enrollments

### DIFF
--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -86,21 +86,22 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
         Returns all learner enrollment records for a given enterprise.
         """
         enterprise_id = self.kwargs['enterprise_id']
-        enrollments = EnterpriseEnrollment.objects.filter(enterprise_id=enterprise_id)
 
-        enrollments = self.apply_filters(enrollments)
-
+        enterprise = EnterpriseUser.objects.filter(enterprise_id=enterprise_id)
         self.ensure_data_exists(
             self.request,
-            enrollments,
+            enterprise,
             error_message=(
-                "No course enrollments are associated with Enterprise {enterprise_id} from endpoint '{path}'."
-                .format(
+                "No enterprise found with id {enterprise_id} from endpoint '{path}'.".format(
                     enterprise_id=enterprise_id,
                     path=self.request.get_full_path()
                 )
             )
         )
+
+        enrollments = EnterpriseEnrollment.objects.filter(enterprise_id=enterprise_id)
+
+        enrollments = self.apply_filters(enrollments)
         return enrollments
 
     def apply_filters(self, queryset):

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -8,12 +8,14 @@ from datetime import datetime
 
 import factory
 from faker import Factory as FakerFactory
+from faker.providers import misc
 
 from django.contrib.auth.models import User
 
 from enterprise_data.models import EnterpriseEnrollment, EnterpriseUser
 
 FAKER = FakerFactory.create()
+FAKER.add_provider(misc)
 
 
 class EnterpriseEnrollmentFactory(factory.django.DjangoModelFactory):
@@ -31,7 +33,7 @@ class EnterpriseEnrollmentFactory(factory.django.DjangoModelFactory):
         model = EnterpriseEnrollment
 
     id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1, max=999999))  # pylint: disable=no-member,invalid-name
-    enterprise_id = factory.lazy_attribute(lambda x: 'ee5e6b3a069a4947bb8dd2dbc323396c')
+    enterprise_id = str(FAKER.uuid4())  # pylint: disable=no-member
     lms_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=no-member
     course_id = factory.lazy_attribute(lambda x: FAKER.slug())  # pylint: disable=no-member
     enrollment_created_timestamp = factory.lazy_attribute(lambda x: '2018-01-01')
@@ -67,12 +69,12 @@ class EnterpriseUserFactory(factory.django.DjangoModelFactory):
     """
     Enterprise User Factory.
 
-    Creates an instance of Enteprise User with minimal boilerplate
+    Creates an instance of Enterprise User with minimal boilerplate
     """
     class Meta(object):
         model = EnterpriseUser
 
-    enterprise_id = factory.lazy_attribute(lambda x: 'ee5e6b3a069a4947bb8dd2dbc323396c')
+    enterprise_id = str(FAKER.uuid4())  # pylint: disable=no-member
     lms_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=no-member
     enterprise_user_id = factory.lazy_attribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=no-member
     enterprise_sso_uid = factory.lazy_attribute(lambda x: FAKER.text(max_nb_chars=255))  # pylint: disable=no-member


### PR DESCRIPTION
- the ```/enterprise/api/v0/enterprise/<enterprise_uuid>/enrollments```
  used to return 404 if there were no enrollments for that enterprise
- now that case will return an empty list to signify that there is an
  enterprise with that UUID, but it has no enrollments
- if there is no enterprise user with the given UUID, 404 is thrown and
  the following error message is logged:
  ```No enterprise found with id {enterprise_id} from endpoint '{path}'.```

Remove 404 and return empty list when enterprise has 0 enrollments. Log error and throw 404 when enterprise doesn't exist