### PR TITLE
[BD] Fix tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,13 +50,9 @@ deps =
     data: -r{toxinidir}/requirements/test-master.txt
     reporting: -r{toxinidir}/requirements/test-reporting.txt
 
-[testenv:data]
 commands =
-    pytest -Wd {posargs} --ignore enterprise_reporting/
-
-[testenv:reporting]
-commands =
-    pytest -Wd --cov enterprise_reporting --cov-report term-missing --cov-report xml enterprise_reporting/tests
+    data: pytest -Wd {posargs} --ignore enterprise_reporting/
+    reporting: pytest -Wd --cov enterprise_reporting --cov-report term-missing --cov-report xml enterprise_reporting/tests
 
 [testenv:quality]
 whitelist_externals =


### PR DESCRIPTION
## Description

Currently, tox is not running the actual commands for each environment (data and reporting).  This is due to an error from this PR https://github.com/edx/edx-enterprise-data/pull/179
This solves that.

I am removing [testenv:data]	 and [testenv:reporting] sections in order to avoid the creation of a new section for each django version.


## Reviewers
- [ ] @jmbowman
- [ ] @Andrey-canon
- [x] Ready for edX review.