### PR TITLE
[Fix] Update the ref_name of the serializers with the same name in v0 and v1 of the enterprise data api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[2.2.20] - 2021-08-13
+---------------------
+* Add ref_name to the same named serializers in v0 and v1 of enterprise data
+
 [2.2.19] - 2021-08-04
 ---------------------
 * Include `has_passed` field in API V1 response

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "2.2.19"
+__version__ = "2.2.20"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/serializers.py
+++ b/enterprise_data/api/v0/serializers.py
@@ -82,5 +82,8 @@ class LearnerCompletedCoursesSerializer(serializers.Serializer):    # pylint: di
     """
     Serializer for learner's completed courses.
     """
+    class Meta:
+        ref_name = 'v0.LearnerCompletedCoursesSerializer'
+
     user_email = serializers.EmailField()
     completed_courses = serializers.IntegerField()

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -82,5 +82,8 @@ class LearnerCompletedCoursesSerializer(serializers.Serializer):    # pylint: di
     """
     Serializer for learner's completed courses.
     """
+    class Meta:
+        ref_name = 'v1.LearnerCompletedCoursesSerializer'
+
     user_email = serializers.EmailField()
     completed_courses = serializers.IntegerField()


### PR DESCRIPTION
The reason this needs to be done is because, drf_yasg, which is the library to generate swagger docs, have trouble with the same name of the two serializers in v0 and v1 of the API version

**Merge checklist:**
- [x] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
