### PR TITLE
[BD] Set enterprise_user_id as unique

### DIFF
--- a/enterprise_data/migrations/0011_enterpriseuser.py
+++ b/enterprise_data/migrations/0011_enterpriseuser.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('enterprise_id', models.UUIDField()),
                 ('lms_user_id', models.PositiveIntegerField()),
-                ('enterprise_user_id', models.PositiveIntegerField()),
+                ('enterprise_user_id', models.PositiveIntegerField(unique=True)),
                 ('enterprise_sso_uid', models.CharField(max_length=255, null=True)),
                 ('user_account_creation_timestamp', models.DateTimeField(null=True)),
                 ('user_email', models.CharField(max_length=255, null=True)),


### PR DESCRIPTION
## Description

Migrations in mysql(for reports database) are failing due to enterprise_user_id is not set as unique (in the [model](https://github.com/edx/edx-enterprise-data/blob/88f808b6bbdd047e36e865f01aae2a53df501bc7/enterprise_data/models.py#L106) it is defined at that way). More context in https://github.com/edx/edx-analytics-data-api/pull/340#discussion_r399545972

## Reviewers
- [ ] @andrey-canon
- [x] Ready for edX review.
- [ ] @jmbowman 