### PR TITLE
ENT-3450 | ENT-3451 | added snowflake client. added reports for grade and course_structure.

### DIFF
--- a/enterprise_reporting/clients/snowflake.py
+++ b/enterprise_reporting/clients/snowflake.py
@@ -1,0 +1,64 @@
+"""
+Client for connecting to a Snowflake database.
+"""
+
+import datetime
+import os
+from logging import getLogger
+
+from snowflake import connector
+
+LOGGER = getLogger(__name__)
+
+
+class SnowflakeClient:
+    """
+    Client for connecting to Snowflake.
+    """
+
+    def __init__(self, username=None, password=None, account=None):
+        """
+        Instantiate a new client using the Django settings to determine the Snowflake credentials.
+        If there are none configured, throw an exception.
+        """
+        username = username or os.environ['SNOWFLAKE_USERNAME']
+        password = password or os.environ['SNOWFLAKE_PASSWORD']
+        account = account or os.environ['SNOWFLAKE_ACCOUNT']
+
+        self.connection_info = {
+            'user': username,
+            'password': password,
+            'account': account,
+        }
+
+        self.connection = None
+        self.cursor = None
+
+    def connect(self):
+        """
+        Open a connection to Snowflake.
+        """
+        self.connection = connector.connect(**self.connection_info)
+        self.cursor = self.connection.cursor()
+
+    def close_connection(self):
+        """
+        Close the connection to Snowflake.
+        """
+        self.cursor.close()
+        self.connection.close()
+        self.cursor = None
+        self.connection = None
+
+    def stream_results(self, query):
+        """
+        Streams the results for a query using the current connection.
+        """
+        for row in self.cursor.execute(query):
+            formatted_row = []
+            for value in row:
+                if isinstance(value, datetime.datetime):
+                    formatted_row.append(value.strftime('%Y-%m-%d %H:%M:%S'))
+                else:
+                    formatted_row.append(value)
+            yield formatted_row

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -17,6 +17,7 @@ from enterprise_reporting.clients.enterprise import (
     EnterpriseAPIClient,
     EnterpriseDataApiClient
 )
+from enterprise_reporting.clients.snowflake import SnowflakeClient
 from enterprise_reporting.clients.vertica import VerticaClient
 from enterprise_reporting.delivery_method import SFTPDeliveryMethod, SMTPDeliveryMethod
 from enterprise_reporting.utils import decrypt_string, generate_data
@@ -56,6 +57,176 @@ class EnterpriseReportSender(object):
         'time_spent_hours',
         'last_activity_date',
         'user_current_enrollment_mode',
