### PR TITLE
Fix 500 error because of an old version of edx-rbac.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.2.3] - 2019-04-22
+--------------------
+* Version upgrade of edx-rbac.
+
 [1.2.2] - 2019-04-16
 --------------------
 * Turn on role base access control switch.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.10
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,7 +41,7 @@ edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.10
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -46,7 +46,7 @@ edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.10
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 factory-boy==2.11.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.10
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.10
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1


### PR DESCRIPTION
**Description:**
This PR updates `edx-rbac` version to `0.1.11` to fix 500 error related to authorization.