### PR TITLE
[BD] Upgrade vertica-python

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 -c constraints.txt
 
-vertica-python==0.7.3                   # Required for Enterprise Reporting
+vertica-python                          # Required for Enterprise Reporting
 pyminizip                               # Required for Enterprise Reporting
 celery==3.1.18                          # Run task workers in other locations
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
 enum34==1.1.9             # via cryptography, pgpy
-future==0.18.2            # via pyjwkest, vertica-python
+future==0.18.2            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -r requirements/base.in, s3transfer
 idna==2.8                 # via requests
 ipaddress==1.0.23         # via cryptography
@@ -58,7 +58,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0         # via -r requirements/base.in
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.22.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -72,5 +72,5 @@ slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.32.0         # via edx-opaque-keys
 unicodecsv==0.14.1        # via -r requirements/base.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.7.3     # via -r requirements/base.in
+vertica-python==0.10.2    # via -r requirements/base.in
 wcwidth==0.1.8            # via prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,7 +47,7 @@ edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
 enum34==1.1.9             # via astroid, cryptography, pgpy
 filelock==3.0.12          # via tox, virtualenv
-future==0.18.2            # via backports.os, pyjwkest, vertica-python
+future==0.18.2            # via backports.os, pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -r requirements/base.in, -r requirements/quality.in, caniusepython3, isort, s3transfer
 idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, inflect, path.py, pluggy, tox, virtualenv
@@ -97,7 +97,7 @@ pynacl==1.3.0             # via paramiko
 pyopenssl==17.4.0         # via -r requirements/base.in
 pyparsing==2.4.6          # via packaging
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
@@ -122,7 +122,7 @@ twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typing==3.7.4.1           # via importlib-resources
 unicodecsv==0.14.1        # via -r requirements/base.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.7.3     # via -r requirements/base.in
+vertica-python==0.10.2    # via -r requirements/base.in
 virtualenv==20.0.7        # via tox
 wcwidth==0.1.8            # via prompt-toolkit
 webencodings==0.5.1       # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -57,7 +57,7 @@ filelock==3.0.12          # via tox, virtualenv
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
 funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via backports.os, pyjwkest, vertica-python
+future==0.18.2            # via backports.os, pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -r requirements/base.in, -r requirements/quality.in, caniusepython3, isort, s3transfer
 idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, inflect, path.py, pluggy, pytest, tox, virtualenv
@@ -112,7 +112,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
 pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
@@ -139,7 +139,7 @@ twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typing==3.7.4.1           # via importlib-resources
 unicodecsv==0.14.1        # via -r requirements/base.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.7.3     # via -r requirements/base.in
+vertica-python==0.10.2    # via -r requirements/base.in
 virtualenv==20.0.7        # via tox
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -44,7 +44,7 @@ faker==3.0.1              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
 funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via pyjwkest, vertica-python
+future==0.18.2            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -r requirements/base.in, s3transfer
 idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pytest
@@ -81,7 +81,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
 pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.22.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
 responses==0.10.12        # via -r requirements/test.in
@@ -99,6 +99,6 @@ testfixtures==6.14.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/base.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.7.3     # via -r requirements/base.in
+vertica-python==0.10.2    # via -r requirements/base.in
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,7 +44,7 @@ faker==3.0.1              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
 funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via pyjwkest, vertica-python
+future==0.18.2            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -r requirements/base.in, s3transfer
 idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pytest
@@ -81,7 +81,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
 pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo, vertica-python
+pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.22.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
 responses==0.10.12        # via -r requirements/test.in
@@ -99,6 +99,6 @@ testfixtures==6.14.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/base.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.7.3     # via -r requirements/base.in
+vertica-python==0.10.2    # via -r requirements/base.in
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 zipp==1.2.0               # via importlib-metadata


### PR DESCRIPTION
See https://openedx.atlassian.net/projects/BOM/issues/BOM-1359.

Upgrade vertica-python. https://github.com/vertica/vertica-python/releases

### Constraints changed
Remove version constraint in vertica-python
remove vertica-python constrain
### Reviewers
- [ ] @andrey-canon
- [x] Is this ready for edX's review?
- [ ] @jmbowman 
### Post Review

Create a new release.