### PR TITLE
Updated file location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[2.1.5] - 2021-03-10
+--------------------
+* Updated S3 Object locations for Pearson reports.
+
 [2.1.4] - 2021-01-07
 --------------------
 * added `engagement` in DATA_TYPES.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -157,7 +157,7 @@ class EnterpriseReportSender:
             LOGGER.debug('Fetching enterprise grade report from S3')
             # temporarily adding file path for PEARSON
             s3_client.get_enterprise_report(
-                'PEARSON/ENT_REPORT_PEARSON_PERSISTENTSUBSECTIONGRADE.csv',
+                'PEARSON/ENT_REPORT_PEARSON_PERSISTENTSUBSECTIONGRADE/ENT_REPORT_PEARSON_PERSISTENTSUBSECTIONGRADE.csv',
                 data_report_file
             )
         return [data_report_file]
@@ -168,7 +168,10 @@ class EnterpriseReportSender:
         with open(self.data_report_file_name, 'wb') as data_report_file:
             LOGGER.debug('Fetching enterprise course structure report from S3')
             # temporarily adding file path for PEARSON
-            s3_client.get_enterprise_report('PEARSON/ENT_REPORT_PEARSON_COURSE_METRICS.csv', data_report_file)
+            s3_client.get_enterprise_report(
+                'PEARSON/ENT_REPORT_PEARSON_COURSE_METRICS/ENT_REPORT_PEARSON_COURSE_METRICS.csv',
+                data_report_file
+            )
         return [data_report_file]
 
     def _generate_enterprise_report_completion_csv(self):
@@ -177,7 +180,10 @@ class EnterpriseReportSender:
         with open(self.data_report_file_name, 'wb') as data_report_file:
             LOGGER.debug('Fetching enterprise completion report from S3')
             # temporarily adding file path for PEARSON
-            s3_client.get_enterprise_report('PEARSON/ENT_REPORT_PEARSON_BLOCK_COMPLETION.csv', data_report_file)
+            s3_client.get_enterprise_report(
+                'PEARSON/ENT_REPORT_PEARSON_BLOCK_COMPLETION/ENT_REPORT_PEARSON_BLOCK_COMPLETION.csv',
+                data_report_file
+            )
         return [data_report_file]
 
     def _generate_enterprise_report_progress_v2_csv(self):


### PR DESCRIPTION
Updated the file location, now that we are creating a separate
sub-folder for each table copied from Snowflake.

ENT-4266

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
