### PR TITLE
[BD] Unpin edx-django-utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,12 +12,12 @@ billiard==3.3.0.23        # via celery
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo, requests
+certifi==2020.4.5.1       # via py2neo, requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-rbac
@@ -26,11 +26,11 @@ django==1.11.29           # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.in
-edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 jmespath==0.9.5           # via boto3, botocore
@@ -39,7 +39,7 @@ neobolt==1.7.16           # via py2neo
 neotime==1.7.4            # via py2neo
 newrelic==5.10.0.138      # via edx-django-utils
 paramiko==2.7.1           # via -r requirements/reporting.in
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
 prompt-toolkit==2.0.10    # via py2neo
 psutil==1.2.1             # via edx-django-utils

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,15 +22,6 @@ django-waffle<0.19.0
 # See https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40
 drf-jwt<1.15.0
 
-# edx-django-utils version 3.0.0 dropped support for python 2.7, see https://github.com/edx/edx-django-utils/releases/tag/3.0.0
-edx-django-utils<3.0.0
-
-# edx-django-utils version 4.0.0 dropped support for python 2.7, see https://github.com/edx/edx-rest-api-client/releases/tag/4.0.0
-edx-rest-api-client<4.0.0
-
-# Already in python3
-futures; python_version == "2.7"
-
 # readme-renderer requires Pygments>=2.5.1 which is not compatible with py2neo==4.3.0
 readme-renderer<25.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,22 +9,20 @@ anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 awscli==1.11.178          # via -r requirements/reporting.in
-astroid==2.3.3            # via pylint, pylint-celery
-awscli==1.11.178          # via -r requirements/reporting.in
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
 bleach==3.1.4             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo, requests
+certifi==2020.4.5.1       # via py2neo, requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
-diff-cover==2.6.0         # via -r requirements/dev-enterprise_data.in
+cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -34,13 +32,13 @@ django==1.11.29           # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.in
-edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -r requirements/base.in
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
@@ -62,7 +60,7 @@ packaging==20.3           # via tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
 pip-tools==4.5.1          # via -r requirements/dev-enterprise_data.in
 pkginfo==1.5.0.1          # via twine
@@ -87,7 +85,7 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
 pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli, edx-i18n-tools
@@ -107,13 +105,13 @@ testfixtures==6.14.0      # via -r requirements/quality.in
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 tox==3.14.6               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.44.1              # via twine
+tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.16       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,16 +16,16 @@ bleach==3.1.4             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo, requests
+certifi==2020.4.5.1       # via py2neo, requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.0.4           # via pytest-cov
-cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
-diff-cover==2.6.0         # via -r requirements/dev-enterprise_data.in
+diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -35,13 +35,13 @@ django==1.11.29           # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.in
-edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.2              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -70,7 +70,7 @@ paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
 pip-tools==4.5.1          # via -r requirements/dev-enterprise_data.in
 pkginfo==1.5.0.1          # via twine
@@ -95,7 +95,7 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
@@ -120,13 +120,13 @@ text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 tox==3.14.6               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.44.1              # via twine
+tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.16       # via tox
 wcwidth==0.1.9            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -13,13 +13,13 @@ billiard==3.3.0.23        # via celery
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo, requests
+certifi==2020.4.5.1       # via py2neo, requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.0.4           # via pytest-cov
-cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -28,11 +28,11 @@ django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-util
 djangorestframework==3.11.0  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.in
-edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.2              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
@@ -50,7 +50,7 @@ newrelic==5.10.0.138      # via edx-django-utils
 packaging==20.3           # via pytest
 paramiko==2.7.1           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest
 prompt-toolkit==2.0.10    # via py2neo
@@ -66,7 +66,7 @@ pyjwt==1.7.1              # via drf-jwt, edx-rest-api-client
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -15,12 +15,12 @@ billiard==3.3.0.23        # via celery
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo
+certifi==2020.4.5.1       # via py2neo
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.0.4           # via pytest-cov
-cryptography==2.8         # via -r requirements/reporting.in, paramiko, pgpy
+cryptography==2.9         # via -r requirements/reporting.in, paramiko, pgpy
 ddt==1.1.2                # via -r requirements/test-reporting.in
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via awscli, botocore
@@ -36,7 +36,7 @@ neotime==1.7.4            # via py2neo
 packaging==20.3           # via tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via mock
+pbr==5.4.5                # via mock
 pgpy==0.5.2               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest, tox
 prompt-toolkit==2.0.10    # via py2neo
@@ -47,7 +47,7 @@ pycparser==2.20           # via cffi
 pygments==2.3.1           # via py2neo
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pynacl==1.3.0             # via paramiko
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-cov==2.5.1         # via -r requirements/test-reporting.in
 pytest==3.7.1             # via -r requirements/test-reporting.in, pytest-cov
 python-dateutil==2.8.1    # via botocore, vertica-python
@@ -62,7 +62,7 @@ tox==3.14.6               # via -r requirements/test-reporting.in, tox-battery
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.16       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,13 +13,13 @@ billiard==3.3.0.23        # via celery
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2019.11.28       # via py2neo, requests
+certifi==2020.4.5.1       # via py2neo, requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.0.4           # via pytest-cov
-cryptography==2.8         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -29,11 +29,11 @@ django==1.11.29           # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.in
-edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.2              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
@@ -51,7 +51,7 @@ newrelic==5.10.0.138      # via edx-django-utils
 packaging==20.3           # via pytest
 paramiko==2.7.1           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest
 prompt-toolkit==2.0.10    # via py2neo
@@ -67,7 +67,7 @@ pyjwt==1.7.1              # via drf-jwt, edx-rest-api-client
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.22           # via -r requirements/travis.in
 coverage==5.0.4           # via codecov
@@ -17,12 +17,12 @@ importlib-resources==1.4.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.8           # via requests
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.16       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
Unpin edx-django-utils and edx-rest-api-client and run `make upgrade` using python3.

## Reviewers
- [x] Ready for edX review
- [ ] @jmbowman 