+    )
+
+    SNOWFLAKE_GRADES_QUERY = (
+        """
+        WITH enterprise as (
+            SELECT
+                ee.enterprise_customer_uuid,
+                lms_user_id as user_id
+            FROM 
+                prod.enterprise.ent_base_enterprise_enrollment as ee
+            WHERE 
+                ee.enterprise_customer_uuid = '{enterprise_id}'
+        )
+            SELECT
+                {fields}
+            FROM 
+                prod.lms.grades_persistentsubsectiongrade as grade
+            JOIN
+                enterprise
+            ON
+            grade.user_id = enterprise.user_id;
+        """
+    )
+    SNOWFLAKE_GRADES_QUERY_FIELDS = (
+        'enterprise.enterprise_customer_uuid AS ENTERPRISE_CUSTOMER_UUID',
+        'grade.user_id AS USER_ID',
+        'grade.course_id AS COURSE_ID',
+        'grade.usage_key AS USAGE_KEY',
+        'grade.earned_all AS EARNED_ALL',
+        'grade.possible_all AS POSSIBLE_ALL',
+        'grade.earned_graded AS EARNED_GRADED',
+        'grade.possible_graded AS POSSIBLE_GRADED',
+        'grade.first_attempted AS FIRST_ATTEMPTED'
+    )
+
+    SNOWFLAKE_COURSE_STRUCTURE_QUERY = (
+        """
+        WITH section_level as (
+        -- Pull in full course structure table; section data will be handled in joins.
+        SELECT * FROM prod.production.course_structure
+        ),
+        
+        subsection_level as (
+        -- Pull in full course structure table; subsection data will be handled in joins.
+        SELECT * FROM prod.production.course_structure
+        ),
+        
+        component_level as (
+        -- Pull in full course structure table; component data will be handled in joins.
+        SELECT * FROM prod.production.course_structure
+        ),
+        
+        section_index as (
+        -- Generates an index that says "n section is the nth section in this course".
+        -- Allows for section ordering.
+        WITH sub as (
+        SELECT
+            course_block_id,
+            section_block_id,
+            MAX(order_index) as order_index
+        FROM 
+            prod.production.course_structure
+        WHERE
+        /*Filter out higher level blocks 
+          so there is only one row per component.*/
+            block_type NOT IN (
+                'vertical',
+                'sequential',
+                'chapter',
+                'course')
+        GROUP BY
+                1,2)
+        SELECT
+            *,
+            ROW_NUMBER() OVER 
+            (PARTITION BY course_block_id 
+             ORDER BY order_index) as section_index
+        FROM
+            sub
+        ),
+        
+        subsection_index as (
+        -- Generates an index that says "n subsection is the nth subsection in this section".
+        -- Allows for subsection ordering.
+        WITH sub as (
+        SELECT
+            course_block_id,
+            section_block_id,
+            subsection_block_id,
+            MAX(order_index) as order_index
+        FROM 
+            prod.production.course_structure
+        WHERE
+        /*Filter out higher level blocks 
+          so there is only one row per component.*/
+            block_type not in (
+                'vertical',
+                'sequential',
+                'chapter',
+                'course')
+        GROUP BY
+            1,2,3)
+        SELECT
+            *,
+            ROW_NUMBER() OVER 
+            (PARTITION BY course_block_id, section_block_id 
+             ORDER BY order_index) as subsection_index
+        FROM
+            sub),
+            
+        selected_enterprise as (
+        -- Generate a distinct list of every course run key for selected_enterprise learner enrolled in.
+        -- Used to filter dataset down to only data relevant to selected_enterprise's courses.
+        SELECT DISTINCT
+            bee.lms_courserun_key as course_id
+        FROM
+            prod.enterprise.ent_base_enterprise_enrollment as bee
+        WHERE
+            bee.enterprise_customer_uuid = '{enterprise_id}'
+        )
+        
+        SELECT 
+            {fields}
+        FROM
+            component_level as cl
+        JOIN
+            section_level as sl
+        ON
+            cl.section_block_id = sl.block_id
+        JOIN
+            subsection_level as ssl
+        ON
+            cl.subsection_block_id = ssl.block_id
+        LEFT JOIN
+            section_index as si
+        ON
+            cl.section_block_id = si.section_block_id
+        LEFT JOIN
+            subsection_index as ssi
+        ON
+            ssl.block_id = ssi.subsection_block_id
+        JOIN
+            selected_enterprise
+        ON
+            cl.course_id = selected_enterprise.course_id
+        WHERE
+        /*Filter out higher level blocks 
+          so there is only one row per component.*/
+            cl.block_id NOT IN (
+                    'vertical',
+                    'sequential',
+                    'chapter',
+                    'course')
+        ORDER BY
+                cl.course_id,
+                cl.order_index;
+        """
+    )
+
+    SNOWFLAKE_COURSE_STRUCTURE_QUERY_FIELDS = (
+        'cl.course_id AS COURSE_ID',
+        'cl.section_block_id AS SECTION_BLOCK_ID',
+        'sl.display_name AS SECTION_DISPLAY_NAME',
+        'si.section_index AS SECTION_INDEX',
+        'ssl.block_id AS SUBSECTION_BLOCK_ID',
+        'ssl.display_name AS SUBSECTION_DISPLAY_NAME',
+        'ssi.subsection_index AS SUBSECTION_INDEX',
+        'cl.block_id AS COMPONENT_BLOCK_ID',
+        'cl.display_name AS COMPONENT_DISPLAY_NAME',
+        'cl.lms_web_url AS LMS_WEB_URL',
     )
 
     FILE_WRITE_DIRECTORY = '/tmp'
@@ -149,6 +320,40 @@ class EnterpriseReportSender(object):
             LOGGER.debug('Executing this Vertica query: {}'.format(query))
             data_report_file_writer.writerows(vertica_client.stream_results(query))
         vertica_client.close_connection()
+        return [data_report_file]
+
+    def _generate_enterprise_report_grade_csv(self):
+        """Query Snowflake and write output to csv file."""
+        snowflake_client = SnowflakeClient()
+        snowflake_client.connect()
+        with open(self.data_report_file_name, 'w') as data_report_file:
+            data_report_file_writer = csv.writer(data_report_file)
+            headers = [col.split(' AS ')[1] for col in self.SNOWFLAKE_GRADES_QUERY_FIELDS]
+            data_report_file_writer.writerow(headers)
+            query = self.SNOWFLAKE_GRADES_QUERY.format(
+                fields=', '.join(self.SNOWFLAKE_GRADES_QUERY_FIELDS),
+                enterprise_id=self.enterprise_customer_uuid.replace('-', '')
+            )
+            LOGGER.debug('Executing this Snowflake query: {}'.format(query))
+            data_report_file_writer.writerows(snowflake_client.stream_results(query))
+        snowflake_client.close_connection()
+        return [data_report_file]
+
+    def _generate_enterprise_report_course_structure_csv(self):
+        """Query Snowflake and write output to csv file."""
+        snowflake_client = SnowflakeClient()
+        snowflake_client.connect()
+        with open(self.data_report_file_name, 'w') as data_report_file:
+            data_report_file_writer = csv.writer(data_report_file)
+            headers = [col.split(' AS ')[1] for col in self.SNOWFLAKE_COURSE_STRUCTURE_QUERY_FIELDS]
+            data_report_file_writer.writerow(headers)
+            query = self.SNOWFLAKE_COURSE_STRUCTURE_QUERY.format(
+                fields=', '.join(self.SNOWFLAKE_COURSE_STRUCTURE_QUERY_FIELDS),
+                enterprise_id=self.enterprise_customer_uuid.replace('-', '')
+            )
+            LOGGER.debug('Executing this Snowflake query: {}'.format(query))
+            data_report_file_writer.writerows(snowflake_client.stream_results(query))
+        snowflake_client.close_connection()
         return [data_report_file]
 
     def _generate_enterprise_report_progress_v2_csv(self):

