### PR TITLE
use edx-drf-extensions jwt utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[1.3.0] - 2019-07-15
+---------------------
+* Replce edx-rbac jwt utils with edx-drf-extensions jwt utils
+
 [1.2.13] - 2019-07-10
 ---------------------
 * Add logging to monitor enterprise data api.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.13"
+__version__ = "1.3.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data_roles/rules.py
+++ b/enterprise_data_roles/rules.py
@@ -5,11 +5,9 @@ from __future__ import absolute_import, unicode_literals
 
 import crum
 import rules
-from edx_rbac.utils import (
-    get_decoded_jwt_from_request,
-    request_user_has_implicit_access_via_jwt,
-    user_has_access_via_database,
-)
+from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from django.urls import resolve
 
@@ -29,7 +27,7 @@ def request_user_has_implicit_access(*args, **kwargs):  # pylint: disable=unused
     __, __, request_kwargs = resolve(request.path)
     enterprise_id_in_request = request_kwargs.get('enterprise_id')
 
-    decoded_jwt = get_decoded_jwt_from_request(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(
         decoded_jwt,
         ENTERPRISE_DATA_ADMIN_ROLE,

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -20,5 +20,5 @@ six==1.10.0
 PGPy                                    # Required for Enterprise Reporting
 pyOpenSSL==17.4.0 # Any version beyond this requires cryptography 2.X.X
 py2neo
-edx-rbac==0.2.1                         # pinning until ENT-2002 is resolved
+edx-rbac
 rules

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
 awscli==1.11.178
-bcrypt==3.1.6             # via paramiko
+bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
@@ -22,16 +22,16 @@ contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
-django-model-utils==3.1.2  # via edx-rbac
-django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via edx-rbac
+django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
-edx-django-utils==1.0.5
-edx-drf-extensions==2.3.1
+edx-django-utils==2.0.0
+edx-drf-extensions==2.3.3
 edx-opaque-keys==1.0.1
-edx-rbac==0.2.1
+edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
@@ -43,10 +43,10 @@ jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 paramiko==2.4
-pathlib2==2.3.3           # via importlib-metadata
-pbr==5.3.0                # via stevedore
+pathlib2==2.3.4           # via importlib-metadata
+pbr==5.4.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.8.0
 pluggy==0.12.0            # via tox
@@ -84,4 +84,4 @@ urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
 virtualenv==16.6.1        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 awscli==1.11.178
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
-bcrypt==3.1.6             # via paramiko
+bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 bleach==3.1.0             # via readme-renderer
 boto3==1.4.7
@@ -26,22 +26,22 @@ colorama==0.3.7           # via awscli, py2neo
 configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cryptography==1.9
-diff-cover==2.2.0
+diff-cover==2.3.0
 distlib==0.2.9.post0      # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
-django-model-utils==3.1.2  # via edx-rbac
-django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via edx-rbac
+django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
-edx-django-utils==1.0.5
-edx-drf-extensions==2.3.1
+edx-django-utils==2.0.0
+edx-drf-extensions==2.3.3
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1
-edx-rbac==0.2.1
+edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 future==0.17.1            # via pyjwkest, vertica-python
@@ -50,7 +50,7 @@ idna==2.8                 # via cryptography
 importlib-metadata==0.18  # via path.py, pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
-isort==4.3.20
+isort==4.3.21
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -60,12 +60,12 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 paramiko==2.4
 path.py==11.5.2           # via edx-i18n-tools
-pathlib2==2.3.3           # via importlib-metadata
-pbr==5.3.0                # via stevedore
+pathlib2==2.3.4           # via importlib-metadata
+pbr==5.4.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.8.0
 pkginfo==1.5.0.1          # via twine
@@ -107,12 +107,12 @@ semantic-version==2.6.0   # via edx-drf-extensions
 singledispatch==3.4.0.3   # via astroid, pgpy, pylint
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.2.1    # via pydocstyle
+snowballstemmer==1.9.0    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.9.0
+testfixtures==6.10.0
 tox-battery==0.5.1
 tox==3.0.0
-tqdm==4.32.1              # via twine
+tqdm==4.32.2              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
@@ -122,4 +122,7 @@ wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.33.4
 wrapt==1.11.2             # via astroid
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via caniusepython3, twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -13,7 +13,7 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 awscli==1.11.178
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
-bcrypt==3.1.6             # via paramiko
+bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 bleach==3.1.0             # via readme-renderer
 boto3==1.4.7
@@ -31,27 +31,27 @@ cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==1.9
 ddt==1.2.1
-diff-cover==2.2.0
+diff-cover==2.3.0
 distlib==0.2.9.post0      # via caniusepython3
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
-django-model-utils==3.1.2
-django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0
+django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore, readme-renderer
-edx-django-utils==1.0.5
-edx-drf-extensions==2.3.1
+edx-django-utils==2.0.0
+edx-drf-extensions==2.3.3
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1
-edx-rbac==0.2.1
+edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography, pgpy
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
-flaky==3.5.3
+flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
@@ -60,7 +60,7 @@ idna==2.8                 # via cryptography
 importlib-metadata==0.18  # via path.py, pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
-isort==4.3.20
+isort==4.3.21
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore
@@ -72,12 +72,12 @@ mock==3.0.5
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 packaging==19.0           # via caniusepython3, pytest
 paramiko==2.4
 path.py==11.5.2           # via edx-i18n-tools
-pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.3.0                # via stevedore
+pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
+pbr==5.4.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.8.0
 pkginfo==1.5.0.1          # via twine
@@ -106,8 +106,8 @@ pyopenssl==17.4.0
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.4             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-i18n-tools
@@ -124,13 +124,13 @@ semantic-version==2.6.0   # via edx-drf-extensions
 singledispatch==3.4.0.3   # via astroid, pgpy, pylint
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.2.1    # via pydocstyle
+snowballstemmer==1.9.0    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.9.0
+testfixtures==6.10.0
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
 tox==3.0.0
-tqdm==4.32.1              # via twine
+tqdm==4.32.2              # via twine
 twine==1.13.0
 unicodecsv==0.14.1
 urllib3==1.24.3           # via py2neo
@@ -140,4 +140,7 @@ wcwidth==0.1.7            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 wheel==0.33.4
 wrapt==1.11.2             # via astroid
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via caniusepython3, twine

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -10,7 +10,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 awscli==1.11.178
-bcrypt==3.1.6             # via paramiko
+bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
@@ -27,21 +27,21 @@ cryptography==1.9
 ddt==1.2.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
-django-model-utils==3.1.2
-django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0
+django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore
-edx-django-utils==1.0.5
-edx-drf-extensions==2.3.1
+edx-django-utils==2.0.0
+edx-drf-extensions==2.3.3
 edx-opaque-keys==1.0.1
-edx-rbac==0.2.1
+edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
-flaky==3.5.3
+flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
@@ -55,11 +55,11 @@ mock==3.0.5
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 packaging==19.0           # via pytest
 paramiko==2.4
-pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.3.0                # via stevedore
+pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
+pbr==5.4.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.8.0
 pluggy==0.12.0            # via pytest, tox
@@ -80,8 +80,8 @@ pyopenssl==17.4.0
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.4             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
@@ -97,7 +97,7 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.9.0
+testfixtures==6.10.0
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1
@@ -105,4 +105,4 @@ urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
 virtualenv==16.6.1        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -14,8 +14,8 @@ funcsigs==1.0.2           # via mock, pytest
 importlib-metadata==0.18  # via pluggy
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-pathlib2==2.3.3           # via importlib-metadata, pytest
-pbr==5.3.0                # via mock
+pathlib2==2.3.4           # via importlib-metadata, pytest
+pbr==5.4.0                # via mock
 pluggy==0.12.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pytest-cov==2.5.1
@@ -25,4 +25,7 @@ six==1.12.0               # via mock, more-itertools, pathlib2, pytest, tox
 tox-battery==0.5.1
 tox==3.0.0
 virtualenv==16.6.1        # via tox
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 awscli==1.11.178
-bcrypt==3.1.6             # via paramiko
+bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 boto3==1.4.7
 botocore==1.7.36          # via awscli, boto3, s3transfer
@@ -27,21 +27,21 @@ cryptography==1.9
 ddt==1.2.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5
-django-model-utils==3.1.2
-django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0
+django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.15
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 docutils==0.14            # via awscli, botocore
-edx-django-utils==1.0.5
-edx-drf-extensions==2.3.1
+edx-django-utils==2.0.0
+edx-drf-extensions==2.3.3
 edx-opaque-keys==1.0.1
-edx-rbac==0.2.1
+edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography, pgpy
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
-flaky==3.5.3
+flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest, vertica-python
@@ -55,11 +55,11 @@ mock==3.0.5
 more-itertools==5.0.0     # via pytest
 neobolt==1.7.13           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 packaging==19.0           # via pytest
 paramiko==2.4
-pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.3.0                # via stevedore
+pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
+pbr==5.4.0                # via stevedore
 pgpy==0.4.3
 pip-tools==3.8.0
 pluggy==0.12.0            # via pytest, tox
@@ -80,8 +80,8 @@ pyopenssl==17.4.0
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.4             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.1              # via celery, django, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli
@@ -97,7 +97,7 @@ singledispatch==3.4.0.3   # via pgpy
 six==1.10.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via edx-opaque-keys
-testfixtures==6.9.0
+testfixtures==6.10.0
 text-unidecode==1.2       # via faker
 tox==3.0.0
 unicodecsv==0.14.1
@@ -105,4 +105,4 @@ urllib3==1.24.3           # via py2neo
 vertica-python==0.7.3
 virtualenv==16.6.1        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,16 +12,18 @@ contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.18  # via pluggy
-pathlib2==2.3.3           # via importlib-metadata
+importlib-metadata==0.18  # via pluggy, tox
+packaging==19.0           # via tox
+pathlib2==2.3.4           # via importlib-metadata
 pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
+pyparsing==2.4.0          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via pathlib2, tox
+six==1.12.0               # via packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
+tox==3.13.2
 urllib3==1.25.3           # via requests
 virtualenv==16.6.1        # via tox
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata


### PR DESCRIPTION
**Description:** This upgrades the edx-rbac to latest version and as a result of this upgrade we are using jwt utils from edx-drf-extensions package because those jwt utils are now removed from edx-rbac.
 
**JIRA:** [ENT-2002](https://openedx.atlassian.net/browse/ENT-2002)