### PR TITLE
feat: api gateway spec for LPR V1 API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[3.2.0] - 2021-09-17
+---------------------
+  * Add api gateway spec for LPR V1 API
+
 [3.1.0] - 2021-09-16
 ---------------------
   * add `primary_program_type` field in EnterpriseLearnerEnrollment

--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -8,6 +8,7 @@
 #
 # Available service endpoints -- note that alternate endpoints may be presented at the API Gateway tier:
 # GET /v1/enterprise-customer/{uuid}/learner-summary/
+# GET /v2/enterprise-customer/{uuid}/learner-summary/
 
 apigateway_responses_with_mapping_template_for_uuid: &apigateway_responses_with_mapping_template_for_uuid
   default:
@@ -116,3 +117,18 @@ endpoints:
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_enterprise_customer_learner_summary
             uri: "https://${stageVariables.analytics_api_host}/enterprise/api/v0/enterprise/{uuid}/enrollments/"
+  v2:
+    # GET /v3/enterprise-customer/{uuid}/learner-summary/
+    enterpriseCustomerLearnerSummary:
+        get:
+          produces: *produces
+          parameters:
+            - *auth_header
+            - *uuid_parameter
+            - *page_qs_parameter
+            - *page_size_qs_parameter
+          operationId: "get_enterprise_customer_learner_summary"
+          responses: *responses
+          x-amazon-apigateway-integration:
+            <<: *apigateway_integration_enterprise_customer_learner_summary
+            uri: "https://${stageVariables.analytics_api_host}/enterprise/api/v1/enterprise/{uuid}/enrollments/"

--- a/api.yaml
+++ b/api.yaml
@@ -1,10 +1,10 @@
 # This file is a "de-compacted" version of api-compact.yaml. The consuming tools are unable to process YAML anchors.
 # This file was generated using http://www.yamllint.com/.
 
---- 
-apigateway_responses_with_mapping_template_for_uuid: 
-  200: 
-    responseTemplates: 
+---
+apigateway_responses_with_mapping_template_for_uuid:
+  200:
+    responseTemplates:
       application/json: |
           #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($uuid = $input.params('uuid'))
           #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceUuidMatch = "{uuid}")
@@ -15,77 +15,77 @@ apigateway_responses_with_mapping_template_for_uuid:
             "results": $inputRoot.results
           }
     statusCode: "200"
-  401: 
+  401:
     statusCode: "401"
-  403: 
+  403:
     statusCode: "403"
-  404: 
+  404:
     statusCode: "404"
-  429: 
+  429:
     statusCode: "429"
-  500: 
+  500:
     statusCode: "500"
-  default: 
+  default:
     statusCode: "400"
-auth_header: 
+auth_header:
   in: header
   name: Authorization
   required: true
   type: string
-endpoints: 
-  v1: 
-    enterpriseCustomerLearnerSummary: 
-      get: 
+endpoints:
+  v1:
+    enterpriseCustomerLearnerSummary:
+      get:
         operationId: get_enterprise_customer_learner_summary
-        parameters: 
-          - 
+        parameters:
+          -
             in: header
             name: Authorization
             required: true
             type: string
-          - 
+          -
             in: path
             name: uuid
             required: true
             type: string
-          - 
+          -
             in: query
             name: page
             required: false
             type: number
-          - 
+          -
             in: query
             name: page_size
             required: false
             type: number
-        produces: 
+        produces:
           - application/json
           - application/csv
-        responses: 
-          200: 
+        responses:
+          200:
             description: OK
-          400: 
+          400:
             description: "Bad Request"
-          401: 
+          401:
             description: Unauthorized
-          403: 
+          403:
             description: Forbidden
-          404: 
+          404:
             description: "Not Found"
-          429: 
+          429:
             description: "Too Many Requests"
-          500: 
+          500:
             description: "Internal Server Error"
-        x-amazon-apigateway-integration: 
+        x-amazon-apigateway-integration:
           httpMethod: GET
-          requestParameters: 
+          requestParameters:
             integration.request.header.Authorization: method.request.header.Authorization
             integration.request.path.uuid: method.request.path.uuid
             integration.request.querystring.page: method.request.querystring.page
             integration.request.querystring.page_size: method.request.querystring.page_size
-          responses: 
-            200: 
-              responseTemplates: 
+          responses:
+            200:
+              responseTemplates:
                 application/json: |
                     #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($uuid = $input.params('uuid'))
                     #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceUuidMatch = "{uuid}")
@@ -96,63 +96,140 @@ endpoints:
                       "results": $inputRoot.results
                     }
               statusCode: "200"
