### PR TITLE
remove rbac switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.2.8] - 2019-05-17
+--------------------
+* Remove RBAC switch from DB.
+
 [1.2.7] - 2019-05-13
 --------------------
 * Replace edx_rbac.utils.get_decoded_jwt_from_request with edx_rest_framework_extensions.auth.jwt.cookies.get_decoded_jwt.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data_roles/constants.py
+++ b/enterprise_data_roles/constants.py
@@ -8,6 +8,7 @@ ENTERPRISE_DATA_ADMIN_ROLE = 'enterprise_data_admin'
 SYSTEM_ENTERPRISE_ADMIN_ROLE = 'enterprise_admin'
 SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
+# this constant should not be used anymore as it is marked for removal
 # switch is used to enable/disable role based access control
 ROLE_BASED_ACCESS_CONTROL_SWITCH = 'role_based_access_control'
 

--- a/enterprise_data_roles/migrations/0006_remove_role_based_access_control_switch.py
+++ b/enterprise_data_roles/migrations/0006_remove_role_based_access_control_switch.py
@@ -1,0 +1,30 @@
+
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+ROLE_BASED_ACCESS_CONTROL_SWITCH = 'role_based_access_control'
+
+
+def create_switch(apps, schema_editor):
+    """Create the `role_based_access_control` switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the `role_based_access_control` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ROLE_BASED_ACCESS_CONTROL_SWITCH).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise_data_roles', '0005_turn_on_role_based_access_control_switch'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_switch, create_switch),
+    ]


### PR DESCRIPTION
**Description:** This will remove the role base access control switch from db.

**JIRA:** [ENT-1885](https://openedx.atlassian.net/browse/ENT-1885)

**Problem:** [ROLE_BASED_ACCESS_CONTROL_SWITCH](https://github.com/edx/edx-enterprise-data/blob/master/enterprise_data_roles/constants.py#L12) is defined as constant and is used in all the db migrations and if we remove this than travis builds will fail because database is created from a clean state and all the migrations are applied from first to last and migrations will fail when they are unable to find the constant. So it is not possible to remove this constant without manually modifying all the migrations.  