### PR TITLE
ENT-2210: Changes to set value of `unenrollment_end_within_date` to `True`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[1.3.3] - 2019-08-22
+---------------------
+* Fixed issue where same day un-enrollment is shown as `FALSE` in `unenrollment_end_within_date` column of learner report.
+
 [1.3.2] - 2019-08-09
 ---------------------
 * Do not apply encrypted version of password on zipfile in enterprise reporting.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -31,8 +31,8 @@ class EnterpriseEnrollmentSerializer(serializers.ModelSerializer):
         if obj.unenrollment_timestamp:
             unenrollment_within_date = (
                 not obj.course_start or
-                0 < (obj.unenrollment_timestamp - obj.course_start).days <= 14 or
-                0 < (obj.unenrollment_timestamp - obj.enrollment_created_timestamp).days <= 14
+                (obj.unenrollment_timestamp - obj.course_start).days <= 14 or
+                (obj.unenrollment_timestamp - obj.enrollment_created_timestamp).days <= 14
             )
 
         return unenrollment_within_date


### PR DESCRIPTION
This PR has changes to set value of `unenrollment_end_within_date` to `True` if un-enrollment was done on the same day of course start date or on the same day of course enrollment date.