### PR TITLE
ENT-1836 version bump for edx-rbac

### DIFF
--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -68,7 +68,14 @@ def _get_compressed_file(files, password=None):
     # Replace the data and report type with just `.zip`.
     zipfile = re.sub(r'(_(\w+))?\.(\w+)$', '.zip', files[0].name)
     compression = pyminizip.compress_multiple if multiple_files else pyminizip.compress
-    compression([f.name for f in files] if multiple_files else files[0].name, zipfile, password, COMPRESSION_LEVEL)
+    src_file_path_prefix = [] if multiple_files else None
+    compression(
+        [f.name for f in files] if multiple_files else files[0].name,
+        src_file_path_prefix,
+        zipfile,
+        password,
+        COMPRESSION_LEVEL
+    )
     return zipfile
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 pip-tools                 		# Requirements file management
 tox==3.0.0                       		# virtualenv management for tests
 vertica-python==0.7.3                   # Required for Enterprise Reporting
-pyminizip==0.2.1                        # Required for Enterprise Reporting
+pyminizip                               # Required for Enterprise Reporting
 celery==3.1.18                          # Run task workers in other locations
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18
 certifi==2019.3.9         # via urllib3
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 cryptography==1.9
@@ -24,12 +24,12 @@ django-model-utils==3.1.2  # via edx-rbac
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.3  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.11
+edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
@@ -38,13 +38,13 @@ idna==2.8                 # via cryptography, urllib3
 ipaddress==1.0.22         # via cryptography, urllib3
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
-neobolt==1.7.4            # via py2neo
+neobolt==1.7.9            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.16.1.117      # via edx-django-utils
+newrelic==4.18.0.118      # via edx-django-utils
 paramiko==2.4
-pbr==5.1.3                # via stevedore
+pbr==5.2.0                # via stevedore
 pgpy==0.4.3
-pip-tools==3.6.0
+pip-tools==3.6.1
 pluggy==0.9.0             # via tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -56,12 +56,12 @@ pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
-pyminizip==0.2.1
-pymongo==3.7.2            # via edx-opaque-keys
+pyminizip==0.2.4
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, vertica-python
-pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -75,7 +75,7 @@ slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
 tox==3.0.0
 unicodecsv==0.14.1
-urllib3[secure]==1.24.1   # via py2neo
+urllib3[secure]==1.24.3   # via py2neo
 vertica-python==0.7.3
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+astroid==1.5.3            # via pylint, pylint-celery
 awscli==1.11.178
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 bcrypt==3.1.6             # via paramiko
@@ -19,14 +19,14 @@ botocore==1.7.36          # via awscli, boto3, s3transfer
 caniusepython3==7.0.0
 celery==3.1.18
 certifi==2019.3.9         # via urllib3
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
-click-log==0.1.8          # via edx-lint
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
+click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
-diff-cover==1.0.7
+diff-cover==2.0.0
 distlib==0.2.8            # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
@@ -34,14 +34,14 @@ django-model-utils==3.1.2  # via edx-rbac
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.3  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.1
+edx-lint==1.1.2
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.11
+edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
@@ -50,7 +50,7 @@ idna==2.8                 # via cryptography, urllib3
 importlib-metadata==0.9   # via path.py
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, urllib3
-isort==4.3.16
+isort==4.3.18
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -58,16 +58,16 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-neobolt==1.7.4            # via py2neo
+neobolt==1.7.9            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.16.1.117      # via edx-django-utils
+newrelic==4.18.0.118      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
-path.py==11.5.0           # via edx-i18n-tools
+path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3           # via importlib-metadata
-pbr==5.1.3                # via stevedore
+pbr==5.2.0                # via stevedore
 pgpy==0.4.3
-pip-tools==3.6.0
+pip-tools==3.6.1
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via tox
 polib==1.1.0              # via edx-i18n-tools
@@ -87,13 +87,13 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyminizip==0.2.1
-pymongo==3.7.2            # via edx-opaque-keys
+pyminizip==0.2.4
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0
-pyparsing==2.3.1          # via packaging
+pyparsing==2.4.0          # via packaging
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, vertica-python
-pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
@@ -109,17 +109,17 @@ six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.2
+testfixtures==6.8.1
 tox-battery==0.5.1
 tox==3.0.0
 tqdm==4.31.1              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
-urllib3[secure]==1.24.1   # via py2neo
+urllib3[secure]==1.24.3   # via py2neo
 vertica-python==0.7.3
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.33.1
 wrapt==1.11.1             # via astroid
-zipp==0.3.3               # via importlib-metadata
+zipp==0.4.0               # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 awscli==1.11.178
@@ -21,8 +21,8 @@ botocore==1.7.36          # via awscli, boto3, s3transfer
 caniusepython3==7.0.0
 celery==3.1.18
 certifi==2019.3.9         # via urllib3
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
-click-log==0.1.8          # via edx-lint
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
+click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
@@ -31,7 +31,7 @@ cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==1.9
 ddt==1.2.1
