### PR TITLE
fix: fix coverage check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='django32-reporting'
+      if: matrix.python-version == '3.8' && matrix.toxenv=='django32-data'
       uses: codecov/codecov-action@v2
       with:
         flags: unittests


### PR DESCRIPTION
### Description
- Coverage check running with `django32-reporting` fails to get all the test reports so running the check with `django32-data` instead.