### PR TITLE
[BD] Solve problem with django version in reporting tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - 2.7
   - 3.6
 env:
-  - TOXENV=data
-  - TOXENV=reporting
+  - TOXENV=django111-data
+  - TOXENV=django111-reporting
 matrix:
   include:
   - python: 3.6

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/test-master.txt requirements/base.in requirements/reporting.in requirements/test-master.in \
 	                                                      requirements/test.in
 	# Let tox control the Django version for tests
+	grep -e "^django==" requirements/base.txt > requirements/django.txt
 	sed '/^[dD]jango==/d' requirements/test-master.txt > requirements/test-master.tmp
 	mv requirements/test-master.tmp requirements/test-master.txt
 	sed '/^[dD]jango==/d' requirements/test-reporting.txt > requirements/test-reporting.tmp

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/test-reporting.txt requirements/test-reporting.in
 	pip-compile --upgrade -o requirements/test-master.txt requirements/base.in requirements/reporting.in requirements/test-master.in \
 	                                                      requirements/test.in
+	# Let tox control the Django version for tests
+	sed '/^[dD]jango==/d' requirements/test-master.txt > requirements/test-master.tmp
+	mv requirements/test-master.tmp requirements/test-master.txt
+	sed '/^[dD]jango==/d' requirements/test-reporting.txt > requirements/test-reporting.tmp
+	mv requirements/test-reporting.tmp requirements/test-reporting.txt
+
 
 requirements: ## install development environment requirements
 	pip install -qr requirements/base.txt --exists-action w

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ djangorestframework==3.9.4  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pyli
 backports.os==0.1.1       # via path.py
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.1             # via readme-renderer
+bleach==3.1.3             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 caniusepython3==7.2.0     # via -r requirements/quality.in
@@ -39,7 +39,7 @@ djangorestframework==3.9.4  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
@@ -51,7 +51,7 @@ future==0.18.2            # via backports.os, pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/quality.in, caniusepython3, isort, s3transfer
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, inflect, path.py, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-resources==1.4.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 ipaddress==1.0.23         # via cryptography
 isort==4.3.21             # via -r requirements/quality.in, pylint
@@ -122,7 +122,7 @@ typing==3.7.4.1           # via importlib-resources
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.2    # via -r requirements/reporting.in
-virtualenv==20.0.10       # via tox
+virtualenv==20.0.13       # via tox
 wcwidth==0.1.8            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,0 +1,1 @@
+django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pyli
 backports.os==0.1.1       # via path.py
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.1             # via readme-renderer
+bleach==3.1.3             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 caniusepython3==7.2.0     # via -r requirements/quality.in
@@ -30,9 +30,9 @@ colorama==0.3.7           # via awscli, py2neo
 configparser==4.0.2       # via importlib-metadata, pydocstyle, pylint
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 cookies==2.2.1            # via responses
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
-ddt==1.3.0                # via -r requirements/test.in
+ddt==1.3.1                # via -r requirements/test.in
 diff-cover==2.6.0         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via caniusepython3, virtualenv
 django-crum==0.7.5        # via edx-rbac
@@ -44,7 +44,7 @@ djangorestframework==3.9.4  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
@@ -61,7 +61,7 @@ future==0.18.2            # via backports.os, pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/quality.in, caniusepython3, isort, s3transfer
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, inflect, path.py, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-resources==1.4.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 ipaddress==1.0.23         # via cryptography, faker
 isort==4.3.21             # via -r requirements/quality.in, pylint
@@ -139,7 +139,7 @@ typing==3.7.4.1           # via importlib-resources
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.2    # via -r requirements/reporting.in
-virtualenv==20.0.10       # via tox
+virtualenv==20.0.13       # via tox
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -22,19 +22,18 @@ colorama==0.3.7           # via awscli, py2neo
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
 cookies==2.2.1            # via responses
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
-ddt==1.3.0                # via -r requirements/test.in
+ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
 django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test-master.in, django-crum, django-fernet-fields, django-model-utils, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
 djangorestframework==3.9.4  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -21,7 +21,7 @@ click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 cryptography==2.8         # via -r requirements/reporting.in, paramiko, pgpy
 ddt==1.1.2                # via -r requirements/test-reporting.in
 distlib==0.3.0            # via virtualenv
@@ -31,7 +31,7 @@ filelock==3.0.12          # via tox, virtualenv
 funcsigs==1.0.2           # via mock, pytest
 futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, s3transfer
 importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-resources==1.4.0  # via virtualenv
 ipaddress==1.0.23         # via cryptography
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
@@ -71,7 +71,7 @@ typing==3.7.4.1           # via importlib-resources
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo
 vertica-python==0.10.2    # via -r requirements/reporting.in
-virtualenv==20.0.10       # via tox
+virtualenv==20.0.13       # via tox
 wcwidth==0.1.8            # via prompt-toolkit
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,9 +22,9 @@ colorama==0.3.7           # via awscli, py2neo
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
 cookies==2.2.1            # via responses
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
-ddt==1.3.0                # via -r requirements/test.in
+ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
@@ -34,7 +34,7 @@ djangorestframework==3.9.4  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,15 +7,15 @@
 appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.16           # via -r requirements/travis.in
+codecov==2.0.22           # via -r requirements/travis.in
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
-coverage==5.0.3           # via codecov
+coverage==5.0.4           # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-resources==1.4.0  # via virtualenv
 packaging==20.3           # via tox
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
@@ -30,5 +30,5 @@ tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements
 tox==3.14.5               # via -r requirements/travis.in, tox-battery
 typing==3.7.4.1           # via importlib-resources
 urllib3==1.25.8           # via requests
-virtualenv==20.0.10       # via tox
+virtualenv==20.0.13       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ norecursedirs = .* docs requirements node_modules
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
+    django111: -r{toxinidir}/requirements/django.txt
     data: -r{toxinidir}/requirements/test-master.txt
     reporting: -r{toxinidir}/requirements/test-reporting.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {data,reporting}
+envlist = {django111}-{data,reporting}
 
 [wheel]
 universal = 1
@@ -44,15 +44,17 @@ DJANGO_SETTINGS_MODULE = enterprise_data.settings.test
 addopts = --cov enterprise_reporting --cov enterprise_data --cov enterprise_data_roles --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements node_modules
 
-[testenv:data]
+[testenv]
 deps =
-    -r{toxinidir}/requirements/test-master.txt
+    django111: Django>=1.11,<2.0
+    data: -r{toxinidir}/requirements/test-master.txt
+    reporting: -r{toxinidir}/requirements/test-reporting.txt
+
+[testenv:data]
 commands =
     pytest -Wd {posargs} --ignore enterprise_reporting/
 
 [testenv:reporting]
-deps =
-    -r{toxinidir}/requirements/test-reporting.txt
 commands =
     pytest -Wd --cov enterprise_reporting --cov-report term-missing --cov-report xml enterprise_reporting/tests
 


### PR DESCRIPTION
Currently python3 tests of reporting are using django version 3, with this change the django version used will be the version defined in the toxenv.

Context: https://github.com/edx/edx-enterprise-data/pull/175#pullrequestreview-374597395

After this, we can drop python 2.7 usage and add new django versions to the tests.


## Reviewers

- [ ] @andrey-canon
- [x] Ready for edX review
- [ ] @jmbowman 