### PR TITLE
add enterprise-openedx-operator permission checks

### DIFF
--- a/enterprise_data/settings/test.py
+++ b/enterprise_data/settings/test.py
@@ -8,7 +8,11 @@ from __future__ import absolute_import, unicode_literals
 
 from os.path import abspath, dirname, join
 
-from enterprise_data_roles.constants import ENTERPRISE_DATA_ADMIN_ROLE, SYSTEM_ENTERPRISE_ADMIN_ROLE
+from enterprise_data_roles.constants import (
+    ENTERPRISE_DATA_ADMIN_ROLE,
+    SYSTEM_ENTERPRISE_ADMIN_ROLE,
+    SYSTEM_ENTERPRISE_OPERATOR_ROLE,
+)
 
 
 def here(*args):
@@ -126,4 +130,5 @@ JWT_AUTH = {
 
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     SYSTEM_ENTERPRISE_ADMIN_ROLE: [ENTERPRISE_DATA_ADMIN_ROLE],
+    SYSTEM_ENTERPRISE_OPERATOR_ROLE: [ENTERPRISE_DATA_ADMIN_ROLE],
 }

--- a/enterprise_data/tests/mixins.py
+++ b/enterprise_data/tests/mixins.py
@@ -17,11 +17,13 @@ class JWTTestMixin(object):
         """
         Set jwt token in cookies
         """
+        role_data = '{system_wide_role}'.format(system_wide_role=system_wide_role)
+        if context is not None:
+            role_data += ':{context}'.format(context=context)
+
         payload = generate_unversioned_payload(self.user)
         payload.update({
-            'roles': [
-                '{system_wide_role}:{context}'.format(system_wide_role=system_wide_role, context=context)
-            ]
+            'roles': [role_data]
         })
         jwt_token = generate_jwt_token(payload)
 

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -25,9 +25,11 @@ from enterprise_data.tests.test_utils import (
     get_dummy_enterprise_api_data,
 )
 from enterprise_data_roles.constants import (
+    ALL_ACCESS_CONTEXT,
     ENTERPRISE_DATA_ADMIN_ROLE,
     ROLE_BASED_ACCESS_CONTROL_SWITCH,
     SYSTEM_ENTERPRISE_ADMIN_ROLE,
+    SYSTEM_ENTERPRISE_OPERATOR_ROLE,
 )
 from enterprise_data_roles.models import EnterpriseDataFeatureRole, EnterpriseDataRoleAssignment
 
@@ -624,6 +626,26 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
             response = self.client.get(url)
 
         assert response.status_code == status
+
+    def test_permissions_with_enterprise_openedx_operator(self):
+        """
+        Test that role base permissions works as expected with `enterprise_openedx_operator` role.
+        """
+        toggle_switch(ROLE_BASED_ACCESS_CONTROL_SWITCH, True)
+
+        self.set_jwt_cookie(system_wide_role=SYSTEM_ENTERPRISE_OPERATOR_ROLE, context=ALL_ACCESS_CONTEXT)
+
+        url = reverse('v0:enterprise-enrollments-list', kwargs={'enterprise_id': self.enterprise_id})
+        path = 'enterprise_data.filters.EnterpriseApiClient.get_enterprise_customer'
+        with mock.patch(path) as mock_enterprise_api_client:
+            mock_enterprise_api_client.return_value = {
+                'uuid': self.enterprise_id,
+                'enable_audit_enrollment': True,
+                'enforce_data_sharing_consent': True,
+            }
+            response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
 
 
 @ddt.ddt
@@ -1273,6 +1295,19 @@ class TestEnterpriseUsersViewSet(JWTTestMixin, APITransactionTestCase):
 
         assert response.status_code == status
 