--- a/enterprise_reporting/send_enterprise_reports.py
+++ b/enterprise_reporting/send_enterprise_reports.py
@@ -17,7 +17,7 @@ from enterprise_reporting.utils import is_current_time_in_schedule
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
-DATA_TYPES = ['progress', 'progress_v2', 'catalog']
+DATA_TYPES = ['progress', 'progress_v2', 'catalog', 'grade', 'course_structure']
 
 
 def send_data(config):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,67 +6,79 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-awscli==1.18.100          # via -r requirements/reporting.in
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo, requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
 chardet==3.0.4            # via requests
-click==7.0                # via py2neo
-colorama==0.4.3           # via awscli, py2neo
-cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy, pyjwt
-django-crum==0.7.6        # via edx-rbac
+colorama==0.4.3           # via awscli
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, django-fernet-fields, paramiko, pgpy, py2neo, pyjwt, pyopenssl, snowflake-connector-python
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-rbac
-django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
-djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via awscli, botocore
-drf-jwt==1.16.2           # via edx-drf-extensions
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+djangorestframework==3.12.2  # via drf-jwt, edx-drf-extensions, rest-condition
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
+english==2020.7.0         # via py2neo
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via celery
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.14.1.144      # via edx-django-utils
-paramiko==2.7.1           # via -r requirements/reporting.in
-pbr==5.4.5                # via stevedore
-pgpy==0.5.2               # via -r requirements/reporting.in
+newrelic==5.22.1.152      # via edx-django-utils
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via py2neo
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
+pbr==5.5.1                # via stevedore
+pgpy==0.5.3               # via -r requirements/reporting.in
 prompt-toolkit==2.0.10    # via py2neo
-psutil==1.2.1             # via edx-django-utils
-py2neo==4.3.0             # via -r requirements/reporting.in
+psutil==5.7.3             # via edx-django-utils
+py2neo==2020.1.0          # via -r requirements/reporting.in
 pyasn1==0.4.8             # via pgpy, rsa
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pygments==2.3.1           # via py2neo
+pycryptodomex==3.9.9      # via pyjwkest, snowflake-connector-python
+pygments==2.7.2           # via py2neo
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client, snowflake-connector-python
 pyminizip==0.2.4          # via -r requirements/reporting.in
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 pynacl==1.4.0             # via paramiko
-python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2020.1              # via celery, django, neotime, py2neo
+pyopenssl==19.1.0         # via snowflake-connector-python
+pyparsing==2.4.7          # via packaging
+python-dateutil==2.8.1    # via azure-storage-common, botocore, edx-drf-extensions, vertica-python
+pytz==2020.4              # via celery, django, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli
-requests==2.24.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
+requests==2.23.0          # via -r requirements/base.in, azure-storage-common, docker, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, snowflake-connector-python
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.5                  # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via awscli, boto3
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, neotime, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, stevedore, vertica-python
+six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, docker, edx-drf-extensions, edx-opaque-keys, edx-rbac, english, neotime, packaging, pansi, pgpy, prompt-toolkit, py2neo, pyjwkest, pynacl, pyopenssl, python-dateutil, stevedore, vertica-python, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo, requests
-vertica-python==0.10.4    # via -r requirements/reporting.in
+urllib3==1.25.11          # via botocore, py2neo, requests, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
 wcwidth==0.2.5            # via prompt-toolkit
+websocket-client==0.57.0  # via docker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,43 +7,49 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.4            # via virtualenv
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
 astroid==2.3.3            # via pylint, pylint-celery
