### PR TITLE
[BD] Fix RemovedInDjango20Warning: Specifying a namespace in django.conf.u…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ----------
+* Fix compatibility warnings with Django2.0. Remove support for Django<1.9
 
 =========================
 

--- a/enterprise_data/api/v0/urls.py
+++ b/enterprise_data/api/v0/urls.py
@@ -8,6 +8,8 @@ from rest_framework.routers import DefaultRouter
 
 from enterprise_data.api.v0 import views
 
+app_name = 'enterprise_data_api_v0'  # pylint: disable=invalid-name
+
 router = DefaultRouter()  # pylint: disable=invalid-name
 router.register(
     r'enterprise/(?P<enterprise_id>.+)/enrollments',

--- a/enterprise_data/settings/test.py
+++ b/enterprise_data/settings/test.py
@@ -57,15 +57,13 @@ INSTALLED_APPS = (
     "rules.apps.AutodiscoverRulesConfig",
 )
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "crum.CurrentRequestUserMiddleware",
     "waffle.middleware.WaffleMiddleware",
 ]
-
-MIDDLEWARE = MIDDLEWARE_CLASSES  # Django 1.10 compatibility - the setting was renamed
 
 AUTHENTICATION_BACKENDS = [
     "rules.permissions.ObjectPermissionBackend",

--- a/enterprise_data/urls.py
+++ b/enterprise_data/urls.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import include, url
 from django.contrib import admin
 
+app_name = 'enterprise_data'  # pylint: disable=invalid-name
 urlpatterns = [
     url(
         r'^enterprise/api/',


### PR DESCRIPTION
…rls.include() without providing an app_name is deprecated.

Related to https://openedx.atlassian.net/browse/BOM-1359

## Description
This removes that RemovedInDjango20Warning related warning

 https://docs.djangoproject.com/en/dev/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include

Also was removed MIDDLEWARE_CLASSES from django tests settings

## Reviewers 
- [ ] @andrey-canon
- [x] Ready for edX review
- [ ] @jmbowman 