### PR TITLE
[BD] Drop python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: python
 python:
-  - 2.7
-  - 3.6
+  - 3.5
 env:
   - TOXENV=django111-data
   - TOXENV=django111-reporting
-matrix:
-  include:
-  - python: 3.6
-    env: TOXENV=quality
-  - python: 2.7
-    env: TOXENV=quality
+  - TOXENV=quality
 cache:
   - pip
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ----------
+* Drop python 2.7 support
 
 =========================
 

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,10 @@ setup(
     name="edx-enterprise-data",
     version=VERSION,
     classifiers=[
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Framework :: Django',
+        'Framework :: Django :: 1.11',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.5',
     ],
     description="""Enterprise Reporting""",
     author="edX",


### PR DESCRIPTION
## Description

Drop python 2.7 support. Fix tox configuration.

Note: Check if the reporting scripts are being used with python3.

## Reviewers

- [ ] @andrey-canon
- [x] Ready for edX review
- [ ] @jmbowman 