-awscli==1.18.100          # via -r requirements/reporting.in
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.5             # via readme-renderer
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+bleach==3.2.1             # via readme-renderer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo, requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, edx-lint, pip-tools, py2neo
-colorama==0.4.3           # via awscli, py2neo
-cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy, pyjwt
-diff-cover==3.0.1         # via -r requirements/dev-enterprise_data.in
+click==7.1.2              # via click-log, edx-lint, pip-tools
+colorama==0.4.3           # via awscli
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, django-fernet-fields, paramiko, pgpy, py2neo, pyjwt, pyopenssl, snowflake-connector-python
+diff-cover==4.0.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.1            # via virtualenv
-django-crum==0.7.6        # via edx-rbac
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-rbac
-django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
-djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via awscli, botocore, readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
+djangorestframework==3.12.2  # via drf-jwt, edx-drf-extensions, rest-condition
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli, readme-renderer
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev-enterprise_data.in
-edx-lint==1.5.0           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
+edx-lint==1.5.2           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
+english==2020.7.0         # via py2neo
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via inflect, path, pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.0.0  # via inflect, path, pluggy, tox, virtualenv
+importlib-resources==3.2.1  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -53,69 +59,74 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.14.1.144      # via edx-django-utils
-packaging==20.4           # via bleach, tox
-paramiko==2.7.1           # via -r requirements/reporting.in
-path.py==12.4.0           # via edx-i18n-tools
+newrelic==5.22.1.152      # via edx-django-utils
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via bleach, py2neo, tox
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
+path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pbr==5.4.5                # via stevedore
-pgpy==0.5.2               # via -r requirements/reporting.in
-pip-tools==5.2.1          # via -r requirements/dev-enterprise_data.in
-pkginfo==1.5.0.1          # via twine
+pbr==5.5.1                # via stevedore
+pgpy==0.5.3               # via -r requirements/reporting.in
+pip-tools==5.3.1          # via -r requirements/dev-enterprise_data.in
+pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via diff-cover, tox
 polib==1.1.0              # via edx-i18n-tools
 prompt-toolkit==2.0.10    # via py2neo
-psutil==1.2.1             # via edx-django-utils
-py2neo==4.3.0             # via -r requirements/reporting.in
+psutil==5.7.3             # via edx-django-utils
+py2neo==2020.1.0          # via -r requirements/reporting.in
 py==1.9.0                 # via tox
 pyasn1==0.4.8             # via pgpy, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.in
-pygments==2.3.1           # via diff-cover, py2neo, readme-renderer
+pycryptodomex==3.9.9      # via pyjwkest, snowflake-connector-python
+pydocstyle==5.1.1         # via -r requirements/quality.in
+pygments==2.7.2           # via diff-cover, py2neo, readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client, snowflake-connector-python
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyminizip==0.2.4          # via -r requirements/reporting.in
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 pynacl==1.4.0             # via paramiko
+pyopenssl==19.1.0         # via snowflake-connector-python
 pyparsing==2.4.7          # via packaging
-python-dateutil==2.8.1    # via botocore, edx-drf-extensions, vertica-python
-pytz==2020.1              # via celery, django, neotime, py2neo
+python-dateutil==2.8.1    # via azure-storage-common, botocore, edx-drf-extensions, vertica-python
+pytz==2020.4              # via celery, django, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via -c requirements/constraints.txt, twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, slumber, twine
+requests==2.23.0          # via -r requirements/base.in, azure-storage-common, docker, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, slumber, snowflake-connector-python, twine
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.5                  # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via awscli, boto3
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, neotime, packaging, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, stevedore, tox, vertica-python, virtualenv
+six==1.15.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, docker, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, english, neotime, packaging, pansi, pgpy, pip-tools, prompt-toolkit, py2neo, pyjwkest, pynacl, pyopenssl, python-dateutil, readme-renderer, stevedore, tox, vertica-python, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.1      # via -r requirements/quality.in
-toml==0.10.1              # via tox
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
+testfixtures==6.15.0      # via -r requirements/quality.in
+toml==0.10.2              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
-tox==3.17.1               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.48.0              # via twine
+tox==3.20.1               # via -r requirements/dev-enterprise_data.in, tox-battery
+tqdm==4.52.0              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo, requests
-vertica-python==0.10.4    # via -r requirements/reporting.in
-virtualenv==20.0.27       # via tox
+urllib3==1.25.11          # via botocore, py2neo, requests, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
+virtualenv==20.1.0        # via tox
 wcwidth==0.2.5            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
-wheel==0.34.2             # via -r requirements/dev-enterprise_data.in
+websocket-client==0.57.0  # via docker
+wheel==0.35.1             # via -r requirements/dev-enterprise_data.in
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.1          # via -r requirements/pip_tools.in
+pip-tools==5.3.1          # via -r requirements/pip_tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -7,51 +7,58 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.4            # via virtualenv
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0             # via pytest
-awscli==1.18.100          # via -r requirements/reporting.in
+attrs==20.3.0             # via pytest
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-bleach==3.1.5             # via readme-renderer
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+bleach==3.2.1             # via readme-renderer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo, requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, edx-lint, pip-tools, py2neo
-colorama==0.4.3           # via awscli, py2neo
-coverage==5.2             # via pytest-cov
-cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy, pyjwt
+click==7.1.2              # via click-log, edx-lint, pip-tools
+colorama==0.4.3           # via awscli
+coverage==5.3             # via pytest-cov
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, django-fernet-fields, paramiko, pgpy, py2neo, pyjwt, pyopenssl, snowflake-connector-python
 ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
-diff-cover==3.0.1         # via -r requirements/dev-enterprise_data.in
+diff-cover==4.0.1         # via -r requirements/dev-enterprise_data.in
 distlib==0.3.1            # via virtualenv
