### PR TITLE
ENT-2444 | Changing coursegraph query to better capture urls

### DIFF
--- a/enterprise_reporting/tests/test_external_link_report.py
+++ b/enterprise_reporting/tests/test_external_link_report.py
@@ -8,11 +8,10 @@ import unittest
 
 from enterprise_reporting.external_resource_link_report import (
     AGGREGATE_REPORT_CSV_HEADER_ROW,
-    EXHAUSTIVE_REPORT_CSV_HEADER_ROW,
     create_csv_string,
     create_columns_for_aggregate_report,
-    create_columns_for_exhaustive_report,
     process_coursegraph_results,
+    split_up_results,
 )
 
 
@@ -62,11 +61,16 @@ class TestUtilsCoursegraph(unittest.TestCase):
              'organization': 'edx2',
              'h.course_key': 'course-v1:I+am+a+test4',
              'h.data': 'I have no urls'},
+            {'course_title': 'course4',
+             'organization': 'edx2',
+             'h.course_key': 'course-v1:I+am+a+test4+with+bad+url',
+             'h.data': '<p>code choking on https://[Web App Name].scm.azureWeb Apps.net</p>'},
 
             {'course_title': 'oldcourse',
              'organization': 'oldx2',
              'h.course_key': 'oldx2course:I+am+a+test+for+old+coursekeys',
              'h.data': '<span href="http://www.google3.com">my site</span>'},
+
         ]
 
     def test_process_coursegraph_results(self):
@@ -109,6 +113,38 @@ class TestUtilsCoursegraph(unittest.TestCase):
         }
         assert process_coursegraph_results(self.raw_data) == expected
 
+    def test_split_up_results(self):
+        """
+        split_up_results should take a dictionary of process results and split
+        it into a list of smaller dictionaries.
+        """
+        processed_results = OrderedDict([
+            ('course-v1:I+am+a+test1', {
+                'course_title': 'course1',
+                'organization': 'edx',
+                'domain_count': OrderedDict([
+                    ('http://www.google.com', 2),
+                    ('http://www.facebook.com', 1),
+                ]),
+            }),
+            ('course-v1:I+am+a+test2', {
+                'course_title': 'course2',
+                'organization': 'edx',
+                'domain_count': {'http://www.google2.com': 4},
+            }),
+            ('course-v1:I+am+a+test3', {
+                'course_title': 'course3',
+                'organization': 'edx2',
+                'domain_count': {'http://www.google3.com': 1},
+            }),
+        ])
+
+        results_list = split_up_results(processed_results)
+
+        assert len(results_list) == 2
+        assert len(results_list[0]) == 1
+        assert len(results_list[1]) == 2
+
     def test_create_aggregate_report_csv_string(self):
         """
         generate_aggregate_report_csv_string should create the expected csv
@@ -146,49 +182,5 @@ class TestUtilsCoursegraph(unittest.TestCase):
             processed_results,
             AGGREGATE_REPORT_CSV_HEADER_ROW,
             create_columns_for_aggregate_report,
-        )
-        assert actual == expected
-
-    def test_generate_exhaustive_report_csv_string(self):
-        """
-        generate_exhaustive_report_csv_string should create the expected csv
-        string given some processed results
-        """
-        processed_results = OrderedDict([
-            ('course-v1:I+am+a+test1', {
-                'course_title': 'course1',
-                'organization': 'edx',
-                'external_links': [
-                    'http://www.google.com',
-                    'http://www.facebook.com/'
-                ],
-            }),
-            ('course-v1:I+am+a+test2', {
-                'course_title': 'course2',
-                'organization': 'edx',
-                'external_links': [
-                    'http://www.google2.com/',
-                    'http://www.google2.com',
-                    'http://www.google2.com/someextension/',
-                ],
-            }),
-            ('course-v1:I+am+a+test3', {
-                'course_title': 'course3',
-                'organization': 'edx2',
-                'external_links': ['http://www.google3.com'],
-            }),
-        ])
-        expected =(
-            u'Course Key,Course Title,Partner,External Links\n'
-            u'course-v1:I+am+a+test1,"course1",edx,http://www.google.com\n'
-            u',,,http://www.facebook.com/\n'
-            u'course-v1:I+am+a+test2,"course2",edx,http://www.google2.com/\n'
-            u',,,http://www.google2.com\n,,,http://www.google2.com/someextension/\n'
-            u'course-v1:I+am+a+test3,"course3",edx2,http://www.google3.com\n'
-        )
-        actual = create_csv_string(
-            processed_results,
-            EXHAUSTIVE_REPORT_CSV_HEADER_ROW,
-            create_columns_for_exhaustive_report,
         )
         assert actual == expected


### PR DESCRIPTION
The updating of the query to more thoroughly match the strings we're looking for (http:// or https://) has made the resulting CSVs so large that they were unable to be emailed. As a result I have added logic to split the aggregate report into 2 parts and email both in turn, but am opting to remove the exhaustive report altogether (way too large).

