### PR TITLE
Make zipfile password protected with only encrypted_password

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[1.3.1] - 2019-08-06
+---------------------
+* Make zipfile password protected with encrypted_password in enterprise reporting.
+
 [1.3.0] - 2019-07-15
 ---------------------
 * Replce edx-rbac jwt utils with edx-drf-extensions jwt utils

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/delivery_method.py
+++ b/enterprise_reporting/delivery_method.py
@@ -27,12 +27,13 @@ class DeliveryMethod(object):
         self.data_type = reporting_config['data_type']
         self.report_type = reporting_config['report_type']
         self.password = password
+        self.encrypted_password = reporting_config['encrypted_password']
         self.pgp_encryption_key = reporting_config.get('pgp_encryption_key')
 
     def send(self, files):
         """Base method for sending files, to perform common sending logic."""
         LOGGER.info('Encrypting data report for {}'.format(self.enterprise_customer_name))
-        return compress_and_encrypt(files, self.password, self.pgp_encryption_key)
+        return compress_and_encrypt(files, self.encrypted_password, self.pgp_encryption_key)
 
 
 class SMTPDeliveryMethod(DeliveryMethod):
@@ -51,7 +52,7 @@ class SMTPDeliveryMethod(DeliveryMethod):
 
     def __init__(self, reporting_config, password):
         """Initialize the SMTP Delivery Method."""
-        super().__init__(reporting_config, password)
+        super(SMTPDeliveryMethod, self).__init__(reporting_config, password)
         self._email = reporting_config['email']
 
     @property
@@ -94,7 +95,7 @@ class SFTPDeliveryMethod(DeliveryMethod):
 
     def __init__(self, reporting_config, password):
         """Initialize the SFTP Delivery Method."""
-        super().__init__(reporting_config, password)
+        super(SFTPDeliveryMethod, self).__init__(reporting_config, password)
         self.hostname = reporting_config['sftp_hostname']
         self.port = reporting_config['sftp_port']
         self.username = reporting_config['sftp_username']

--- a/enterprise_reporting/tests/utils.py
+++ b/enterprise_reporting/tests/utils.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import os
+import tempfile
+from zipfile import ZipFile
+
+
+def create_files(files_data):
+    """
+    Creates files based on provided file data.
+    """
+    files = []
+    total_size = 0
+    for file_data in files_data:
+        tf = tempfile.NamedTemporaryFile(suffix='.txt')
+        tf.write(file_data['size'] * b'i')
+        tf.flush()
+        tf.seek(0)
+
+        files.append({
+            'file': tf,
+            'size': file_data['size'],
+        })
+        total_size += file_data['size']
+
+    return files, total_size
+
+def verify_compressed(self, zip_file, files, original_file_size, password):
+    """
+    Verify that file is compress correctly.
+    """
+    # Verify file is compressed.
+    zip_file_size = os.path.getsize(zip_file)
+    assert zip_file_size < original_file_size
+
+    zipfile = ZipFile(zip_file, 'r')
+
+    for file in files:
+        # Verify text file is present in zip file.
+        assert file['file'].name.split('/')[-1] in zipfile.namelist()
+
+        # Verify file content is readable with correct password.
+        content = zipfile.read(file['file'].name.split('/')[-1], password)
+        assert len(content) == file['size']
+
+        # Also verify file is not accessible with any other passwords i.e wrong passwords.
+        with self.assertRaises(RuntimeError):
+            zipfile.read(file['file'].name.split('/')[-1], b'wrong-password')


### PR DESCRIPTION
This PR fixes `sftp_password` being applied to zipfile while compression when `delivery_method` id `sftp`. Now `encrypted_password` will be used to secure the zip file.

[ENT-2114](https://openedx.atlassian.net/browse/ENT-2114)