-django-crum==0.7.6        # via edx-rbac
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
-djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via awscli, botocore, readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, rest-condition
+djangorestframework==3.12.2  # via drf-jwt, edx-drf-extensions, rest-condition
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli, readme-renderer
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev-enterprise_data.in
-edx-lint==1.5.0           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
+edx-lint==1.5.2           # via -r requirements/dev-enterprise_data.in, -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
-factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.1              # via factory-boy
+english==2020.7.0         # via py2neo
+factory-boy==3.1.0        # via -r requirements/test.in
+faker==4.15.0             # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 flaky==3.7.0              # via -r requirements/test.in
-freezegun==0.3.15         # via -r requirements/test.in
+freezegun==1.0.0          # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.0.0  # via inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.2.1  # via virtualenv
 inflect==3.0.2            # via jinja2-pluralize
+iniconfig==1.1.1          # via pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
@@ -61,76 +68,80 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.4.0     # via pytest
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.14.1.144      # via edx-django-utils
-packaging==20.4           # via bleach, pytest, tox
-paramiko==2.7.1           # via -r requirements/reporting.in
-path.py==12.4.0           # via edx-i18n-tools
+newrelic==5.22.1.152      # via edx-django-utils
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via bleach, py2neo, pytest, tox
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
+path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via pytest
-pbr==5.4.5                # via stevedore
-pgpy==0.5.2               # via -r requirements/reporting.in
-pip-tools==5.2.1          # via -r requirements/dev-enterprise_data.in
-pkginfo==1.5.0.1          # via twine
+pbr==5.5.1                # via stevedore
+pgpy==0.5.3               # via -r requirements/reporting.in
+pip-tools==5.3.1          # via -r requirements/dev-enterprise_data.in
+pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 prompt-toolkit==2.0.10    # via py2neo
-psutil==1.2.1             # via edx-django-utils
-py2neo==4.3.0             # via -r requirements/reporting.in
+psutil==5.7.3             # via edx-django-utils
+py2neo==2020.1.0          # via -r requirements/reporting.in
 py==1.9.0                 # via pytest, tox
 pyasn1==0.4.8             # via pgpy, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.in
-pygments==2.3.1           # via diff-cover, py2neo, readme-renderer
+pycryptodomex==3.9.9      # via pyjwkest, snowflake-connector-python
+pydocstyle==5.1.1         # via -r requirements/quality.in
+pygments==2.7.2           # via diff-cover, py2neo, readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client, snowflake-connector-python
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyminizip==0.2.4          # via -r requirements/reporting.in
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 pynacl==1.4.0             # via paramiko
+pyopenssl==19.1.0         # via snowflake-connector-python
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2020.1              # via celery, django, neotime, py2neo
+pytest-cov==2.10.1        # via -r requirements/test.in
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.1.2             # via pytest-cov, pytest-django
+python-dateutil==2.8.1    # via azure-storage-common, botocore, edx-drf-extensions, faker, freezegun, vertica-python
+pytz==2020.4              # via celery, django, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli, edx-i18n-tools
 readme-renderer==24.0     # via -c requirements/constraints.txt, twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, twine
-responses==0.10.15        # via -r requirements/test.in
+requests==2.23.0          # via -r requirements/base.in, azure-storage-common, docker, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, snowflake-connector-python, twine
+responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.5                  # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via awscli, boto3
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, python-dateutil, readme-renderer, responses, stevedore, tox, vertica-python, virtualenv
+six==1.15.0               # via -r requirements/base.in, astroid, bcrypt, bleach, cryptography, docker, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, english, mock, neotime, packaging, pansi, pathlib2, pgpy, pip-tools, prompt-toolkit, py2neo, pyjwkest, pynacl, pyopenssl, python-dateutil, readme-renderer, responses, stevedore, tox, vertica-python, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.1      # via -r requirements/quality.in, -r requirements/test.in
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
+testfixtures==6.15.0      # via -r requirements/quality.in, -r requirements/test.in
 text-unidecode==1.3       # via faker
-toml==0.10.1              # via tox
+toml==0.10.2              # via pytest, tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev-enterprise_data.in
-tox==3.17.1               # via -r requirements/dev-enterprise_data.in, tox-battery
-tqdm==4.48.0              # via twine
+tox==3.20.1               # via -r requirements/dev-enterprise_data.in, tox-battery
+tqdm==4.52.0              # via twine
 twine==1.15.0             # via -r requirements/dev-enterprise_data.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo, requests
-vertica-python==0.10.4    # via -r requirements/reporting.in
-virtualenv==20.0.27       # via tox
-wcwidth==0.2.5            # via prompt-toolkit, pytest
+urllib3==1.25.11          # via botocore, py2neo, requests, responses, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
+virtualenv==20.1.0        # via tox
+wcwidth==0.2.5            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
-wheel==0.34.2             # via -r requirements/dev-enterprise_data.in
+websocket-client==0.57.0  # via docker
+wheel==0.35.1             # via -r requirements/dev-enterprise_data.in
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/requirements/reporting.in
+++ b/requirements/reporting.in
@@ -1,8 +1,8 @@
 # Used for enterprise reporting
 -c constraints.txt
 
