### PR TITLE
ENT-1783: Fallback to request.auth if JWT cookies are not found.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =======
+[1.2.9] - 2019-05-28
+--------------------
+* Fallback to request.auth if JWT cookies are not found.
+
 [1.2.8] - 2019-05-17
 --------------------
 * Remove RBAC switch from DB.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data_roles/rules.py
+++ b/enterprise_data_roles/rules.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import crum
 import rules
 from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
 from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from django.urls import resolve
@@ -26,7 +27,7 @@ def request_user_has_implicit_access(*args, **kwargs):  # pylint: disable=unused
     __, __, request_kwargs = resolve(request.path)
     enterprise_id_in_request = request_kwargs.get('enterprise_id')
 
-    decoded_jwt = get_decoded_jwt(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(
         decoded_jwt,
         ENTERPRISE_DATA_ADMIN_ROLE,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,8 @@ certifi==2019.3.9         # via py2neo
 cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
@@ -27,25 +29,27 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.2.1
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0    # via edx-drf-extensions
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography
+importlib-metadata==0.15  # via pluggy
 ipaddress==1.0.22         # via cryptography
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
-neobolt==1.7.12           # via py2neo
+neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 paramiko==2.4
+pathlib2==2.3.3           # via importlib-metadata
 pbr==5.2.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.7.0
-pluggy==0.11.0            # via tox
+pluggy==0.12.0            # via tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py2neo==4.3.0
@@ -68,6 +72,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.0.1
 s3transfer==0.1.13        # via awscli, boto3
+scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
@@ -77,5 +82,6 @@ tox==3.0.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,7 +27,7 @@ configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
 diff-cover==2.0.1
-distlib==0.2.8            # via caniusepython3
+distlib==0.2.9.post0      # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2  # via edx-rbac
@@ -37,20 +37,20 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
-edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.2.1
+edx-lint==1.2.1
+edx-opaque-keys==1.0.0    # via edx-drf-extensions
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography
-importlib-metadata==0.11  # via path.py
+importlib-metadata==0.15  # via path.py, pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
-isort==4.3.19
+isort==4.3.20
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -58,9 +58,9 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-neobolt==1.7.12           # via py2neo
+neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
 path.py==11.5.2           # via edx-i18n-tools
@@ -69,7 +69,7 @@ pbr==5.2.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.11.0            # via tox
+pluggy==0.12.0            # via tox
 polib==1.1.0              # via edx-i18n-tools
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -112,14 +112,14 @@ stevedore==1.30.1         # via edx-opaque-keys
 testfixtures==6.8.2
 tox-battery==0.5.1
 tox==3.0.0
-tqdm==4.31.1              # via twine
+tqdm==4.32.1              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
-zipp==0.5.0               # via importlib-metadata
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -32,7 +32,7 @@ coverage==4.5.3           # via pytest-cov
 cryptography==1.9
 ddt==1.2.1
 diff-cover==2.0.1
-distlib==0.2.8            # via caniusepython3
+distlib==0.2.9.post0      # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
 django-model-utils==3.1.2
@@ -42,25 +42,25 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
-edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.2.1
+edx-lint==1.2.1
+edx-opaque-keys==1.0.0    # via edx-drf-extensions
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 factory-boy==2.12.0
-faker==1.0.6              # via factory-boy
+faker==1.0.7              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography
-importlib-metadata==0.11  # via path.py
+importlib-metadata==0.15  # via path.py, pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
-isort==4.3.19
+isort==4.3.20
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -70,9 +70,9 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.12           # via py2neo
+neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
 path.py==11.5.2           # via edx-i18n-tools
@@ -81,7 +81,7 @@ pbr==5.2.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.11.0            # via pytest, tox
+pluggy==0.12.0            # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -130,14 +130,14 @@ testfixtures==6.8.2
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
 tox==3.0.0
-tqdm==4.31.1              # via twine
+tqdm==4.32.1              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
-zipp==0.5.0               # via importlib-metadata
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -19,6 +19,8 @@ certifi==2019.3.9         # via py2neo
 cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==1.9
@@ -32,33 +34,34 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.2.1
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0    # via edx-drf-extensions
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.12.0
-faker==1.0.6              # via factory-boy
+faker==1.0.7              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography
+importlib-metadata==0.15  # via pluggy
 ipaddress==1.0.22         # via cryptography, faker
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.12           # via py2neo
+neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 paramiko==2.4
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.2.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.7.0
-pluggy==0.11.0            # via pytest, tox
+pluggy==0.12.0            # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py2neo==4.3.0
@@ -98,5 +101,6 @@ tox==3.0.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -6,14 +6,17 @@
 #
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via pytest-cov
 ddt==1.1.2
 funcsigs==1.0.2           # via mock, pytest
+importlib-metadata==0.15  # via pluggy
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-pathlib2==2.3.3           # via pytest
+pathlib2==2.3.3           # via importlib-metadata, pytest
 pbr==5.2.0                # via mock
-pluggy==0.11.0            # via pytest, tox
+pluggy==0.12.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pytest-cov==2.5.1
 pytest==3.7.1
@@ -21,4 +24,5 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0               # via mock, more-itertools, pathlib2, pytest, tox
 tox-battery==0.5.1
 tox==3.0.0
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,6 +19,8 @@ certifi==2019.3.9         # via py2neo
 cffi==1.12.3              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==1.9
@@ -32,33 +34,34 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-opaque-keys==0.4.4    # via edx-drf-extensions
-edx-rbac==0.2.1
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0    # via edx-drf-extensions
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.12.0
-faker==1.0.6              # via factory-boy
+faker==1.0.7              # via factory-boy
 flaky==3.5.3
 freezegun==0.3.11
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via cryptography
+importlib-metadata==0.15  # via pluggy
 ipaddress==1.0.22         # via cryptography, faker
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-neobolt==1.7.12           # via py2neo
+neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 paramiko==2.4
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.2.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.7.0
-pluggy==0.11.0            # via pytest, tox
+pluggy==0.12.0            # via pytest, tox
 prompt-toolkit==2.0.9     # via py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py2neo==4.3.0
@@ -98,5 +101,6 @@ tox==3.0.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
-virtualenv==16.5.0        # via tox
+virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,15 +7,21 @@
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
-filelock==3.0.10          # via tox
+filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-pluggy==0.11.0            # via tox
+importlib-metadata==0.15  # via pluggy
+pathlib2==2.3.3           # via importlib-metadata
+pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
-requests==2.21.0          # via codecov
-six==1.12.0               # via tox
+requests==2.22.0          # via codecov
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.9.0
-urllib3==1.24.3           # via requests
-virtualenv==16.5.0        # via tox
+tox==3.12.1
+urllib3==1.25.3           # via requests
+virtualenv==16.6.0        # via tox
+zipp==0.5.1               # via importlib-metadata


### PR DESCRIPTION
**Description:**
This PR updates the logic to get JWT data falls back to `request.auth` if JWT cookies are not present.