### PR TITLE
fix: add rate-limiting retry for enterprise requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.2.1] - 2022-03-15
+---------------------
+  * Added error handling for rate limit exceptions
+
 [4.2.0] - 2022-03-15
 ---------------------
   * Removed currently broken admin url inclusion from enterprise-data.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -6,8 +6,10 @@ import os
 from datetime import datetime
 from functools import wraps
 from urllib.parse import parse_qs, urlparse
+import time
 
 from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.exceptions import HttpClientError
 
 
 class EdxOAuth2APIClient:
@@ -129,7 +131,16 @@ def traverse_pagination(response, endpoint):
     next_page = response.get('next')
     while next_page:
         querystring = parse_qs(urlparse(next_page).query, True)
-        response = endpoint.get(**querystring)
+        try:
+            response = endpoint.get(**querystring)
+        except HttpClientError as exc:
+            # If we get HTTP429, we should pause for a period of time before re-requesting one more time.
+            # This status code is expected because of rate limiting on the endpoint
+            if exc.response.status_code == 429:
+                time.sleep(5)
+                response = endpoint.get(**querystring)
+            else:
+                raise exc
         results += response.get('results', [])
         next_page = response.get('next')
 


### PR DESCRIPTION
## [MST-1304 ](https://openedx.atlassian.net/browse/MST-1304)

Every time the [enterprise-reporting jenkins job](https://github.com/edx/jenkins-job-dsl-internal/blob/master/jobs/tools-edx-jenkins.edx.org/createEnterpriseDataReportingJobs.groovy) runs, it creates spikes of errors for prod analytics api. This is because the jenkins job makes many calls to an[ endpoint that is rate limited](https://github.com/openedx/edx-enterprise-data/blob/22d05deeac3b25cd73bd659e0a92840ea89c683b/enterprise_data/clients.py#L74), and eventually errors out when that rate limit is reached. If we know that we may get a rate limiting error, we should catch that exception and retry after the appropriate amount of time has passed.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [x] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