+    def test_permissions_with_enterprise_openedx_operator(self):
+        """
+        Test that role base permissions works as expected with `enterprise_openedx_operator` role.
+        """
+        toggle_switch(ROLE_BASED_ACCESS_CONTROL_SWITCH, True)
+
+        self.set_jwt_cookie(system_wide_role=SYSTEM_ENTERPRISE_OPERATOR_ROLE, context=ALL_ACCESS_CONTEXT)
+
+        url = reverse('v0:enterprise-users-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
 
 @ddt.ddt
 class TestEnterpriseLearnerCompletedCourses(JWTTestMixin, APITransactionTestCase):
@@ -1541,3 +1576,16 @@ class TestEnterpriseLearnerCompletedCourses(JWTTestMixin, APITransactionTestCase
         response = self.client.get(url)
 
         assert response.status_code == status
+
+    def test_permissions_with_enterprise_openedx_operator(self):
+        """
+        Test that role base permissions works as expected with `enterprise_openedx_operator` role.
+        """
+        toggle_switch(ROLE_BASED_ACCESS_CONTROL_SWITCH, True)
+
+        self.set_jwt_cookie(system_wide_role=SYSTEM_ENTERPRISE_OPERATOR_ROLE, context=ALL_ACCESS_CONTEXT)
+
+        url = reverse('v0:enterprise-learner-completed-courses-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK

--- a/enterprise_data_roles/admin.py
+++ b/enterprise_data_roles/admin.py
@@ -23,7 +23,7 @@ class EnterpriseDataRoleAssignmentAdminForm(UserRoleAssignmentAdminForm):
         """
 
         model = EnterpriseDataRoleAssignment
-        fields = ('user', 'role')
+        fields = "__all__"
 
 
 @admin.register(EnterpriseDataRoleAssignment)
@@ -39,4 +39,5 @@ class EnterpriseDataRoleAssignmentAdmin(UserRoleAssignmentAdmin):
 
         model = EnterpriseDataRoleAssignment
 
+    fields = ('user', 'role', 'enterprise_id')
     form = EnterpriseDataRoleAssignmentAdminForm

--- a/enterprise_data_roles/constants.py
+++ b/enterprise_data_roles/constants.py
@@ -6,6 +6,10 @@ from __future__ import unicode_literals
 
 ENTERPRISE_DATA_ADMIN_ROLE = 'enterprise_data_admin'
 SYSTEM_ENTERPRISE_ADMIN_ROLE = 'enterprise_admin'
+SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
 # switch is used to enable/disable role based access control
 ROLE_BASED_ACCESS_CONTROL_SWITCH = 'role_based_access_control'
+
+# context to give access to all resources
+ALL_ACCESS_CONTEXT = '*'

--- a/enterprise_data_roles/models.py
+++ b/enterprise_data_roles/models.py
@@ -44,12 +44,12 @@ class EnterpriseDataRoleAssignment(UserRoleAssignment):
 
     def get_context(self):
         """
-        Return the enterprise customer id or None.
+        Return the enterprise customer id or `*` if the user has access to all resources.
         """
-        enterprise_id = self.enterprise_id
-        if enterprise_id:
+        enterprise_id = '*'
+        if self.enterprise_id:
             # converting the UUID('ee5e6b3a-069a-4947-bb8d-d2dbc323396c') to 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
-            enterprise_id = str(enterprise_id)
+            enterprise_id = str(self.enterprise_id)
 
         return enterprise_id
 

--- a/enterprise_data_roles/rules.py
+++ b/enterprise_data_roles/rules.py
@@ -4,56 +4,13 @@ Rules needed to restrict access to the enterprise data api.
 from __future__ import absolute_import, unicode_literals
 
 import rules
-from edx_rbac.utils import (
-    get_decoded_jwt_from_request,
-    get_request_or_stub,
-    request_user_has_implicit_access_via_jwt,
-    user_has_access_via_database,
-)
+from edx_rbac.utils import get_request_or_stub, request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt as get_decoded_jwt_from_jwt_cookie
 
 from django.urls import resolve
 
-from enterprise_data_roles.constants import ENTERPRISE_DATA_ADMIN_ROLE, SYSTEM_ENTERPRISE_ADMIN_ROLE
+from enterprise_data_roles.constants import ENTERPRISE_DATA_ADMIN_ROLE
 from enterprise_data_roles.models import EnterpriseDataRoleAssignment
-
-
-def has_correct_context_for_implicit_access(request, decoded_jwt, system_wide_role_name):
-    """
-    Check if request has correct role assignement context.
-    """
-    __, __, kwargs = resolve(request.path)
-    enterprise_id_in_request = kwargs.get('enterprise_id')
-
-    jwt_roles_claim = decoded_jwt.get('roles', [])
-
-    for role_data in jwt_roles_claim:
-        role_in_jwt, enterprise_id_in_jwt = role_data.split(':')
-        if role_in_jwt == system_wide_role_name:
-            return enterprise_id_in_jwt == enterprise_id_in_request
-
-    return False
-
-
-def has_correct_context_for_explicit_access(request):
-    """
-    Check if request has correct role assignement context.
-    """
-    __, __, kwargs = resolve(request.path)
-    enterprise_id_in_request = kwargs.get('enterprise_id')
-
-    try:
-        role_assignment = EnterpriseDataRoleAssignment.objects.get(
-            user=request.user,
-            role__name=ENTERPRISE_DATA_ADMIN_ROLE
-        )
-    except EnterpriseDataRoleAssignment.DoesNotExist:
-        return False
-
-    # if there is no enterprise_id set than user is allowed
-    if role_assignment.get_context() is None:
-        return True
-
-    return role_assignment.get_context() == enterprise_id_in_request
 
 
 @rules.predicate
@@ -65,14 +22,15 @@ def request_user_has_implicit_access(*args, **kwargs):  # pylint: disable=unused
         boolean: whether the request user has access or not
     """
     request = get_request_or_stub()
+    __, __, request_kwargs = resolve(request.path)
+    enterprise_id_in_request = request_kwargs.get('enterprise_id')
 
-    decoded_jwt = get_decoded_jwt_from_request(request)
-    implicit_access = request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DATA_ADMIN_ROLE)
-
-    if not implicit_access:
-        return False
-
-    return has_correct_context_for_implicit_access(request, decoded_jwt, SYSTEM_ENTERPRISE_ADMIN_ROLE)
+    decoded_jwt = get_decoded_jwt_from_jwt_cookie(request)
+    return request_user_has_implicit_access_via_jwt(
+        decoded_jwt,
+        ENTERPRISE_DATA_ADMIN_ROLE,
+        enterprise_id_in_request
+    )
 
 
 @rules.predicate
@@ -84,17 +42,18 @@ def request_user_has_explicit_access(*args, **kwargs):  # pylint: disable=unused
         boolean: whether the request user has access or not
     """
     request = get_request_or_stub()
+    __, __, request_kwargs = resolve(request.path)
+    enterprise_id_in_request = request_kwargs.get('enterprise_id')
 
-    explicit_access = user_has_access_via_database(
+    return user_has_access_via_database(
         request.user,
         ENTERPRISE_DATA_ADMIN_ROLE,
-        EnterpriseDataRoleAssignment
+        EnterpriseDataRoleAssignment,
+        enterprise_id_in_request
     )
 
-    if not explicit_access:
-        return False
 
-    return has_correct_context_for_explicit_access(request)
-
-
-rules.add_perm('can_access_enterprise', request_user_has_implicit_access | request_user_has_explicit_access)
+rules.add_perm(
+    'can_access_enterprise',
+    request_user_has_implicit_access | request_user_has_explicit_access
+)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,15 +21,15 @@ cryptography==1.9
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2  # via edx-rbac
-django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.1.0
+edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.7
+edx-rbac==0.1.10
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
@@ -40,11 +40,11 @@ jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 neobolt==1.7.4            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 paramiko==2.4
 pbr==5.1.3                # via stevedore
 pgpy==0.4.3
-pip-tools==3.5.0
+pip-tools==3.6.0
 pluggy==0.9.0             # via tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -52,7 +52,7 @@ py2neo==4.2.0
 py==1.8.0                 # via tox
 pyasn1==0.4.5             # via paramiko, pgpy, rsa
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ cffi==1.12.2              # via bcrypt, cryptography, pynacl
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-configparser==3.7.3       # via importlib-metadata, pydocstyle, pylint
+configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
 diff-cover==1.0.7
@@ -31,28 +31,28 @@ distlib==0.2.8            # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2  # via edx-rbac
-django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
-edx-drf-extensions==2.1.0
+edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.7
+edx-rbac==0.1.10
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography, urllib3
-importlib-metadata==0.8   # via path.py
+importlib-metadata==0.9   # via path.py
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, urllib3
-isort==4.3.15
+isort==4.3.16
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
@@ -60,14 +60,14 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 neobolt==1.7.4            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
 path.py==11.5.0           # via edx-i18n-tools
 pathlib2==2.3.3           # via importlib-metadata
 pbr==5.1.3                # via stevedore
 pgpy==0.4.3
-pip-tools==3.5.0
+pip-tools==3.6.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via tox
 polib==1.1.0              # via edx-i18n-tools
@@ -78,7 +78,7 @@ py==1.8.0                 # via tox
 pyasn1==0.4.5             # via paramiko, pgpy, rsa
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.3.1           # via diff-cover, py2neo, readme-renderer
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -109,7 +109,7 @@ six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 tox-battery==0.5.1
 tox==3.0.0
 tqdm==4.31.1              # via twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -25,7 +25,7 @@ cffi==1.12.2              # via bcrypt, cryptography, pynacl
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-configparser==3.7.3       # via importlib-metadata, pydocstyle, pylint
+configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
@@ -36,17 +36,17 @@ distlib==0.2.8            # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
-edx-drf-extensions==2.1.0
+edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.7
+edx-rbac==0.1.10
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 factory-boy==2.11.1
@@ -57,12 +57,12 @@ funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography, urllib3
-importlib-metadata==0.8   # via path.py
+importlib-metadata==0.9   # via path.py
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker, urllib3
-isort==4.3.15
+isort==4.3.16
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
@@ -72,14 +72,14 @@ mock==2.0.0
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.4            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
 path.py==11.5.0           # via edx-i18n-tools
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
 pgpy==0.4.3
-pip-tools==3.5.0
+pip-tools==3.6.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -90,7 +90,7 @@ py==1.8.0                 # via pytest, pytest-catchlog, tox
 pyasn1==0.4.5             # via paramiko, pgpy, rsa
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.3.1           # via diff-cover, py2neo, readme-renderer
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -107,7 +107,7 @@ pyparsing==2.3.1          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
@@ -126,7 +126,7 @@ six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
 tox==3.0.0

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -26,15 +26,15 @@ ddt==1.2.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.1.0
+edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.7
+edx-rbac==0.1.10
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1
@@ -52,12 +52,12 @@ mock==2.0.0
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.4            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 paramiko==2.4
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
 pgpy==0.4.3
-pip-tools==3.5.0
+pip-tools==3.6.0
 pluggy==0.9.0             # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -65,7 +65,7 @@ py2neo==4.2.0
 py==1.8.0                 # via pytest, pytest-catchlog, tox
 pyasn1==0.4.5             # via paramiko, pgpy, rsa
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
@@ -76,7 +76,7 @@ pyopenssl==17.4.0
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
@@ -92,7 +92,7 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,15 +26,15 @@ ddt==1.2.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2
-django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.1.0
+edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.7
+edx-rbac==0.1.10
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1
@@ -52,12 +52,12 @@ mock==2.0.0
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.4            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 paramiko==2.4
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
 pgpy==0.4.3
-pip-tools==3.5.0
+pip-tools==3.6.0
 pluggy==0.9.0             # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -65,7 +65,7 @@ py2neo==4.2.0
 py==1.8.0                 # via pytest, pytest-catchlog, tox
 pyasn1==0.4.5             # via paramiko, pgpy, rsa
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
@@ -76,7 +76,7 @@ pyopenssl==17.4.0
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
@@ -92,7 +92,7 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -16,6 +16,6 @@ requests==2.21.0          # via codecov
 six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.6
 urllib3==1.24.1           # via requests
 virtualenv==16.4.3        # via tox


### PR DESCRIPTION
[ENT-1738](https://openedx.atlassian.net/browse/ENT-1711)

Description: Add permission checks for `enterprise_openedx_operator` role and update the logic for existing implicit and explicit access checks.

Dependencies:
1. https://github.com/edx/edx-rbac/pull/16
2. https://github.com/edx/edx-enterprise/pull/450

**Testing**

Done some testing previously with waffle switch OFF, Please see https://github.com/edx/edx-enterprise-data/pull/112#issuecomment-476555848

Waffle Switch OFF:

- staff users with the enterprise_data_api_access group who are may or may not be linked to an enterprise get access.
- non-staff users linked to the same enterprise as the request object who have the enterprise_data_api_access group get access.
- all other users are denied (staff without the group, matching enterprise users without the group, non matching enterprise users with the group)

Waffle Switch ON:

- users with the system wide role in their jwt and a matching enterprise get access.
- users with a feature specific role assignment with a matching enterprise get access.
- users with an operator role get access.
- all other users are denied (this includes staff)


## 

**Testing Details**

Test Enterprises

-  name = batman, uuid = 6ae013d4-c5c4-474d-8da9-0e559b2448e2
-  name = riddler, uuid = 885f4d97-5a21-4e8a-8723-a434bc527e74

##

### Waffle Switch OFF

##

* **Case:** With waffle switch OFF, staff users with the enterprise_data_api_access group who are may or may not be linked to an enterprise get access.
    * user100@example.com
        * staff = True
        * has enterprise_data_api_access
        * linked to enterprise batman
    *  user100@example.com
        * staff = True
        * has enterprise_data_api_access
        * not linked to any enterprise
* **Result:** HTTP_200_OK and user100@example.com is able to access all the enterprises and data with in them

##

* **Case:** With waffle switch OFF, non-staff users linked to the same enterprise as the request object who have the enterprise_data_api_access group get access.
    * user101@example.com              
        * staff = False
        * has enterprise_data_api_access
        * linked to enterprise riddler
* **Result:** HTTP_200_OK
* **NOTE:** 
     - user100@example.com is able to access the riddler enterprise only
     - gets HTTP_401 if try to access an endpoint with any enterprise id other than riddler

##

* **Case:** With waffle switch OFF, all other users are denied (staff without the group, matching enterprise users without the group, non matching enterprise users with the group)
    * user102@example.com         
        * staff = True
        * has no enterprise_data_api_access
        * not linked to any enterprise
   * **Result:** HTTP_403_FORBIDDEN

    * user103@example.com 
        * staff = False
        * has no enterprise_data_api_access
        * linked with riddler enterprise
    * **Result:** HTTP_403_FORBIDDEN

##

### Waffle Switch ON

* Create `SystemWideEnterpriseUserRoleAssignment` for a user for `enterprise_admin` role
* Add `SYSTEM_WIDE_ROLE_CLASSES` set to `['enterprise.SystemWideEnterpriseUserRoleAssignment']` in edx-platform
* Add `crum.CurrentRequestUserMiddleware `in `MIDDLEWARE_CLASSES` in edx-analytics-data-api
* Add `SYSTEM_TO_FEATURE_ROLE_MAPPING` in edx-analytics-data-api
* Link the user with an enterprise so that correct context is attached to role — do this in lms enterprise django admin

Dependency: https://github.com/edx/edx-analytics-data-api/pull/257

**NOTE:** user must have `enterprise_data_api_access` group for testing
            * This should not be required but currently we are making calls to `with_access_to` endpoint and that endpoint requires `enterprise_data_api_access` group to be present otherwise we will get `HTTP_403_FORBIDDEN`
            * I have tested with [with_access_to](https://github.com/edx/edx-portal/blob/master/src/data/services/LmsApiService.js#L29) removed calls from edx-portal and it works

##

* **Case:** With waffle switch ON, users with the system wide role in their jwt and a matching enterprise get access.
   * user200@example.com
        * has `enterprise_data_api_access` group
        * linked with `batman` enterprise
        * has `enterprise_admin` role assignment
        * role data is `enterprise_admin:6ae013d4-c5c4-474d-8da9-0e559b2448e2`
    * **Result:** HTTP_200_OK
##

* **Case:** With waffle switch ON, users with a feature specific role assignment with a matching enterprise get access.
   * user201@example.com 
        * has `enterprise_data_api_access` group
        * linked with `riddler` enterprise
        * create `EnterpriseDataRoleAssignment` record with `enterprise_admin` role
        * role data is `enterprise_admin:885f4d975a214e8a8723a434bc527e74`
    * **Result:** HTTP_200_OK

##

* **Case:** With waffle switch ON, users with an operator role get access.
   * user203@example.com 
        * has `enterprise_data_api_access` group
        * has `enterprise_openedx_operator` role assignment
        * not linked with any enterprise
        * role data in jwt is `enterprise_openedx_operator:*`
    * **Result:** HTTP_200_OK

##

* **Case:** With waffle switch ON, all other users are denied (this includes staff)
   * edx@example.com 
        * has `enterprise_data_api_access` group
        * `superuser` and `staff`
        * no role assignment
        * linked with `batman` enterprise
    * **Result:** HTTP_403_FORBIDDEN
   * **NOTE:** User is able to see all the enterprises but gets error when try to access any enterprise
