### PR TITLE
WL-1920 | Audit track enrollments appearing in customer's learner progress report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,12 @@ Change Log
 Unreleased
 ----------
 
-=======
+=========================
+
+[1.2.11] - 2019-06-17
+---------------------
+* filtering audit enrollment records based on Enterprise customer's enable_audit_data_reporting instead of enable_audit_enrollment
+
 [1.2.10] - 2019-06-04
 ---------------------
 * Pin edx-opaque-keys to 0.4.4 to avoid dependency conflicts downstream.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -98,22 +98,22 @@ class EnterpriseApiClient(EdxRestApiClient):
         session = request.session
         enterprise_data = None
 
-        audit_enrollment_check = enterprise_id not in session.get('enable_audit_enrollment', {})
+        audit_enrollment_check = enterprise_id not in session.get('enable_audit_data_reporting', {})
         data_sharing_consent_check = enterprise_id not in session.get('enforce_data_sharing_consent', {})
 
         if audit_enrollment_check or data_sharing_consent_check:
             enterprise_data = self.get_enterprise_customer(request.user, enterprise_id)
-            enable_audit_enrollment = False
+            enable_audit_data_reporting = False
             enforce_data_sharing_consent = False
 
             if enterprise_data:
-                enable_audit_enrollment = enterprise_data.get('enable_audit_enrollment', False)
+                enable_audit_data_reporting = enterprise_data.get('enable_audit_data_reporting', False)
                 enforce_data_sharing_consent = enterprise_data.get('enforce_data_sharing_consent', '')
 
             update_session_with_enterprise_data(
                 request,
                 enterprise_id,
-                enable_audit_enrollment=enable_audit_enrollment,
+                enable_audit_data_reporting=enable_audit_data_reporting,
                 enforce_data_sharing_consent=enforce_data_sharing_consent,
             )
 

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -73,9 +73,9 @@ class AuditEnrollmentsFilterBackend(filters.BaseFilterBackend, FiltersMixin):
 
         self.update_session_with_enterprise_data(request)
 
-        enable_audit_enrollment = request.session['enable_audit_enrollment'].get(enterprise_id, False)
+        enable_audit_data_reporting = request.session['enable_audit_data_reporting'].get(enterprise_id, False)
 
-        if not enable_audit_enrollment:
+        if not enable_audit_data_reporting:
             # Filter out enrollments that have audit mode and do not have a coupon code or an offer.
             filter_query = {
                 view.ENROLLMENT_MODE_FILTER: 'audit',

--- a/enterprise_data/tests/test_filters.py
+++ b/enterprise_data/tests/test_filters.py
@@ -37,7 +37,7 @@ class TestConsentGrantedFilterBackend(JWTTestMixin, APITestCase):
         with mock.patch(mock_path) as mock_enterprise_api_client:
             mock_enterprise_api_client.return_value = {
                 'uuid': self.enterprise_id,
-                'enable_audit_enrollment': True,
+                'enable_audit_data_reporting': True,
                 'enforce_data_sharing_consent': enforce_dsc or True,
             }
             return self.client.get(self.url)

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -100,7 +100,7 @@ def get_dummy_enterprise_api_data(**kwargs):
         'enforce_data_sharing_consent': kwargs.get('enforce_data_sharing_consent', 'at_enrollment'),
         'branding_configuration': {},
         'identity_provider': 'saml-ubc',
-        'enable_audit_enrollment': kwargs.get('enable_audit_enrollment', False),
+        'enable_audit_data_reporting': kwargs.get('enable_audit_data_reporting', False),
         'replace_sensitive_sso_username': False
     }
     return enterprise_api_dummy_data

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -261,7 +261,7 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
     )
     @ddt.unpack
     def test_get_queryset_returns_enrollments_with_audit_enrollment_filter(
-            self, enable_audit_enrollment, coupon_code, offer, total_enrollments,
+            self, enable_audit_data_reporting, coupon_code, offer, total_enrollments,
             user_current_enrollment_mode, enrollments_count
     ):
         enterprise_user = EnterpriseUserFactory()
@@ -270,7 +270,7 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
 
         self.mocked_get_enterprise_customer.return_value = get_dummy_enterprise_api_data(
             enterprise_id=enterprise_id,
-            enable_audit_enrollment=enable_audit_enrollment,
+            enable_audit_data_reporting=enable_audit_data_reporting,
         )
 
         for index in range(total_enrollments):
@@ -506,7 +506,7 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
     def test_no_page_querystring_skips_pagination(self):
         self.mocked_get_enterprise_customer.return_value = {
             'uuid': self.enterprise_id,
-            'enable_audit_enrollment': True,
+            'enable_audit_data_reporting': True,
             'enforce_data_sharing_consent': True,
         }
         url = reverse('v0:enterprise-enrollments-list',
@@ -585,7 +585,7 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
         """
         self.mocked_get_enterprise_customer.return_value = {
             'uuid': self.enterprise_id,
-            'enable_audit_enrollment': True,
+            'enable_audit_data_reporting': True,
             'enforce_data_sharing_consent': True,
         }
 
@@ -617,7 +617,7 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
         """
         self.mocked_get_enterprise_customer.return_value = {
             'uuid': self.enterprise_id,
-            'enable_audit_enrollment': True,
+            'enable_audit_data_reporting': True,
             'enforce_data_sharing_consent': True,
         }
 

--- a/enterprise_data/utils.py
+++ b/enterprise_data/utils.py
@@ -18,7 +18,7 @@ def update_session_with_enterprise_data(request, enterprise_id, **kwargs):
     The values will be set in session in the following format:
     {
         'enterprises_with_access': {'ee5e6b3a-069a-4947-bb8d-d2dbc323396c': True},
-        'enable_audit_enrollment': {'ee5e6b3a-069a-4947-bb8d-d2dbc323396c': False}
+        'enable_audit_data_reporting': {'ee5e6b3a-069a-4947-bb8d-d2dbc323396c': False}
     }
 
     Arguments:


### PR DESCRIPTION
filtering audit enrollment records based on Enterprise customer's
`enable_audit_data_reporting` instead of `enable_audit_enrollment`