### PR TITLE
[BD-6] Add tests in python 3.8 and remove Django 1.11, 2.0 and 2.1 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
 python:
   - 3.5
+  - 3.8
 env:
-  - TOXENV=django111-data
-  - TOXENV=django111-reporting
-  - TOXENV=quality
-  - TOXENV=django20-data
-  - TOXENV=django21-data
   - TOXENV=django22-data
   - TOXENV=django22-reporting
+  - TOXENV=quality
 cache:
   - pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
   - tox
 after_success:
   - codecov
+jobs:
+  allow_failures:
+    - python: 3.8
 deploy:
   provider: pypi
   user: edx

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,11 +17,11 @@ cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
-django-crum==0.7.5        # via edx-rbac
+cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+django-crum==0.7.6        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-rbac
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via -r requirements/base.in, edx-rbac
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
@@ -54,15 +54,15 @@ pyminizip==0.2.4          # via -r requirements/reporting.in
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo
+pytz==2020.1              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.1.13        # via awscli, boto3
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, neotime, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, stevedore, vertica-python
+semantic-version==2.8.5   # via edx-drf-extensions
+six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, edx-rbac, neotime, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,27 +17,27 @@ cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-rbac
 django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 paramiko==2.7.1           # via -r requirements/reporting.in
 pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
@@ -64,6 +64,7 @@ s3transfer==0.1.13        # via awscli, boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, neotime, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,7 @@
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
 # Django version 2.0.0 dropped support to python2.7
-Django<2.0
+Django>=2.2,<2.3
 
 # django-model-utils version 4.0.0 dropped support to python 2.7
 django-model-utils<4.0.0
@@ -21,6 +21,8 @@ django-waffle<0.19.0
 
 # See https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40
 drf-jwt<1.15.0
+
+pip-tools<5.0.0
 
 # readme-renderer requires Pygments>=2.5.1 which is not compatible with py2neo==4.3.0
 readme-renderer<25.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,15 +13,10 @@
 # Django version 2.0.0 dropped support to python2.7
 Django>=2.2,<2.3
 
-# django-model-utils version 4.0.0 dropped support to python 2.7
-django-model-utils<4.0.0
-
-# django-waffle version 0.19.0 dropped support to Django 2.0 and 2.1, see https://github.com/django-waffle/django-waffle/blob/master/CHANGES
-django-waffle<0.19.0
-
 # See https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40
 drf-jwt<1.15.0
 
+# pip20+ requires for greater version of pip-tools. But installing 19.3.1 in all our containers and VMs.
 pip-tools<5.0.0
 
 # readme-renderer requires Pygments>=2.5.1 which is not compatible with py2neo==4.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,23 +21,23 @@ chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-rbac
 django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via pyjwkest
@@ -47,22 +47,22 @@ importlib-resources==1.4.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 packaging==20.3           # via tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
-pip-tools==4.5.1          # via -r requirements/dev-enterprise_data.in
+pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -100,8 +100,9 @@ semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, neotime, packaging, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, stevedore, tox, vertica-python, virtualenv
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/quality.in
+testfixtures==6.14.1      # via -r requirements/quality.in
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 tox==3.14.6               # via -r requirements/dev-enterprise_data.in, tox-battery
@@ -111,7 +112,7 @@ typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.18       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ astroid==2.3.3            # via pylint, pylint-celery
 awscli==1.11.178          # via -r requirements/reporting.in
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
@@ -21,13 +21,13 @@ chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
-django-crum==0.7.5        # via edx-rbac
+django-crum==0.7.6        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-rbac
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via -r requirements/base.in, edx-rbac
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
@@ -43,7 +43,7 @@ filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, inflect, path, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -56,7 +56,7 @@ mccabe==0.6.1             # via pylint
 neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
 newrelic==5.12.0.140      # via edx-django-utils
-packaging==20.3           # via tox
+packaging==20.3           # via bleach, tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
@@ -87,7 +87,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo
+pytz==2020.1              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via -c requirements/constraints.txt, twine
 requests-toolbelt==0.9.1  # via twine
@@ -96,8 +96,8 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.1.13        # via awscli, boto3
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, neotime, packaging, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, stevedore, tox, vertica-python, virtualenv
+semantic-version==2.8.5   # via edx-drf-extensions
+six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, neotime, packaging, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, stevedore, tox, vertica-python, virtualenv
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip_tools.in
+pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
+click==7.1.2              # via pip-tools
 pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ attrs==19.3.0             # via pytest
 awscli==1.11.178          # via -r requirements/reporting.in
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 boto3==1.4.7              # via -r requirements/reporting.in
 botocore==1.7.36          # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
