### PR TITLE
WIP: Pin bcrypt version <3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,8 +53,9 @@ chardet==3.0.4
     # via requests
 colorama==0.4.3
     # via awscli
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   django-fernet-fields

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,8 +20,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 boto3==1.15.18

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -187,7 +187,7 @@ pymongo==3.11.2
     # via edx-opaque-keys
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -255,8 +255,10 @@ six==1.15.0
     #   websocket-client
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,3 +21,6 @@ tox-battery==0.5.2
 
 # Constrain until https://github.com/datadriventests/ddt/issues/83 is fixed.
 ddt<1.4.0
+
+# bcrypt>=3.2.0 dropped support for python35 which is still required in enterprise-data-reporting jobs.
+bcrypt<3.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,3 +27,5 @@ ddt<1.4.0
 bcrypt<3.2
 # cryptography>=3.3
 cryptography<3.3
+# snowflake-connector-python>=2.3.7
+snowflake-connector-python<2.3.7

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,5 +22,8 @@ tox-battery==0.5.2
 # Constrain until https://github.com/datadriventests/ddt/issues/83 is fixed.
 ddt<1.4.0
 
-# bcrypt>=3.2.0 dropped support for python35 which is still required in enterprise-data-reporting jobs.
+# Following versions dropped support for python35 which is still required in enterprise-data-reporting jobs.
+# bcrypt>=3.2.0
 bcrypt<3.2
+# cryptography>=3.3
+cryptography<3.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -70,8 +70,9 @@ colorama==0.4.3
     # via
     #   awscli
     #   twine
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   django-fernet-fields

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -281,7 +281,7 @@ pymongo==3.11.2
     # via edx-opaque-keys
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -370,8 +370,10 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.0.0
     # via pydocstyle
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,8 +26,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 bleach==3.2.1
@@ -389,7 +391,7 @@ tox==3.20.1
     # via
     #   -r requirements/dev-enterprise_data.in
     #   tox-battery
-tqdm==4.55.0
+tqdm==4.55.1
     # via twine
 twine==3.3.0
     # via -r requirements/dev-enterprise_data.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,8 +28,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 bleach==3.2.1
@@ -433,7 +435,7 @@ tox==3.20.1
     # via
     #   -r requirements/dev-enterprise_data.in
     #   tox-battery
-tqdm==4.55.0
+tqdm==4.55.1
     # via twine
 twine==3.3.0
     # via -r requirements/dev-enterprise_data.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -74,8 +74,9 @@ colorama==0.4.3
     #   twine
 coverage==5.3.1
     # via pytest-cov
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   django-fernet-fields

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -306,7 +306,7 @@ pymongo==3.11.2
     # via edx-opaque-keys
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -409,8 +409,10 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.0.0
     # via pydocstyle
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -57,8 +57,9 @@ colorama==0.4.3
     # via awscli
 coverage==5.3.1
     # via pytest-cov
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   django-fernet-fields

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -216,7 +216,7 @@ pymongo==3.11.2
     # via edx-opaque-keys
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -298,8 +298,10 @@ six==1.15.0
     #   websocket-client
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -22,8 +22,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 boto3==1.15.18

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -151,7 +151,7 @@ pyminizip==0.2.4
     # via -r requirements/reporting.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -210,8 +210,10 @@ six==1.15.0
     #   vertica-python
     #   virtualenv
     #   websocket-client
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 toml==0.10.2
     # via tox
 tox-battery==0.5.2

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -61,8 +61,9 @@ colorama==0.4.3
     # via awscli
 coverage==5.3.1
     # via pytest-cov
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   paramiko

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -26,8 +26,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 boto3==1.15.18

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,8 +57,9 @@ colorama==0.4.3
     # via awscli
 coverage==5.3.1
     # via pytest-cov
-cryptography==3.3.1
+cryptography==3.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/reporting.in
     #   azure-storage-blob
     #   django-fernet-fields

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -214,7 +214,7 @@ pymongo==3.11.2
     # via edx-opaque-keys
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.1
     # via snowflake-connector-python
 pyparsing==2.4.7
     # via packaging
@@ -296,8 +296,10 @@ six==1.15.0
     #   websocket-client
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==2.3.7
-    # via -r requirements/reporting.in
+snowflake-connector-python==2.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/reporting.in
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,8 +22,10 @@ azure-core==1.9.0
     # via azure-storage-blob
 azure-storage-blob==12.6.0
     # via snowflake-connector-python
-bcrypt==3.2.0
-    # via paramiko
+bcrypt==3.1.7
+    # via
+    #   -c requirements/constraints.txt
+    #   paramiko
 billiard==3.3.0.23
     # via celery
 boto3==1.15.18


### PR DESCRIPTION
After merging the https://github.com/edx/edx-enterprise-data/pull/217, the [Enterprise reporting job](https://tools-edx-jenkins.edx.org/job/enterprise/job/enterprise-data-reporting/) started failing because of python version conflict. 
So, pinned the versions required by `python35` unless the job is upgraded to run with `python38` instead. 