-awscli                                  # for assuming aws roles for sending email via SES
-boto3
+awscli==1.18.159                        # for assuming aws roles for sending email via SES
+boto3==1.15.18
 celery==3.1.18                          # Run task workers in other locations
 cryptography
 paramiko
@@ -11,3 +11,4 @@ py2neo
 pyminizip                               # Required for Enterprise Reporting
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 vertica-python                          # Required for Enterprise Reporting
+snowflake-connector-python              # Required for Enterprise Reporting

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -6,88 +6,99 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-attrs==19.3.0             # via pytest
-awscli==1.18.100          # via -r requirements/reporting.in
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
+attrs==20.3.0             # via pytest
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo, requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
 chardet==3.0.4            # via requests
-click==7.0                # via py2neo
-colorama==0.4.3           # via awscli, py2neo
-coverage==5.2             # via pytest-cov
-cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy, pyjwt
+colorama==0.4.3           # via awscli
+coverage==5.3             # via pytest-cov
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, django-fernet-fields, paramiko, pgpy, py2neo, pyjwt, pyopenssl, snowflake-connector-python
 ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
-django-crum==0.7.6        # via edx-rbac
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via awscli, botocore
-drf-jwt==1.16.2           # via edx-drf-extensions
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+djangorestframework==3.12.2  # via -r requirements/test-master.in, drf-jwt, edx-drf-extensions, rest-condition
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, -r requirements/test-master.in, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
-factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.1              # via factory-boy
+english==2020.7.0         # via py2neo
+factory-boy==3.1.0        # via -r requirements/test.in
+faker==4.15.0             # via factory-boy
 flaky==3.7.0              # via -r requirements/test.in
-freezegun==0.3.15         # via -r requirements/test.in
+freezegun==1.0.0          # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
 jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.4.0     # via pytest
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.14.1.144      # via edx-django-utils
-packaging==20.4           # via pytest
-paramiko==2.7.1           # via -r requirements/reporting.in
+newrelic==5.22.1.152      # via edx-django-utils
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via py2neo, pytest
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.5                # via stevedore
-pgpy==0.5.2               # via -r requirements/reporting.in
+pbr==5.5.1                # via stevedore
+pgpy==0.5.3               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest
 prompt-toolkit==2.0.10    # via py2neo
-psutil==1.2.1             # via edx-django-utils
-py2neo==4.3.0             # via -r requirements/reporting.in
+psutil==5.7.3             # via edx-django-utils
+py2neo==2020.1.0          # via -r requirements/reporting.in
 py==1.9.0                 # via pytest
 pyasn1==0.4.8             # via pgpy, rsa
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pygments==2.3.1           # via py2neo
+pycryptodomex==3.9.9      # via pyjwkest, snowflake-connector-python
+pygments==2.7.2           # via py2neo
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client, snowflake-connector-python
 pyminizip==0.2.4          # via -r requirements/reporting.in
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 pynacl==1.4.0             # via paramiko
+pyopenssl==19.1.0         # via snowflake-connector-python
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2020.1              # via celery, django, neotime, py2neo
+pytest-cov==2.10.1        # via -r requirements/test.in
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.1.2             # via pytest-cov, pytest-django
+python-dateutil==2.8.1    # via azure-storage-common, botocore, edx-drf-extensions, faker, freezegun, vertica-python
+pytz==2020.4              # via celery, django, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli
-requests==2.24.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.10.15        # via -r requirements/test.in
+requests==2.23.0          # via -r requirements/base.in, azure-storage-common, docker, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber, snowflake-connector-python
+responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.5                  # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via awscli, boto3
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
+six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, docker, edx-drf-extensions, edx-opaque-keys, edx-rbac, english, mock, neotime, packaging, pansi, pathlib2, pgpy, prompt-toolkit, py2neo, pyjwkest, pynacl, pyopenssl, python-dateutil, responses, stevedore, vertica-python, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.1      # via -r requirements/test.in
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
+testfixtures==6.15.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
+toml==0.10.2              # via pytest
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo, requests
-vertica-python==0.10.4    # via -r requirements/reporting.in
-wcwidth==0.2.5            # via prompt-toolkit, pytest
+urllib3==1.25.11          # via botocore, py2neo, requests, responses, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
+wcwidth==0.2.5            # via prompt-toolkit
+websocket-client==0.57.0  # via docker
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -7,63 +7,78 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.4            # via virtualenv
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
-awscli==1.18.100          # via -r requirements/reporting.in
+attrs==20.3.0             # via pytest
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
-click==7.0                # via py2neo
-colorama==0.4.3           # via awscli, py2neo
-coverage==5.2             # via pytest-cov
-cryptography==2.9.2       # via -r requirements/reporting.in, paramiko, pgpy
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
+chardet==3.0.4            # via requests
+colorama==0.4.3           # via awscli
+coverage==5.3             # via pytest-cov
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, paramiko, pgpy, py2neo, pyopenssl, snowflake-connector-python
 ddt==1.1.2                # via -c requirements/constraints.txt, -r requirements/test-reporting.in
 distlib==0.3.1            # via virtualenv
