### PR TITLE
Respect the enterprise customer enforce_data_sharing_consent field when filtering enrollments.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+=======
+[1.0.16] - 2019-01-24
+--------------------
+* Respect the "externally managed" data consent policy in the enrollment view.
+
 [1.0.15] - 2019-01-24
 ---------------------
 * Bumping version so others can install newer version of this app that includes convenient management commands for devs
@@ -24,11 +29,11 @@ Unreleased
 * Only include current active enrollments which are not complete yet in active learners table.
 
 [1.0.11] - 2018-11-02
----------------------
+--------------------
 Revert 1.0.9 changes - enrollment_created_date as this value is redundent with the enrollment_created_timestamp
 
 [1.0.10] - 2018-11-02
----------------------
+--------------------
 Upgrade dependencies
 
 [1.0.9] - 2018-11-02

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.15"
+__version__ = "1.0.16"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/permissions.py
+++ b/enterprise_data/permissions.py
@@ -102,11 +102,13 @@ class HasDataAPIDjangoGroupAccess(permissions.BasePermission):
                 )
             else:
                 enable_audit_enrollment = enterprise_data.get('enable_audit_enrollment', False)
+                enforce_data_sharing_consent = enterprise_data.get('enforce_data_sharing_consent', '')
                 update_session_with_enterprise_data(
                     request,
                     enterprise_in_url,
                     enterprises_with_access=True,
-                    enable_audit_enrollment=enable_audit_enrollment
+                    enable_audit_enrollment=enable_audit_enrollment,
+                    enforce_data_sharing_consent=enforce_data_sharing_consent,
                 )
 
         permitted = request.session['enterprises_with_access'][enterprise_in_url]


### PR DESCRIPTION
[EDUCATOR-3866](https://openedx.atlassian.net/browse/EDUCATOR-3866)

This will enable enterprise customers with enforce_data_sharing_consent=externally_managed to view enrollment data that hasn't been explicitly granted consent.