### PR TITLE
fix: extra error handling isn't necessary for rate limiting exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.2.3] - 2022-03-16
+---------------------
+  * Remove error handling for rate limit exceptions for data API calls
+
 [4.2.2] - 2022-03-16
 ---------------------
   * Update error handling for rate limit exceptions. Moved handling to source of errors.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.2.2"
+__version__ = "4.2.3"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -4,7 +4,6 @@ Clients used to connect to other systems.
 
 
 import logging
-import time
 
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import EdxRestApiClient
@@ -91,19 +90,11 @@ class EnterpriseApiClient(EdxRestApiClient):
         try:
             response = endpoint.get()
         except (HttpClientError, HttpServerError) as exc:
-            if exc.response.status_code == 429:
-                LOGGER.info(
-                    "[Data Overview Info] Rate limiting encountered while retrieving Enterprise Customer details, "
-                    "will try again in 10 seconds."
-                )
-                time.sleep(10)
-                response = endpoint.get()
-            else:
-                LOGGER.warning(
-                    "[Data Overview Failure] Unable to retrieve Enterprise Customer details. "
-                    f"User: {user.username}, Enterprise: {enterprise_id}, Exception: {exc}"
-                )
-                raise exc
+            LOGGER.warning(
+                "[Data Overview Failure] Unable to retrieve Enterprise Customer details. "
+                f"User: {user.username}, Enterprise: {enterprise_id}, Exception: {exc}"
+            )
+            raise exc
 
         TieredCache.set_all_tiers(cache_key, response, DEFAULT_REPORTING_CACHE_TIMEOUT)
 


### PR DESCRIPTION
The extra exception handling for rate limiting isn't necessary, as the jenkins job I thought was causing errors isn't actually the source of the errors.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