-docutils==0.15.2          # via awscli, botocore
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli
+english==2020.7.0         # via py2neo
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+idna==2.10                # via requests
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
+importlib-resources==3.2.1  # via virtualenv
 jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==2.0.0               # via -r requirements/test-reporting.in
-more-itertools==8.4.0     # via pytest
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
+more-itertools==8.6.0     # via pytest
 neotime==1.7.4            # via py2neo
-packaging==20.4           # via tox
-paramiko==2.7.1           # via -r requirements/reporting.in
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via py2neo, tox
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.5                # via mock
-pgpy==0.5.2               # via -r requirements/reporting.in
+pbr==5.5.1                # via mock
+pgpy==0.5.3               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest, tox
 prompt-toolkit==2.0.10    # via py2neo
-py2neo==4.3.0             # via -r requirements/reporting.in
+py2neo==2020.1.0          # via -r requirements/reporting.in
 py==1.9.0                 # via pytest, tox
 pyasn1==0.4.8             # via pgpy, rsa
 pycparser==2.20           # via cffi
-pygments==2.3.1           # via py2neo
+pycryptodomex==3.9.9      # via snowflake-connector-python
+pygments==2.7.2           # via py2neo
+pyjwt==1.7.1              # via snowflake-connector-python
 pyminizip==0.2.4          # via -r requirements/reporting.in
 pynacl==1.4.0             # via paramiko
+pyopenssl==19.1.0         # via snowflake-connector-python
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.5.1         # via -r requirements/test-reporting.in
 pytest==3.7.1             # via -r requirements/test-reporting.in, pytest-cov
-python-dateutil==2.8.1    # via botocore, vertica-python
-pytz==2020.1              # via celery, neotime, py2neo
+python-dateutil==2.8.1    # via azure-storage-common, botocore, vertica-python
+pytz==2020.4              # via celery, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli
+requests==2.23.0          # via azure-storage-common, docker, snowflake-connector-python
 rsa==4.5                  # via awscli
 s3transfer==0.3.3         # via awscli, boto3
-six==1.15.0               # via bcrypt, cryptography, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pynacl, pytest, python-dateutil, tox, vertica-python, virtualenv
-toml==0.10.1              # via tox
+six==1.15.0               # via bcrypt, cryptography, docker, english, mock, neotime, packaging, pansi, pathlib2, pgpy, prompt-toolkit, py2neo, pynacl, pyopenssl, pytest, python-dateutil, tox, vertica-python, virtualenv, websocket-client
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+toml==0.10.2              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/test-reporting.in
-tox==3.17.1               # via -r requirements/test-reporting.in, tox-battery
+tox==3.20.1               # via -r requirements/test-reporting.in, tox-battery
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo
-vertica-python==0.10.4    # via -r requirements/reporting.in
-virtualenv==20.0.27       # via tox
+urllib3==1.25.11          # via botocore, py2neo, requests, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
+virtualenv==20.1.0        # via tox
 wcwidth==0.2.5            # via prompt-toolkit
+websocket-client==0.57.0  # via docker
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,89 +6,100 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-attrs==19.3.0             # via pytest
-awscli==1.18.100          # via -r requirements/reporting.in
+asn1crypto==1.4.0         # via oscrypto, snowflake-connector-python
+attrs==20.3.0             # via pytest
+awscli==1.18.159          # via -r requirements/reporting.in
+azure-common==1.1.26      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-storage-blob==2.1.0  # via snowflake-connector-python
+azure-storage-common==2.1.0  # via azure-storage-blob
 bcrypt==3.1.7             # via paramiko
 billiard==3.3.0.23        # via celery
-boto3==1.14.23            # via -r requirements/reporting.in
-botocore==1.17.23         # via awscli, boto3, s3transfer
+boto3==1.15.18            # via -r requirements/reporting.in, snowflake-connector-python
+botocore==1.18.18         # via awscli, boto3, s3transfer
 celery==3.1.18            # via -r requirements/reporting.in
-certifi==2020.6.20        # via py2neo, requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
+certifi==2020.11.8        # via py2neo, requests, snowflake-connector-python
+cffi==1.14.3              # via bcrypt, cryptography, pynacl, snowflake-connector-python
 chardet==3.0.4            # via requests
-click==7.0                # via py2neo
-colorama==0.4.3           # via awscli, py2neo
-coverage==5.2             # via pytest-cov
-cryptography==2.9.2       # via -r requirements/reporting.in, django-fernet-fields, paramiko, pgpy, pyjwt
+colorama==0.4.3           # via awscli
+coverage==5.3             # via pytest-cov
+cryptography==3.2.1       # via -r requirements/reporting.in, azure-storage-common, django-fernet-fields, paramiko, pgpy, py2neo, pyjwt, pyopenssl, snowflake-connector-python
 ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
