### PR TITLE
decrypt zip password if present

### DIFF
--- a/enterprise_reporting/delivery_method.py
+++ b/enterprise_reporting/delivery_method.py
@@ -33,7 +33,8 @@ class DeliveryMethod(object):
     def send(self, files):
         """Base method for sending files, to perform common sending logic."""
         LOGGER.info('Encrypting data report for {}'.format(self.enterprise_customer_name))
-        return compress_and_encrypt(files, decrypt_string(self.encrypted_password), self.pgp_encryption_key)
+        zip_password = decrypt_string(self.encrypted_password) if self.encrypted_password else self.encrypted_password
+        return compress_and_encrypt(files, zip_password, self.pgp_encryption_key)
 
 
 class SMTPDeliveryMethod(DeliveryMethod):


### PR DESCRIPTION
**Description:** We were decrypting the zip password without checking if password really present in the reporting config, decrypting a `None` password gives `TypeError: encoding without a string argument`. Check if password exists and then decrypt it.

**JIRA:** [ENT-2248](https://openedx.atlassian.net/browse/ENT-2248)