@@ -23,14 +23,14 @@ click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.1             # via pytest-cov
-cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
-django-crum==0.7.5        # via edx-rbac
+django-crum==0.7.6        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
@@ -50,7 +50,7 @@ freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -65,7 +65,7 @@ more-itertools==8.2.0     # via pytest
 neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
 newrelic==5.12.0.140      # via edx-django-utils
-packaging==20.3           # via pytest, tox
+packaging==20.3           # via bleach, pytest, tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
@@ -100,7 +100,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo
+pytz==2020.1              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via -c requirements/constraints.txt, twine
 requests-toolbelt==0.9.1  # via twine
@@ -110,8 +110,8 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.1.13        # via awscli, boto3
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, responses, stevedore, tox, vertica-python, virtualenv
+semantic-version==2.8.5   # via edx-drf-extensions
+six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, responses, stevedore, tox, vertica-python, virtualenv
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,8 +22,8 @@ chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint, pip-tools, py2neo
 colorama==0.3.7           # via awscli, py2neo
-coverage==5.0.4           # via pytest-cov
-cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+coverage==5.1             # via pytest-cov
+cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 diff-cover==2.6.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.0            # via virtualenv
@@ -31,19 +31,19 @@ django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
 django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore, readme-renderer
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev-enterprise_data.in
 edx-lint==1.4.1           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.2              # via factory-boy
+faker==4.0.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
@@ -54,7 +54,7 @@ importlib-resources==1.4.0  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
@@ -62,9 +62,9 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 packaging==20.3           # via pytest, tox
 paramiko==2.7.1           # via -r requirements/reporting.in
 path.py==12.4.0           # via edx-i18n-tools
@@ -72,7 +72,7 @@ path==13.1.0              # via path.py
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via stevedore
 pgpy==0.5.2               # via -r requirements/reporting.in
-pip-tools==4.5.1          # via -r requirements/dev-enterprise_data.in
+pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -105,7 +105,7 @@ pyyaml==3.12              # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via -c requirements/constraints.txt, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, twine
-responses==0.10.12        # via -r requirements/test.in
+responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
@@ -114,8 +114,9 @@ semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, responses, stevedore, tox, vertica-python, virtualenv
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/quality.in, -r requirements/test.in
+testfixtures==6.14.1      # via -r requirements/quality.in, -r requirements/test.in
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
@@ -126,7 +127,7 @@ typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.18       # via tox
 wcwidth==0.1.9            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r requirements/dev-enterprise_data.in

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -19,12 +19,12 @@ chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.1             # via pytest-cov
-cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
-django-crum==0.7.5        # via edx-rbac
+django-crum==0.7.6        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.0  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
@@ -71,7 +71,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo
+pytz==2020.1              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
 responses==0.10.14        # via -r requirements/test.in
@@ -79,8 +79,8 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.1.13        # via awscli, boto3
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
+semantic-version==2.8.5   # via edx-drf-extensions
+six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -18,8 +18,8 @@ cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-coverage==5.0.4           # via pytest-cov
-cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+coverage==5.1             # via pytest-cov
+cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -28,13 +28,13 @@ django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-util
 djangorestframework==3.11.0  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.2              # via factory-boy
+faker==4.0.3              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
@@ -44,9 +44,9 @@ jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 packaging==20.3           # via pytest
 paramiko==2.7.1           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
@@ -74,7 +74,7 @@ python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, 
 pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.10.12        # via -r requirements/test.in
+responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
@@ -82,8 +82,9 @@ s3transfer==0.1.13        # via awscli, boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/test.in
+testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -7,7 +7,7 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
-atomicwrites==1.3.0       # via pytest
+atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
 awscli==1.11.178          # via -r requirements/reporting.in
 bcrypt==3.1.7             # via paramiko
@@ -20,13 +20,13 @@ cffi==1.14.0              # via bcrypt, cryptography, pynacl
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.1             # via pytest-cov
-cryptography==2.9.1       # via -r requirements/reporting.in, paramiko, pgpy
+cryptography==2.9.2       # via -r requirements/reporting.in, paramiko, pgpy
 ddt==1.1.2                # via -r requirements/test-reporting.in
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via awscli, botocore
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==2.0.0               # via -r requirements/test-reporting.in
@@ -51,7 +51,7 @@ pyparsing==2.4.7          # via packaging
 pytest-cov==2.5.1         # via -r requirements/test-reporting.in
 pytest==3.7.1             # via -r requirements/test-reporting.in, pytest-cov
 python-dateutil==2.8.1    # via botocore, vertica-python
