### PR TITLE
feat: Update default database selection for Analytics API V1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 =========================
 
+[2.2.15] - 2021-07-08
+--------------------
+* Update default database selection for Analytics API V1
+* Update filter backend queryset for Audit enrollments
+
 [2.2.14] - 2021-07-07
 --------------------
 * Update logs

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "2.2.14"
+__version__ = "2.2.15"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -120,17 +120,11 @@ class AuditUsersEnrollmentFilterBackend(filters.BaseFilterBackend, FiltersMixin)
             if not enable_audit_data_reporting:
                 audit_enrollments_enterprise_user_ids = EnterpriseLearnerEnrollment.objects.filter(
                     enterprise_customer_uuid=view.kwargs['enterprise_id'],
-                    user_current_enrollment_mode="audit"
+                    enterprise_user_id__isnull=False,
+                    user_current_enrollment_mode="audit",
                 ).values_list(
                     'enterprise_user_id',
                     flat=True
-                )
-                audit_enrollments_enterprise_user_ids = list(audit_enrollments_enterprise_user_ids)
-                LOGGER.info(
-                    "[ELV_ANALYTICS_API_V1] Enterprise: [%s], AuditDataReporting: [%s], AuditEnrollments: [%s]",
-                    enterprise_id,
-                    enable_audit_data_reporting,
-                    len(audit_enrollments_enterprise_user_ids)
                 )
                 queryset = queryset.exclude(enterprise_user_id__in=audit_enrollments_enterprise_user_ids)
 

--- a/enterprise_data/models.py
+++ b/enterprise_data/models.py
@@ -17,14 +17,11 @@ class EnterpriseReportingModelManager(models.Manager):
     Custom ModelManager for every model that wants to use `enterprise_reporting` database.
     """
 
-    def get_queryset(self):
+    def db_manager(self, using=None, hints=None):  # pylint: disable=unused-argument
         """
         Override to use the `enterprise_reporting` database instead of default.
         """
-        qs = super().get_queryset()
-        qs = qs.using(settings.ENTERPRISE_REPORTING_DB_ALIAS)
-
-        return qs
+        return super().db_manager(using=settings.ENTERPRISE_REPORTING_DB_ALIAS, hints=hints)
 
 
 class EnterpriseLearner(models.Model):


### PR DESCRIPTION
Update filter backend queryset for Audit enrollments

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
