### PR TITLE
ENT-2033: Added ability to include/exclude date from report configuration file name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 
 =========================
 
+[1.3.11] - 2019-12-27
+---------------------
+* Added the ability to include or exclude date from reporting configuration file name.
+
 [1.3.10] - 2019-12-11
 ---------------------
 * Added the correct condition for logging the warning in enterprise-enrollments endpoint.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -96,11 +96,12 @@ class EnterpriseReportSender(object):
     @property
     def data_report_file_name(self):
         """Get the full path to the report file."""
-        return "{dir}/{enterprise_id}_{data}_{ext}_{date}.{ext}".format(
+        date_str = "_{}".format(NOW) if self.reporting_config.get('include_date') else ""
+        return "{dir}/{enterprise_id}_{data}_{ext}{date_str}.{ext}".format(
             dir=self.FILE_WRITE_DIRECTORY,
             enterprise_id=self.enterprise_customer_uuid,
             data=self.data_type,
-            date=NOW,
+            date_str=date_str,
             ext=self.report_type,
         )
 

--- a/enterprise_reporting/tests/test_reporter.py
+++ b/enterprise_reporting/tests/test_reporter.py
@@ -2,11 +2,62 @@
 """
 Test reporter.
 """
-
 import unittest
+import datetime
+import pytest
+import six
+import ddt
 
 from enterprise_reporting import reporter
+from enterprise_reporting.reporter import EnterpriseReportSender
+from enterprise_reporting.utils import encrypt_string
 
 
+@pytest.mark.skipif(six.PY2, reason="Not compatible with Python 2")
+@ddt.ddt
 class TestReporter(unittest.TestCase):
-	pass
+	""""
+	Tests about reporter methods
+	"""
+	def setUp(self):
+		self.FILE_WRITE_DIRECTORY = '/tmp'
+		self.date = datetime.datetime.now().strftime("%Y-%m-%d")
+		self.reporting_config = {
+			'enterprise_customer': {
+				'uuid': '4815162242', 'name': 'John'
+			},
+			'delivery_method': 'sftp',
+			'data_type': 'catalog',
+			'uuid': '987654321',
+			'sftp_hostname': '127.0.0.1',
+			'active': True,
+			'report_type': 'json',
+			'encrypted_password': 'bleeH-bLah-blUe001',
+			'sftp_username': 'John1',
+			'sftp_port': 22,
+			'sftp_file_path': 'home/user/Documents',
+			'encrypted_sftp_password': 'abraAcaDabradOo',
+		}
+		sftp_password = self.reporting_config['encrypted_sftp_password']
+		self.reporting_config['encrypted_sftp_password'] = encrypt_string(sftp_password)
+
+	@ddt.data(
+		True,
+		False
+	)
+	def test_data_report_file_name(self, flag_value):
+		"""
+		Tests if the report config file name is generated correctly when date is included
+		"""
+		self.reporting_config['include_date'] = flag_value
+		enterprise_report_sender = EnterpriseReportSender.create(self.reporting_config)
+		actual_file_name = enterprise_report_sender.data_report_file_name
+		date_str = "_{}".format(self.date) if self.reporting_config.get('include_date') else ""
+		expected_file_name = "{dir}/{enterprise_uuid}_{data_type}_{report_type}{date}.{report_type}".format(
+			dir=self.FILE_WRITE_DIRECTORY,
+			enterprise_uuid=self.reporting_config['enterprise_customer']['uuid'],
+			data_type=self.reporting_config['data_type'],
+			date=date_str,
+			report_type=self.reporting_config['report_type']
+		)
+		assert actual_file_name == expected_file_name

--- a/enterprise_reporting/tests/test_utils.py
+++ b/enterprise_reporting/tests/test_utils.py
@@ -8,8 +8,6 @@ import os
 import tempfile
 import unittest
 from collections import OrderedDict
-from zipfile import ZipFile
-
 import ddt
 import pgpy
 from pgpy.constants import CompressionAlgorithm, HashAlgorithm, KeyFlags, PubKeyAlgorithm, SymmetricKeyAlgorithm
@@ -245,6 +243,21 @@ class TestCompressEncrypt(unittest.TestCase):
 
         with self.assertRaises(PGPError):
             wrong_key.decrypt(message)
+
+    @ddt.data(
+        '_catalog_json_2019-09-30.json',
+        '_catalog_json.json'
+    )
+    def test_compression_file_name(self, file_suffix):
+        """
+        Tests that files are compressed with the correct file name, even when date is included or excluded
+        """
+        tf = tempfile.NamedTemporaryFile(suffix=file_suffix)
+        tf.write(b'randomtext54321')
+        actual_file_name = utils._get_compressed_file([tf])
+        expected_file_name = tf.name.split('.json', 1)[0] + '.zip'
+        assert actual_file_name == expected_file_name
+
 
 class TestPrepareAttachments(unittest.TestCase):
 

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -65,8 +65,8 @@ def _get_compressed_file(files, password=None):
     Given file(s) and a password, create a zip file. Return the new filename.
     """
     multiple_files = len(files) > 1
-    # Replace the data and report type with just `.zip`.
-    zipfile = re.sub(r'(_(\w+))?\.(\w+)$', '.zip', files[0].name)
+    # Replace the file extension with `.zip`
+    zipfile = re.sub(r'\.(\w+)$', '.zip', files[0].name)
     compression = pyminizip.compress_multiple if multiple_files else pyminizip.compress
     src_file_path_prefix = [] if multiple_files else None
     compression(


### PR DESCRIPTION
Added "Include Date" field in Enterprise Customer Report Configuration Admin Form as mentioned in  ENT-2033. 

Steps to check it:
1. Go to LMS and add Enterprise Customer
2. Go to Enterprise Customer -> Enterprise customer reporting configurations
2. Add Enterprise Customer Reporting Configuration
3. You can see that the form now shows the "Include Date" field. 

Test Cases: test_reporter.py, test_utils.py::TestCompressEncrypt