-django-crum==0.7.6        # via edx-rbac
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, -r requirements/test.in, edx-rbac
-django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
-djangorestframework==3.11.0  # via drf-jwt, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via awscli, botocore
-drf-jwt==1.16.2           # via edx-drf-extensions
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-fernet-fields, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-rbac, rest-condition
+djangorestframework==3.12.2  # via drf-jwt, edx-drf-extensions, rest-condition
+docker==4.3.1             # via py2neo
+docutils==0.15.2          # via awscli
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
-factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.1              # via factory-boy
+english==2020.7.0         # via py2neo
+factory-boy==3.1.0        # via -r requirements/test.in
+faker==4.15.0             # via factory-boy
 flaky==3.7.0              # via -r requirements/test.in
-freezegun==0.3.15         # via -r requirements/test.in
+freezegun==1.0.0          # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
 jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via celery
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.4.0     # via pytest
-neobolt==1.7.17           # via py2neo
+monotonic==1.5            # via py2neo
 neotime==1.7.4            # via py2neo
-newrelic==5.14.1.144      # via edx-django-utils
-packaging==20.4           # via pytest
-paramiko==2.7.1           # via -r requirements/reporting.in
+newrelic==5.22.1.152      # via edx-django-utils
+oscrypto==1.2.1           # via snowflake-connector-python
+packaging==20.4           # via py2neo, pytest
+pansi==2020.7.3           # via py2neo
+paramiko==2.7.2           # via -r requirements/reporting.in
 pathlib2==2.3.5           # via pytest
-pbr==5.4.5                # via stevedore
-pgpy==0.5.2               # via -r requirements/reporting.in
+pbr==5.5.1                # via stevedore
+pgpy==0.5.3               # via -r requirements/reporting.in
 pluggy==0.13.1            # via pytest
 prompt-toolkit==2.0.10    # via py2neo
-psutil==1.2.1             # via edx-django-utils
-py2neo==4.3.0             # via -r requirements/reporting.in
+psutil==5.7.3             # via edx-django-utils
+py2neo==2020.1.0          # via -r requirements/reporting.in
 py==1.9.0                 # via pytest
 pyasn1==0.4.8             # via pgpy, rsa
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pygments==2.3.1           # via py2neo
+pycryptodomex==3.9.9      # via pyjwkest, snowflake-connector-python
+pygments==2.7.2           # via py2neo
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-rest-api-client, snowflake-connector-python
 pyminizip==0.2.4          # via -r requirements/reporting.in
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 pynacl==1.4.0             # via paramiko
+pyopenssl==19.1.0         # via snowflake-connector-python
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via botocore, edx-drf-extensions, faker, freezegun, vertica-python
-pytz==2020.1              # via celery, django, neotime, py2neo
+pytest-cov==2.10.1        # via -r requirements/test.in
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.1.2             # via pytest-cov, pytest-django
+python-dateutil==2.8.1    # via azure-storage-common, botocore, edx-drf-extensions, faker, freezegun, vertica-python
+pytz==2020.4              # via celery, django, neotime, py2neo, snowflake-connector-python
 pyyaml==5.3.1             # via awscli
-requests==2.24.0          # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.10.15        # via -r requirements/test.in
+requests==2.23.0          # via -r requirements/base.in, azure-storage-common, docker, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber, snowflake-connector-python
+responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.5                  # via awscli
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via awscli, boto3
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, neotime, packaging, pathlib2, pgpy, prompt-toolkit, pyjwkest, pynacl, python-dateutil, responses, stevedore, vertica-python
+six==1.15.0               # via -r requirements/base.in, bcrypt, cryptography, docker, edx-drf-extensions, edx-opaque-keys, edx-rbac, english, mock, neotime, packaging, pansi, pathlib2, pgpy, prompt-toolkit, py2neo, pyjwkest, pynacl, pyopenssl, python-dateutil, responses, stevedore, vertica-python, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
-testfixtures==6.14.1      # via -r requirements/test.in
+snowflake-connector-python==2.3.6  # via -r requirements/reporting.in
+sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
+testfixtures==6.15.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
+toml==0.10.2              # via pytest
 unicodecsv==0.14.1        # via -r requirements/reporting.in
-urllib3==1.24.3           # via botocore, py2neo, requests
-vertica-python==0.10.4    # via -r requirements/reporting.in
-wcwidth==0.2.5            # via prompt-toolkit, pytest
+urllib3==1.25.11          # via botocore, py2neo, requests, responses, snowflake-connector-python
+vertica-python==1.0.0     # via -r requirements/reporting.in
+wcwidth==0.2.5            # via prompt-toolkit
+websocket-client==0.57.0  # via docker
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,24 +5,24 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.6.20        # via requests
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.8            # via -r requirements/travis.in
-coverage==5.2             # via codecov
+codecov==2.1.10           # via -r requirements/travis.in
+coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
+importlib-resources==3.2.1  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.24.0          # via codecov
+requests==2.25.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
+toml==0.10.2              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
-tox==3.17.1               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.9           # via requests
-virtualenv==20.0.27       # via tox
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
+urllib3==1.26.2           # via requests
+virtualenv==20.1.0        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
related ticket: https://github.com/edx/edx-enterprise/pull/1042
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
