### PR TITLE
[BD] Add tests using django2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ env:
   - TOXENV=django111-data
   - TOXENV=django111-reporting
   - TOXENV=quality
+  - TOXENV=django20-data
+  - TOXENV=django21-data
+  - TOXENV=django22-data
+  - TOXENV=django22-reporting
 cache:
   - pip
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,14 @@ Change Log
 
 Unreleased
 ----------
-* Fix for JWT being double encoded
-* Drop python 2.7 support
 
 =========================
+
+[2.0.0] - 2020-04-01
+--------------------
+* Fix for JWT being double encoded
+* Drop python 2.7 support
+* Add support to Django 2.0, 2.1 and 2.2
 
 [1.3.16] - 2020-03-13
 ---------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -4,6 +4,6 @@ Enterprise data api application. This Django app exposes API endpoints used by e
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.16"
+__version__ = "2.0.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -67,5 +67,5 @@ slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.32.0         # via edx-opaque-keys
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 wcwidth==0.1.9            # via prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -108,12 +108,12 @@ testfixtures==6.14.0      # via -r requirements/quality.in
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 tox==3.14.6               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.43.0              # via twine
+tqdm==4.44.1              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 virtualenv==20.0.15       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -100,7 +100,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.3              # via celery, django, neotime, py2neo
@@ -123,12 +123,12 @@ text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 tox==3.14.6               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.43.0              # via twine
+tqdm==4.44.1              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 virtualenv==20.0.15       # via tox
 wcwidth==0.1.9            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -68,7 +68,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.3              # via celery, django, neotime, py2neo
@@ -87,6 +87,6 @@ testfixtures==6.14.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 wcwidth==0.1.9            # via prompt-toolkit, pytest
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -61,7 +61,7 @@ tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements
 tox==3.14.6               # via -r requirements/test-reporting.in, tox-battery
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 virtualenv==20.0.15       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -69,7 +69,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
 pytz==2019.3              # via celery, django, neotime, py2neo
@@ -88,6 +88,6 @@ testfixtures==6.14.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
-vertica-python==0.10.2    # via -r requirements/reporting.in
+vertica-python==0.10.3    # via -r requirements/reporting.in
 wcwidth==0.1.9            # via prompt-toolkit, pytest
 zipp==1.2.0               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
     classifiers=[
         'Framework :: Django',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,9 @@ norecursedirs = .* docs requirements node_modules
 [testenv]
 deps =
     django111: -r{toxinidir}/requirements/django.txt
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     data: -r{toxinidir}/requirements/test-master.txt
     reporting: -r{toxinidir}/requirements/test-reporting.txt
 


### PR DESCRIPTION
## Description

Add tests using django 2.0, 2.1 and 2.2. In the case of the reporting scripts only were added the django 2.2 tests since I think that is is not necessary to test the other versions. 

Part of https://openedx.atlassian.net/projects/BOM/issues/BOM-1359.


## Reviewers

- [ ] @andrey-canon
- [x] Ready for edX review
- [x] @jmbowman 