-pytz==2019.3              # via celery, neotime, py2neo
+pytz==2020.1              # via celery, neotime, py2neo
 pyyaml==3.12              # via awscli
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -19,8 +19,8 @@ certifi==2020.4.5.1       # via py2neo
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-coverage==5.0.4           # via pytest-cov
-cryptography==2.9         # via -r requirements/reporting.in, paramiko, pgpy
+coverage==5.1             # via pytest-cov
+cryptography==2.9.1       # via -r requirements/reporting.in, paramiko, pgpy
 ddt==1.1.2                # via -r requirements/test-reporting.in
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via awscli, botocore
@@ -31,7 +31,7 @@ jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==2.0.0               # via -r requirements/test-reporting.in
 more-itertools==8.2.0     # via pytest
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
 packaging==20.3           # via tox
 paramiko==2.7.1           # via -r requirements/reporting.in
@@ -62,7 +62,7 @@ tox==3.14.6               # via -r requirements/test-reporting.in, tox-battery
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo
 vertica-python==0.10.3    # via -r requirements/reporting.in
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.18       # via tox
 wcwidth==0.1.9            # via prompt-toolkit
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,24 +18,24 @@ cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
-coverage==5.0.4           # via pytest-cov
-cryptography==2.9         # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+coverage==5.1             # via pytest-cov
+cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
 django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.2              # via factory-boy
+faker==4.0.3              # via factory-boy
 flaky==3.6.1              # via -r requirements/test.in
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
@@ -45,9 +45,9 @@ jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
-neobolt==1.7.16           # via py2neo
+neobolt==1.7.17           # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 packaging==20.3           # via pytest
 paramiko==2.7.1           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
@@ -75,7 +75,7 @@ python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, 
 pytz==2019.3              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.10.12        # via -r requirements/test.in
+responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
@@ -83,8 +83,9 @@ s3transfer==0.1.13        # via awscli, boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/test.in
+testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/reporting.in
 urllib3==1.24.3           # via py2neo, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,12 +19,12 @@ chardet==3.0.4            # via requests
 click==7.0                # via py2neo
 colorama==0.3.7           # via awscli, py2neo
 coverage==5.1             # via pytest-cov
-cryptography==2.9.1       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
+cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy
 ddt==1.3.1                # via -r requirements/test.in
-django-crum==0.7.5        # via edx-rbac
+django-crum==0.7.6        # via edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-model-utils==3.2.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
 djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via awscli, botocore
@@ -72,7 +72,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2019.3              # via celery, django, neotime, py2neo
+pytz==2020.1              # via celery, django, neotime, py2neo
 pyyaml==3.12              # via awscli
 requests==2.23.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
 responses==0.10.14        # via -r requirements/test.in
@@ -80,8 +80,8 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==3.4.2                # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.1.13        # via awscli, boto3
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
+semantic-version==2.8.5   # via edx-drf-extensions
+six==1.14.0               # via -r requirements/base.in, bcrypt, cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,7 +13,7 @@ distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,7 +8,7 @@ appdirs==1.4.3            # via virtualenv
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.22           # via -r requirements/travis.in
-coverage==5.0.4           # via codecov
+coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
@@ -23,6 +23,6 @@ six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.8           # via requests
-virtualenv==20.0.16       # via tox
+urllib3==1.25.9           # via requests
+virtualenv==20.0.18       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,6 @@ setup(
     version=VERSION,
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {django111}-{data,reporting}
+envlist = django{22,30}-{data,reporting}
 
 [wheel]
 universal = 1
@@ -46,10 +46,8 @@ norecursedirs = .* docs requirements node_modules
 
 [testenv]
 deps =
-    django111: -r{toxinidir}/requirements/django.txt
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
+    django22: -r{toxinidir}/requirements/django.txt
+    django30: Django>=3,<3.1
     data: -r{toxinidir}/requirements/test-master.txt
     reporting: -r{toxinidir}/requirements/test-reporting.txt
 


### PR DESCRIPTION
Add tests in python 3.8 and remove Django 1.11, 2.0 and 2.1 tests
## Reviewers
- [ ] @awais786 
- [ ] @jmbowman 
- [x] Ready for edX review.