### PR TITLE
Turn off RBAC waffle switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.2.3] - 2019-04-16
+--------------------
+* Turn off role base access control switch.
+
 [1.2.2] - 2019-04-16
 --------------------
 * Turn on role base access control switch.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data_roles/migrations/0006_turn_off_role_based_access_control_switch.py
+++ b/enterprise_data_roles/migrations/0006_turn_off_role_based_access_control_switch.py
@@ -1,0 +1,30 @@
+
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from enterprise_data_roles.constants import ROLE_BASED_ACCESS_CONTROL_SWITCH
+
+
+def turn_on_switch(apps, schema_editor):
+    """Turn on the `role_based_access_control` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+
+
+def turn_off_switch(apps, schema_editor):
+    """Turn off the the `role_based_access_control` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise_data_roles', '0005_turn_on_role_based_access_control_switch'),
+    ]
+
+    operations = [
+        migrations.RunPython(turn_off_switch, turn_on_switch),
+    ]


### PR DESCRIPTION
This PR adds migration to turn OFF RBAC waffle switch intended to go on staging environment.

- [ ] Testing with RBAC waffle switch turn on is done on staging environment.

**NOTE**: This should only go when all the testings with switch ON has been done :)