-            401: 
+            401:
               statusCode: "401"
-            403: 
+            403:
               statusCode: "403"
-            404: 
+            404:
               statusCode: "404"
-            429: 
+            429:
               statusCode: "429"
-            500: 
+            500:
               statusCode: "500"
-            default: 
+            default:
               statusCode: "400"
           type: http
           uri: "https://${stageVariables.analytics_api_host}/enterprise/api/v0/enterprise/{uuid}/enrollments/"
-page_qs_parameter: 
+  v2:
+    enterpriseCustomerLearnerSummary:
+      get:
+        operationId: get_enterprise_customer_learner_summary
+        parameters:
+          -
+            in: header
+            name: Authorization
+            required: true
+            type: string
+          -
+            in: path
+            name: uuid
+            required: true
+            type: string
+          -
+            in: query
+            name: page
+            required: false
+            type: number
+          -
+            in: query
+            name: page_size
+            required: false
+            type: number
+        produces:
+          - application/json
+          - application/csv
+        responses:
+          200:
+            description: OK
+          400:
+            description: "Bad Request"
+          401:
+            description: Unauthorized
+          403:
+            description: Forbidden
+          404:
+            description: "Not Found"
+          429:
+            description: "Too Many Requests"
+          500:
+            description: "Internal Server Error"
+        x-amazon-apigateway-integration:
+          httpMethod: GET
+          requestParameters:
+            integration.request.header.Authorization: method.request.header.Authorization
+            integration.request.path.uuid: method.request.path.uuid
+            integration.request.querystring.page: method.request.querystring.page
+            integration.request.querystring.page_size: method.request.querystring.page_size
+          responses:
+            200:
+              responseTemplates:
+                application/json: |
+                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($uuid = $input.params('uuid'))
+                    #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceUuidMatch = "{uuid}")
+                    {
+                      "count": $inputRoot.count,
+                      "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceUuidMatch, $uuid)",
+                      "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceUuidMatch, $uuid)",
+                      "results": $inputRoot.results
+                    }
+              statusCode: "200"
+            401:
+              statusCode: "401"
+            403:
+              statusCode: "403"
+            404:
+              statusCode: "404"
+            429:
+              statusCode: "429"
+            500:
+              statusCode: "500"
+            default:
+              statusCode: "400"
+          type: http
+          uri: "https://${stageVariables.analytics_api_host}/enterprise/api/v1/enterprise/{uuid}/enrollments/"
+page_qs_parameter:
   in: query
   name: page
   required: false
   type: number
-page_size_qs_parameter: 
+page_size_qs_parameter:
   in: query
   name: page_size
   required: false
   type: number
-produces: 
+produces:
   - application/json
   - application/csv
-responses: 
-  200: 
+responses:
+  200:
     description: OK
-  400: 
+  400:
     description: "Bad Request"
-  401: 
+  401:
     description: Unauthorized
-  403: 
+  403:
     description: Forbidden
-  404: 
+  404:
     description: "Not Found"
-  429: 
+  429:
     description: "Too Many Requests"
-  500: 
+  500:
     description: "Internal Server Error"
-uuid_parameter: 
+uuid_parameter:
   in: path
   name: uuid
   required: true
   type: string
-x-amazon-apigateway-integration-enterprise-customer-learner-summary: 
+x-amazon-apigateway-integration-enterprise-customer-learner-summary:
   httpMethod: GET
-  requestParameters: 
+  requestParameters:
     integration.request.header.Authorization: method.request.header.Authorization
     integration.request.path.uuid: method.request.path.uuid
     integration.request.querystring.page: method.request.querystring.page
     integration.request.querystring.page_size: method.request.querystring.page_size
-  responses: 
-    200: 
-      responseTemplates: 
+  responses:
+    200:
+      responseTemplates:
         application/json: |
             #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($uuid = $input.params('uuid'))
             #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceUuidMatch = "{uuid}")
@@ -163,16 +240,16 @@ x-amazon-apigateway-integration-enterprise-customer-learner-summary:
               "results": $inputRoot.results
             }
       statusCode: "200"
-    401: 
+    401:
       statusCode: "401"
-    403: 
+    403:
       statusCode: "403"
-    404: 
+    404:
       statusCode: "404"
-    429: 
+    429:
       statusCode: "429"
-    500: 
+    500:
       statusCode: "500"
-    default: 
+    default:
       statusCode: "400"
   type: http

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Add api gateway spec for version v3 of `learner-summary` endpoint so that LPR V1 API can be accessed through new learner-summary endpoint.

**JIRA:** https://openedx.atlassian.net/browse/ENT-4881

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
