### PR TITLE
feat!: advertise constraints when packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[3.4.0] - 2021-10-22
+---------------------
+  * Advertise constraints when packaging
+
 [3.3.0] - 2021-09-21
 ---------------------
   * Added support for Django32

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ import sys
 
 from setuptools import setup
 
+# groups "my-package-name<=x.y.z,..." into ("my-package-name", "<=x.y.z,...")
+requirement_line_regex = re.compile(r"([a-zA-Z0-9-]+)([<>=][^#\s]+)?")
 
 def get_version(*file_paths):
     """
@@ -31,17 +33,46 @@ if sys.argv[-1] == "tag":
 
 def load_requirements(*requirements_paths):
     """
-    Load all requirements from the specified requirements files.
+    Load all requirements from the specified requirements files, including any constraints from other files that
+    are pulled in.
     Returns a list of requirement strings.
     """
-    requirements = set()
+    requirements = {}
+    constraint_files = set()
+
+    def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
+        regex_match = requirement_line_regex.match(current_line)
+        if regex_match:
+            package = regex_match.group(1)
+            version_constraints = regex_match.group(2)
+            existing_version_constraints = current_requirements.get(package, None)
+            # it's fine to add constraints to an unconstrained package, but raise an error if there are already
+            # constraints in place
+            if existing_version_constraints and existing_version_constraints != version_constraints:
+                raise BaseException('Multiple constraint definitions found for {}: "{}" and "{}".'
+                                    .format(package, existing_version_constraints, version_constraints))
+            if add_if_not_present or package in current_requirements:
+                current_requirements[package] = version_constraints
+
+    # process .in files and store the path to any constraint files that are pulled in
     for path in requirements_paths:
         with open(path) as reqs:
-            requirements.update(
-                line.split('#')[0].strip() for line in reqs
-                if is_requirement(line.strip())
-            )
-    return list(requirements)
+            for line in reqs:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, True)
+                # ignore non-local constraint files
+                if line and line.startswith('-c') and not line.startswith('-c http'):
+                    constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
+
+    # process constraint files and add any new constraints found to existing requirements
+    for constraint_file in constraint_files:
+        with open(constraint_file) as reader:
+            for line in reader:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, False)
+
+    # process back into list of "pkg><=constraints" strings
+    return ['{}{}'.format(pkg, version or '') for (pkg, version) in requirements.items()]
 
 
 def is_requirement(line):
@@ -49,7 +80,7 @@ def is_requirement(line):
     Return True if the requirement line is a package requirement;
     that is, it is not blank, a comment, a URL, or an included file.
     """
-    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
+    return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 
 setup(


### PR DESCRIPTION
Updates setup.py to read constraints files as well when generating metadata about requirements. This will enable library users to more quickly see if an upgrade is compatible with current requirements.

Before, edx_enterprise_data.egg-info/requires.txt looked like:
```
edx-django-utils
requests
rules
edx-drf-extensions
edx-rbac
django-fernet-fields
edx-opaque-keys
edx-rest-api-client
Django
django-model-utils

[reporting]
paramiko
PGPy
celery==3.1.18
vertica-python
pyminizip
snowflake-connector-python
py2neo
awscli==1.18.159
boto3==1.15.18
unicodecsv==0.14.1
cryptography
```

After the change:
```
requests
edx-rest-api-client
edx-django-utils
edx-drf-extensions
edx-opaque-keys
Django<2.3,>=2.2
django-fernet-fields
django-model-utils
edx-rbac
rules

[reporting]
awscli==1.18.159
boto3==1.15.18
celery==3.1.18
cryptography
paramiko
PGPy
py2neo
pyminizip
unicodecsv==0.14.1
vertica-python
snowflake-connector-python
```

Note that the constraints on Django are now listed

**Merge checklist:**
- [N/A ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [N/A ] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ N/A] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.