### PR TITLE
Use get_decoded_jwt_from_request from edx-rbac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.2.4] - 2019-04-22
+--------------------
+* Use `get_decoded_jwt_from_request` from edx-rbac.
+
 [1.2.3] - 2019-04-22
 --------------------
 * Version upgrade of edx-rbac.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data_roles/rules.py
+++ b/enterprise_data_roles/rules.py
@@ -4,8 +4,12 @@ Rules needed to restrict access to the enterprise data api.
 from __future__ import absolute_import, unicode_literals
 
 import rules
-from edx_rbac.utils import get_request_or_stub, request_user_has_implicit_access_via_jwt, user_has_access_via_database
-from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt as get_decoded_jwt_from_jwt_cookie
+from edx_rbac.utils import (
+    get_decoded_jwt_from_request,
+    get_request_or_stub,
+    request_user_has_implicit_access_via_jwt,
+    user_has_access_via_database,
+)
 
 from django.urls import resolve
 
@@ -25,7 +29,7 @@ def request_user_has_implicit_access(*args, **kwargs):  # pylint: disable=unused
     __, __, request_kwargs = resolve(request.path)
     enterprise_id_in_request = request_kwargs.get('enterprise_id')
 
-    decoded_jwt = get_decoded_jwt_from_jwt_cookie(request)
+    decoded_jwt = get_decoded_jwt_from_request(request)
     return request_user_has_implicit_access_via_jwt(
         decoded_jwt,
         ENTERPRISE_DATA_ADMIN_ROLE,


### PR DESCRIPTION
**Description:**
In this PR we are switching to use `get_decoded_jwt_from_request` from edx-rbac instead of the one present in `edx-drf-extensions`.