### PR TITLE
feat: Management command for adding EnterpriseLearnerEnrollment dummy data for LPR v1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.1.1] - 2022-03-01
+---------------------
+  * Created a new management command for adding EnterpriseLearnerEnrollment dummy data for learner progress report v1.
+
 [4.1.0] - 2022-03-01
 ---------------------
   * Created a new management command for adding dummy data for learner progress report v1.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/management/commands/create_enterprise_learner_enrollment_lpr_v1.py
+++ b/enterprise_data/management/commands/create_enterprise_learner_enrollment_lpr_v1.py
@@ -1,0 +1,58 @@
+"""
+Management command for creating enterprise learner enrollments
+"""
+
+
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+
+import enterprise_data.tests.test_utils
+
+
+class Command(BaseCommand):
+    """ Management command for creating dummy `EnterpriseLearnerEnrollment` instances for (LPR) V1."""
+
+    help = 'Creates an EnterpriseLearnerEnrollment with randomized attributes'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'enterprise_customer_uuid',
+            type=str,
+            help='UUID for an enterprise'
+        )
+        parser.add_argument(
+            'enterprise_user_id',
+            type=int,
+            default=None,
+            help='enterprise_user_id for an enterprise_user'
+        )
+        # this is optional and will be marked as False if not available in argumnets.
+        parser.add_argument('--consent_granted', action='store_true')
+
+    def handle(self, *args, **options):
+        enterprise_customer_uuid = options['enterprise_customer_uuid']
+        enterprise_user_id = options.get('enterprise_user_id')
+        is_consent_granted = options.get('consent_granted')
+
+        try:
+            enterprise_data.tests.test_utils.EnterpriseLearnerEnrollmentFactory(
+                enterprise_customer_uuid=enterprise_customer_uuid,
+                enterprise_user_id=enterprise_user_id,
+                is_consent_granted=is_consent_granted,
+            )
+            info = (
+                '\nCreated EnterpriseLearnerEnrollment with enterprise_customer_uuid '
+                '{} for EnterpriseUser with enterprise_user_id of {} and consent {}\n\n'.format(
+                    enterprise_customer_uuid,
+                    enterprise_user_id,
+                    is_consent_granted,
+                )
+            )
+            sys.stdout.write(info)
+        except Exception as exc:
+            info = (
+                'Error trying to create EnterpriseUser with uuid '
+                '{}: {}'.format(enterprise_customer_uuid, exc)
+            )
+            raise CommandError(info) from exc

--- a/enterprise_data/management/commands/create_enterprise_learner_lpr_v1.py
+++ b/enterprise_data/management/commands/create_enterprise_learner_lpr_v1.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         # TODO: Need to update this to the correct comment for LPR V1 once that is added.
         info = (
             'You can create some enrollments for this user by running the following '
-            'command:\n\n    ./manage.py create_enterprise_enrollment {} {}\n\n'.format(
+            'command:\n\n    ./manage.py create_enterprise_learner_enrollment_lpr_v1 {} {}\n\n'.format(
                 ent_user.enterprise_customer_uuid,
                 ent_user.enterprise_user_id,
             )

--- a/enterprise_data/management/commands/tests/test_create_enterprise_learner_enrollment_lpr_v1.py
+++ b/enterprise_data/management/commands/tests/test_create_enterprise_learner_enrollment_lpr_v1.py
@@ -1,0 +1,81 @@
+"""
+Tests for create_enterprise_learner_enrollment_lpr_v1 management command
+"""
+from unittest import TestCase, mock
+
+from pytest import mark
+
+from django.core.management import call_command
+
+from enterprise_data.models import EnterpriseLearner, EnterpriseLearnerEnrollment
+from enterprise_data.tests.test_utils import EnterpriseLearnerFactory
+
+
+@mark.django_db
+class TestCreateEnterpriseLearnerEnrollmentCommand(TestCase):
+    """ Tests for create_enterprise_learner_enrollment_lpr_v1 management command"""
+
+    def setUp(self):
+        super().setUp()
+        self.uuid = 'a'*32
+        self.enterprise_user = EnterpriseLearnerFactory(enterprise_customer_uuid=self.uuid)
+
+    def test_create_enterprise_learner_enrollment_lpr_v1_with_dsc_disabled(self):
+        """
+        Management command should successfully be able to create EnterpriseLearnerEnrollment with DSC Disabled
+        """
+        assert EnterpriseLearner.objects.count() == 1
+        assert EnterpriseLearnerEnrollment.objects.count() == 0
+
+        args = [self.uuid, self.enterprise_user.enterprise_user_id]
+        call_command('create_enterprise_learner_enrollment_lpr_v1', *args)
+
+        assert EnterpriseLearnerEnrollment.objects.count() == 1
+        enterprise_learner_enrollment = EnterpriseLearnerEnrollment.objects.filter(
+            enterprise_customer_uuid=args[0]
+        )
+        assert enterprise_learner_enrollment.count() == 1
+        assert enterprise_learner_enrollment[0].progress_status is not None
+        assert enterprise_learner_enrollment[0].letter_grade is not None
+        assert enterprise_learner_enrollment[0].enterprise_user_id is not None
+        assert enterprise_learner_enrollment[0].user_username is not None
+        assert enterprise_learner_enrollment[0].user_email is not None
+        assert enterprise_learner_enrollment[0].enterprise_user is not None
+
+    def test_create_enterprise_learner_enrollment_lpr_v1_with_dsc_enabled(self):
+        """
+        Management command should successfully be able to create EnterpriseLearnerEnrollment with DSC enabled
+        """
+        assert EnterpriseLearner.objects.count() == 1
+        assert EnterpriseLearnerEnrollment.objects.count() == 0
+
+        args = [self.uuid, self.enterprise_user.enterprise_user_id, '--consent_granted']
+        call_command('create_enterprise_learner_enrollment_lpr_v1', *args)
+
+        assert EnterpriseLearnerEnrollment.objects.count() == 1
+        enterprise_learner_enrollment = EnterpriseLearnerEnrollment.objects.filter(
+            enterprise_customer_uuid=args[0]
+        )
+        assert enterprise_learner_enrollment.count() == 1
+        assert enterprise_learner_enrollment[0].letter_grade is None
+        assert enterprise_learner_enrollment[0].last_activity_date is None
+        assert enterprise_learner_enrollment[0].progress_status is None
+        assert enterprise_learner_enrollment[0].enterprise_user_id is None
+        assert enterprise_learner_enrollment[0].user_username is None
+        assert enterprise_learner_enrollment[0].enterprise_user is None
+        assert enterprise_learner_enrollment[0].user_email is None
+        assert EnterpriseLearner.objects.count() == 1
+
+    def test_create_enterprise_learner_enrollment_lpr_v1_error(self):
+        """
+        Management command will not create enrollment if an error is thrown
+        """
+        assert EnterpriseLearnerEnrollment.objects.count() == 0
+
+        args = [self.uuid, self.enterprise_user.enterprise_user_id]
+        with mock.patch('enterprise_data.tests.test_utils.EnterpriseLearnerEnrollmentFactory') as mock_factory:
+            mock_factory.side_effect = [Exception]
+            with self.assertRaises(Exception):
+                call_command('create_enterprise_learner_enrollment_lpr_v1', *args)
+
+        assert EnterpriseLearnerEnrollment.objects.count() == 0


### PR DESCRIPTION
Created a new management command for adding EnterpriseLearnerEnrollment dummy data for learner progress report v1

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
