### PR TITLE
ENT-1603: Only filter out audit rows that do not have any offer or code applied

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Mushtaq Ali <mushtaak@gmail.com>
 Muhammad Ammar <mammar@gmail.com>
 Irfan Ahmad <iahmad@edx.org>
 Robert Raposa <rraposa@edx.org>
+Saleem Latif <saleem_ee@hotmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.0.17] - 2019-03-05
+---------------------
+* In audit enrollments filtering, only filter out audit rows that do not have any offer or code applied.
+
 [1.0.16] - 2019-01-24
 --------------------
 * Respect the "externally managed" data consent policy in the enrollment view.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.16"
+__version__ = "1.0.17"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -80,6 +80,8 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
     ordering = ('user_email',)
     CONSENT_GRANTED_FILTER = 'consent_granted'
     ENROLLMENT_MODE_FILTER = 'user_current_enrollment_mode'
+    COUPON_CODE_FILTER = 'coupon_code'
+    OFFER_FILTER = 'offer'
 
     def get_queryset(self):
         """

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -55,7 +55,12 @@ class AuditEnrollmentsFilterBackend(filters.BaseFilterBackend):
         enable_audit_enrollment = request.session['enable_audit_enrollment'].get(enterprise_id, False)
 
         if not enable_audit_enrollment:
-            filter_kwargs = {view.ENROLLMENT_MODE_FILTER: 'audit'}
-            queryset = queryset.exclude(**filter_kwargs)
+            # Filter out enrollments that have audit mode and do not have a coupon code or an offer.
+            filter_query = {
+                view.ENROLLMENT_MODE_FILTER: 'audit',
+                view.COUPON_CODE_FILTER: None,
+                view.OFFER_FILTER: None
+            }
+            queryset = queryset.exclude(**filter_query)
 
         return queryset

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -199,21 +199,58 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
 
     @ddt.data(
         (
-            True, 2, 'verified', 2
+            True, None, None, 2, 'verified', 2
         ),
         (
-            True, 2, 'audit', 2
+            True, None, None, 2, 'audit', 2
         ),
         (
-            False, 2, 'verified', 2
+            False, None, None, 2, 'verified', 2
         ),
         (
-            False, 2, 'audit', 0
+            False, None, None, 2, 'audit', 0
+        ),
+        (
+            True, 'Test Coupon Code', None, 2, 'verified', 2
+        ),
+        (
+            True, 'Test Coupon Code', None, 2, 'audit', 2
+        ),
+        (
+            False, 'Test Coupon Code', None, 2, 'verified', 2
+        ),
+        (
+            False, 'Test Coupon Code', None, 2, 'audit', 2
+        ),
+        (
+            True, None, 'Test Offer', 2, 'verified', 2
+        ),
+        (
+            True, None, 'Test Offer', 2, 'audit', 2
+        ),
+        (
+            False, None, 'Test Offer', 2, 'verified', 2
+        ),
+        (
+            False, None, 'Test Offer', 2, 'audit', 2
+        ),
+        (
+            True, 'Test Coupon Code', 'Test Offer', 2, 'verified', 2
+        ),
+        (
+            True, 'Test Coupon Code', 'Test Offer', 2, 'audit', 2
+        ),
+        (
+            False, 'Test Coupon Code', 'Test Offer', 2, 'verified', 2
+        ),
+        (
+            False, 'Test Coupon Code', 'Test Offer', 2, 'audit', 2
         ),
     )
     @ddt.unpack
     def test_get_queryset_returns_enrollments_with_audit_enrollment_filter(
-            self, enable_audit_enrollment, total_enrollments, user_current_enrollment_mode, enrollments_count
+            self, enable_audit_enrollment, coupon_code, offer, total_enrollments,
+            user_current_enrollment_mode, enrollments_count
     ):
         enterprise_user = EnterpriseUserFactory()
         enterprise_id = enterprise_user.enterprise_id
@@ -241,6 +278,9 @@ class TestEnterpriseEnrollmentsViewSet(APITestCase):
                 course_title='course101',
                 has_passed=True,
                 consent_granted=True,
+                coupon_name='Test Coupon {}'.format(index),
+                coupon_code=coupon_code,
+                offer=offer,
             )
 
         response = self.client.get(url)


### PR DESCRIPTION
**JIRA Ticket:** [ENT-1603](https://openedx.atlassian.net/browse/ENT-1603)

**Description:**
When users unenroll, even if their original enrollment mode was verified, the enrollment mode gets set to audit. When we are reporting from the data API, we are filtering out audit rows depending on if the enterprise is configured to include or exclude audit enrollments (https://github.com/edx/edx-enterprise-data/blob/master/enterprise_data/filters.py#L41). As a short term fix, we should update this logic to only filter out audit rows that do not have any offer or code applied.

**Acceptance Criteria:**

- Only filters out audit rows that do not have any offer or code applied