### PR TITLE
feat: include all fields in api v1 response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[2.2.18] - 2021-07-27
+---------------------
+* Include all fields in Analytics API V1 response
+
 [2.2.17] - 2021-07-15
 ---------------------
 * Update the edx-rbac from 1.3.3 to 1.5.0

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "2.2.17"
+__version__ = "2.2.18"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -14,6 +14,9 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
     """
     course_api_url = serializers.SerializerMethodField()
     has_passed = serializers.BooleanField(default=False, write_only=True)
+    enterprise_user_id = serializers.SerializerMethodField()
+    # TODO: below fields should be removed once admin-portal is switched to V1
+    # and code has been updated to handle fields with new names
     consent_granted = serializers.BooleanField(source='is_consent_granted')
     enrollment_created_timestamp = serializers.DateField(source='enrollment_date')
     unenrollment_timestamp = serializers.DateField(source='unenrollment_date')
@@ -29,14 +32,13 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = EnterpriseLearnerEnrollment
-        fields = (
-            'course_api_url', 'has_passed', 'consent_granted', 'enrollment_created_timestamp',
-            'unenrollment_timestamp', 'offer', 'course_price', 'discount_price', 'course_id',
-            'course_start', 'course_end', 'passed_timestamp', 'enterprise_id', 'user_account_creation_timestamp',
-            'user_current_enrollment_mode', 'coupon_code', 'coupon_name', 'course_key', 'course_title',
-            'course_pacing_type', 'course_duration_weeks', 'course_max_effort', 'course_min_effort',
-            'last_activity_date', 'progress_status', 'current_grade', 'letter_grade', 'user_country_code',
-            'user_email', 'user_username', 'enterprise_name', 'enterprise_sso_uid', 'enterprise_user_id',
+        exclude = (
+            'enterprise_user', 'created',
+            # TODO: below fields should be removed once admin-portal is switched to V1
+            # and code has been updated to handle fields with new names
+            'is_consent_granted', 'enrollment_date', 'unenrollment_date', 'offer_type',
+            'course_list_price', 'amount_learner_paid', 'courserun_key', 'course_start_date',
+            'course_end_date', 'passed_date', 'enterprise_customer_uuid', 'user_account_creation_date',
         )
 
     def get_course_api_url(self, obj):
@@ -44,6 +46,10 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
         return '/enterprise/v1/enterprise-catalogs/{enterprise_customer_uuid}/courses/{courserun_key}'.format(
             enterprise_customer_uuid=obj.enterprise_customer_uuid, courserun_key=obj.courserun_key
         )
+
+    def get_enterprise_user_id(self, obj):
+        """Returns enterprise user id of a learner's enrollment"""
+        return obj.enterprise_user_id
 
 
 class EnterpriseLearnerSerializer(serializers.ModelSerializer):

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -68,6 +68,46 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ModelViewSe
     ENROLLMENT_MODE_FILTER = 'user_current_enrollment_mode'
     COUPON_CODE_FILTER = 'coupon_code'
     OFFER_FILTER = 'offer_type'
+    # This will be used as CSV header. We are using a custom header to output csv columns in desired order.
+    # By default, csv renderer will output fields in sorted order.
+    header = [
+        'enrollment_id', 'enterprise_enrollment_id', 'consent_granted', 'paid_by',
+        'user_current_enrollment_mode', 'enrollment_created_timestamp', 'unenrollment_timestamp',
+        'unenrollment_end_within_date', 'is_refunded', 'seat_delivery_method',
+        'offer_name', 'offer', 'coupon_code', 'coupon_name', 'contract_id',
+        'course_price', 'discount_price', 'course_key', 'course_id',
+        'course_title', 'course_pacing_type', 'course_start', 'course_end',
+        'course_duration_weeks', 'course_max_effort', 'course_min_effort',
+        'course_primary_program', 'course_primary_subject', 'has_passed',
+        'last_activity_date', 'progress_status', 'passed_timestamp', 'current_grade',
+        'letter_grade', 'enterprise_user_id', 'user_email', 'user_account_creation_timestamp',
+        'user_country_code', 'user_username', 'enterprise_name', 'enterprise_id',
+        'enterprise_sso_uid', 'created', 'course_api_url',
+    ]
+    # TODO: below labels dict should be removed once admin-portal is switched to V1
+    # and code has been updated to handle fields with new names. For each key, the
+    # corresponding header in header list above should be update with key value
+    # Custom labels. Each key corresponds to the header and the value corresponds to the custom label for that header
+    labels = {
+        'consent_granted': 'is_consent_granted',
+        'enrollment_created_timestamp': 'enrollment_date',
+        'unenrollment_timestamp': 'unenrollment_date',
+        'offer': 'offer_type',
+        'course_price': 'course_list_price',
+        'discount_price': 'amount_learner_paid',
+        'course_id': 'courserun_key',
+        'course_start': 'course_start_date',
+        'course_end': 'course_end_date',
+        'passed_timestamp': 'passed_date',
+        'enterprise_id': 'enterprise_customer_uuid',
+        'user_account_creation_timestamp': 'user_account_creation_date',
+    }
+
+    def get_renderer_context(self):
+        renderer_context = super().get_renderer_context()
+        renderer_context['header'] = self.header
+        renderer_context['labels'] = self.labels
+        return renderer_context
 
     def get_queryset(self):
         """


### PR DESCRIPTION
**Description:**
* Add all fields in API V1 response
* Add `header` and `labels` attributes for use in CSV renderer. Please [see](https://github.com/mjumbewu/django-rest-framework-csv) how header and labels work together.
* See related changes in https://github.com/edx/edx-analytics-data-api/pull/461

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