-diff-cover==1.0.7
+diff-cover==2.0.0
 distlib==0.2.8            # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
@@ -39,18 +39,18 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.3  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.1
+edx-lint==1.1.2
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.11
+edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 factory-boy==2.11.1
-faker==1.0.4              # via factory-boy
+faker==1.0.5              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
@@ -60,7 +60,7 @@ idna==2.8                 # via cryptography, urllib3
 importlib-metadata==0.9   # via path.py
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker, urllib3
-isort==4.3.16
+isort==4.3.18
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -68,18 +68,18 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.4            # via py2neo
+neobolt==1.7.9            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.16.1.117      # via edx-django-utils
+newrelic==4.18.0.118      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
-path.py==11.5.0           # via edx-i18n-tools
+path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pgpy==0.4.3
-pip-tools==3.6.0
+pip-tools==3.6.1
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -99,17 +99,17 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyminizip==0.2.1
-pymongo==3.7.2            # via edx-opaque-keys
+pyminizip==0.2.4
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0
-pyparsing==2.3.1          # via packaging
+pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
@@ -126,18 +126,18 @@ six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.2
+testfixtures==6.8.1
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
 tox==3.0.0
 tqdm==4.31.1              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
-urllib3[secure]==1.24.1   # via py2neo
+urllib3[secure]==1.24.3   # via py2neo
 vertica-python==0.7.3
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.33.1
 wrapt==1.11.1             # via astroid
-zipp==0.3.3               # via importlib-metadata
+zipp==0.4.0               # via importlib-metadata

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -16,7 +16,7 @@ boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18
 certifi==2019.3.9         # via urllib3
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 cookies==2.2.1            # via responses
@@ -34,11 +34,11 @@ docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.11
+edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1
-faker==1.0.4              # via factory-boy
+faker==1.0.5              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
@@ -48,16 +48,16 @@ idna==2.8                 # via cryptography, urllib3
 ipaddress==1.0.22         # via cryptography, faker, urllib3
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.4            # via py2neo
+neobolt==1.7.9            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.16.1.117      # via edx-django-utils
+newrelic==4.18.0.118      # via edx-django-utils
 paramiko==2.4
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pgpy==0.4.3
-pip-tools==3.6.0
+pip-tools==3.6.1
 pluggy==0.9.0             # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -69,16 +69,16 @@ pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
-pyminizip==0.2.1
-pymongo==3.7.2            # via edx-opaque-keys
+pyminizip==0.2.4
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0
 pytest-catchlog==1.2.2
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 responses==0.10.6
@@ -92,11 +92,11 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.2
+testfixtures==6.8.1
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1
-urllib3[secure]==1.24.1   # via py2neo
+urllib3[secure]==1.24.3   # via py2neo
 vertica-python==0.7.3
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -12,7 +12,7 @@ funcsigs==1.0.2           # via mock, pytest
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
 pathlib2==2.3.3           # via pytest
-pbr==5.1.3                # via mock
+pbr==5.2.0                # via mock
 pluggy==0.9.0             # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pytest-cov==2.5.1
@@ -21,4 +21,4 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0               # via mock, more-itertools, pathlib2, pytest, tox
 tox-battery==0.5.1
 tox==3.0.0
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18
 certifi==2019.3.9         # via urllib3
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 cookies==2.2.1            # via responses
@@ -29,16 +29,16 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.3  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.1.11
+edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.11.1
-faker==1.0.4              # via factory-boy
+faker==1.0.5              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
@@ -48,16 +48,16 @@ idna==2.8                 # via cryptography, urllib3
 ipaddress==1.0.22         # via cryptography, faker, urllib3
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.4            # via py2neo
+neobolt==1.7.9            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.16.1.117      # via edx-django-utils
+newrelic==4.18.0.118      # via edx-django-utils
 paramiko==2.4
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pgpy==0.4.3
-pip-tools==3.6.0
+pip-tools==3.6.1
 pluggy==0.9.0             # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -69,16 +69,16 @@ pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
-pyminizip==0.2.1
-pymongo==3.7.2            # via edx-opaque-keys
+pyminizip==0.2.4
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0
 pytest-catchlog==1.2.2
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.1             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2018.9              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
 requests==2.9.1
 responses==0.10.6
@@ -92,11 +92,11 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.6.2
+testfixtures==6.8.1
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1
-urllib3[secure]==1.24.1   # via py2neo
+urllib3[secure]==1.24.3   # via py2neo
 vertica-python==0.7.3
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -16,6 +16,6 @@ requests==2.21.0          # via codecov
 six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.8.6
-urllib3==1.24.1           # via requests
-virtualenv==16.4.3        # via tox
+tox==3.9.0
+urllib3==1.24.3           # via requests
+virtualenv==16.5.0        # via tox


### PR DESCRIPTION
Description: This PR upgrades the version of edx-rbac to 0.2.0

JIRA: https://openedx.atlassian.net/browse/ENT-1836