### PR TITLE
FC-0001: Remove EdxRestApiClient usage in edx-enterprise-data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[4.4.0] - 2022-06-23
+---------------------
+  * Replace EdxRestApiClient with OAuthAPIClient.
+
 [4.3.2] - 2022-06-23
 --------------------
   * fix: use EnterpriseReportingModelManager for EnterpriseOffer

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.3.2"
+__version__ = "4.4.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import OAuthAPIClient
-from requests.exceptions import RequestException
+from requests.exceptions import HTTPError, RequestException
 from rest_framework.exceptions import NotFound, ParseError
 
 from django.conf import settings
@@ -41,7 +41,7 @@ class EnterpriseApiClient(OAuthAPIClient):
             response = self.get(url, params=querystring)
             response.raise_for_status()
             data = response.json()
-        except (RequestException) as exc:
+        except (HTTPError, RequestException) as exc:
             LOGGER.warning(
                 "[Data Overview Failure] Unable to retrieve Enterprise Customer Learner details. "
                 f"User: {user.username}, Exception: {exc}"
@@ -85,7 +85,7 @@ class EnterpriseApiClient(OAuthAPIClient):
             response = self.get(url)
             response.raise_for_status()
             data = response.json()
-        except (RequestException) as exc:
+        except (HTTPError, RequestException) as exc:
             LOGGER.warning(
                 "[Data Overview Failure] Unable to retrieve Enterprise Customer details. "
                 f"User: {user.username}, Enterprise: {enterprise_id}, Exception: {exc}"

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -23,8 +23,8 @@ class EnterpriseApiClient(OAuthAPIClient):
     """
     The EnterpriseApiClient is used to communicate with the enterprise API endpoints in the LMS.
 
-    This class is a sub-class of the edX Rest API Client
-    (https://github.com/edx/edx-rest-api-client).
+    This class is a sub-class of the OAuthAPIClient
+    (https://github.com/openedx/edx-rest-api-client).
     """
 
     API_BASE_URL = urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/')

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -6,6 +6,7 @@ from logging import getLogger
 
 from rest_framework import filters
 
+from django.conf import settings
 from django.db.models import Q
 
 from enterprise_data.clients import EnterpriseApiClient
@@ -30,7 +31,11 @@ class FiltersMixin:
         """
         Make cached call to lms to get an enterprise data and update request session.
         """
-        enterprise_client = EnterpriseApiClient(request.auth)
+        enterprise_client = EnterpriseApiClient(
+            settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )
         __ = enterprise_client.get_enterprise_and_update_session(request)
 
 

--- a/enterprise_data/settings/test.py
+++ b/enterprise_data/settings/test.py
@@ -90,6 +90,10 @@ TEMPLATES = [
 
 LMS_BASE_URL = "http://localhost:8000/"
 
+BACKEND_SERVICE_EDX_OAUTH2_KEY = "analytics_api-backend-service-key"
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = "analytics_api-backend-service-secret"
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
+
 ROOT_URLCONF = "enterprise_data.urls"
 
 SECRET_KEY = "insecure-secret-key"

--- a/enterprise_data/tests/test_clients.py
+++ b/enterprise_data/tests/test_clients.py
@@ -1,12 +1,14 @@
 """
 Tests for clients in enterprise_data.
 """
-from unittest import mock
-from unittest.mock import ANY, Mock
+from unittest.mock import Mock
+from urllib.parse import urljoin
 
-from edx_rest_api_client.exceptions import HttpClientError
+import responses
+from requests.exceptions import HTTPError
 from rest_framework.exceptions import NotFound, ParseError
 
+from django.conf import settings
 from django.test import TestCase
 
 from enterprise_data.clients import EnterpriseApiClient
@@ -35,50 +37,94 @@ class TestEnterpriseApiClient(TestCase):
         """
         Set up a mocked Enterprise API Client. Avoiding doing this in setup so we can test __init__.
         """
-        self.client = EnterpriseApiClient('test-token')  # pylint: disable=attribute-defined-outside-init
-        setattr(self.client, 'enterprise-learner', Mock(
-            get=self.mocked_get_endpoint
-        ))
+        self.client = EnterpriseApiClient(  # pylint: disable=attribute-defined-outside-init
+            settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )
 
-        setattr(self.client, 'enterprise-customer', Mock(return_value=Mock(get=self.mocked_get_endpoint)))
+        responses.add(
+            responses.POST,
+            urljoin(settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL + '/', 'access_token'),
+            status=200,
+            json={
+                'access_token': 'test_access_token',
+                'expires_in': 10,
+            },
+            content_type='application/json'
+        )
 
-    @mock.patch('enterprise_data.clients.EdxRestApiClient.__init__')
-    def test_inits_client_with_jwt(self, mock_init):
-        EnterpriseApiClient('test-token')
-        mock_init.assert_called_with(ANY, jwt='test-token')
-
+    @responses.activate
     def test_get_enterprise_learner_returns_results_for_user(self):
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         results = self.client.get_enterprise_learner(self.user)
-        self.mocked_get_endpoint.assert_called_with(username=self.user.username)
         assert results == self.api_response['results'][0]
 
+    @responses.activate
     def test_get_enterprise_learner_raises_exception_on_error(self):
-        self.mocked_get_endpoint = Mock(side_effect=HttpClientError)
         self.mock_client()
-        with self.assertRaises(HttpClientError):
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=404,
+            content_type='application/json'
+        )
+        with self.assertRaises(HTTPError):
             _ = self.client.get_enterprise_learner(self.user)
 
+    @responses.activate
     def test_get_enterprise_learner_returns_none_on_empty_results(self):
         self.mocked_get_endpoint = Mock(return_value={
             'count': 0,
             'results': []
         })
         self.mock_client()
+
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         results = self.client.get_enterprise_learner(self.user)
         self.assertIsNone(results)
 
+    @responses.activate
     def test_get_enterprise_learner_raises_not_found_on_no_results(self):
         self.mocked_get_endpoint = Mock(return_value={})
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         with self.assertRaises(NotFound):
             _ = self.client.get_enterprise_learner(self.user)
 
+    @responses.activate
     def test_get_enterprise_learner_raises_parse_error_on_multiple_results(self):
         self.mocked_get_endpoint = Mock(return_value={
             'count': 2,
             'results': [{}, {}]
         })
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         with self.assertRaises(ParseError):
             _ = self.client.get_enterprise_learner(self.user)

--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -116,7 +116,7 @@ class EdxOAuth2APIClient:
 
         return data or default_val
 
-    def traverse_pagination(self, response, url):
+    def traverse_pagination(self, data, url):
         """
         Traverse a paginated API response.
 
@@ -124,21 +124,20 @@ class EdxOAuth2APIClient:
         APIs.
 
         Arguments:
-            response (Dict): Current response dict from service API
-            access_token (str): jwt token
+            data (Dict): Current response dict from service API
             url (str): API endpoint path
 
         Returns:
             list of dict.
         """
-        results = response.get('results', [])
+        results = data.get('results', [])
 
-        next_page = response.get('next')
+        next_page = data.get('next')
         while next_page:
             querystring = parse_qs(urlparse(next_page).query, True)
-            data = self._requests(url, querystring)
+            request_data = self._requests(url, querystring)
 
-            results += data.get('results', [])
-            next_page = data.get('next')
+            results += request_data.get('results', [])
+            next_page = request_data.get('next')
 
         return results

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -6,10 +6,12 @@ Client for connecting to the LMS Enterprise endpoints.
 import logging
 import os
 from collections import OrderedDict
+from urllib.parse import urljoin
+
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 
-from enterprise_reporting.clients import EdxOAuth2APIClient
 from enterprise_reporting import utils
+from enterprise_reporting.clients import EdxOAuth2APIClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -124,9 +126,7 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
     """
     Client for connecting to the Enterprise API.
     """
-
-    API_BASE_URL = EdxOAuth2APIClient.LMS_ROOT_URL + '/enterprise/api/v1/'
-    APPEND_SLASH = True
+    API_BASE_URL = urljoin(EdxOAuth2APIClient.LMS_ROOT_URL + '/', 'enterprise/api/v1/')
 
     ENTERPRISE_REPORTING_ENDPOINT = 'enterprise_customer_reporting'
     ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT = 'enterprise_catalogs'
@@ -205,9 +205,7 @@ class EnterpriseDataApiClient(EdxOAuth2APIClient):
     Client for connecting to the Enterprise Data API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/enterprise/api/v0'
-    APPEND_SLASH = True
-
+    API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'enterprise/api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
     @EdxOAuth2APIClient.refresh_token
@@ -226,7 +224,7 @@ class EnterpriseDataV1ApiClient(EnterpriseDataApiClient):
     Client for connecting to the Enterprise Data V1 API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/enterprise/api/v1'
+    API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'enterprise/api/v1')
 
 
 class AnalyticsDataApiClient(EdxOAuth2APIClient):
@@ -234,9 +232,7 @@ class AnalyticsDataApiClient(EdxOAuth2APIClient):
     Client for connecting to the Analytics Data API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/api/v0'
-    APPEND_SLASH = True
-
+    API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
     @EdxOAuth2APIClient.refresh_token

--- a/enterprise_reporting/tests/test_clients.py
+++ b/enterprise_reporting/tests/test_clients.py
@@ -1,0 +1,127 @@
+"""
+Tests for clients in enterprise_reporting.
+"""
+from unittest.mock import Mock, patch
+from urllib.parse import urljoin
+
+import responses
+
+from django.conf import settings
+from django.test import TestCase
+
+from enterprise_reporting.clients.enterprise import EnterpriseAPIClient
+
+
+class TestEnterpriseAPIClient(TestCase):
+    """
+    Test Enterprise API client used to connect to the Enterprise API.
+    """
+
+    def setUp(self):
+        self.enterprise_customer_uuid = 'test-enterprise-customer-uuid'
+        self.reporting_config = {}
+        self.api_response = {
+            'results': [{
+                'enterprise_name': 'Test Enterprise',
+                'enterprise_id': 'test-id'
+            }]
+        }
+        self.mocked_get_endpoint = Mock(return_value=self.api_response)
+        self.client = EnterpriseAPIClient(  # pylint: disable=attribute-defined-outside-init
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )
+        self.client.API_BASE_URL = 'http://localhost-test:8000/'
+        super().setUp()
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_get_all_enterprise_reporting_configs(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = {
+            'access_token': 'test_access_token',
+            'expires_in': 10,
+        }
+        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_REPORTING_ENDPOINT)
+        responses.add(
+            responses.GET,
+            url,
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        results = self.client.get_all_enterprise_reporting_configs()
+        assert results['results'] == self.api_response['results']
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_get_enterprise_reporting_configs(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = {
+            'access_token': 'test_access_token',
+            'expires_in': 10,
+        }
+        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_REPORTING_ENDPOINT)
+        responses.add(
+            responses.GET,
+            url,
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        results = self.client.get_enterprise_reporting_configs(self.enterprise_customer_uuid)
+        assert results['results'] == self.api_response['results']
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_get_customer_catalogs(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = {
+            'access_token': 'test_access_token',
+            'expires_in': 10,
+        }
+        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT)
+        responses.add(
+            responses.GET,
+            url,
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        results = self.client.get_customer_catalogs(self.enterprise_customer_uuid)
+        assert results['results'] == self.api_response['results']
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_get_content_metadata(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = {
+            'access_token': 'test_access_token',
+            'expires_in': 10,
+        }
+        mocked_get_endpoint = Mock(return_value={
+            'results': [{
+                'uuid': self.enterprise_customer_uuid
+            }]
+        })
+        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT)
+        responses.add(
+            responses.GET,
+            url,
+            json=mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        api_response = {
+            'results': [{
+                'uuid': self.enterprise_customer_uuid,
+                'content_type': 'program',
+            }]
+        }
+        mocked_get_endpoint = Mock(return_value=api_response)
+        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT + '/' + self.enterprise_customer_uuid)
+        responses.add(
+            responses.GET,
+            url,
+            json=mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        results = self.client.get_content_metadata(self.enterprise_customer_uuid, self.reporting_config)
+        assert results == api_response['results']

--- a/requirements/test-reporting.in
+++ b/requirements/test-reporting.in
@@ -1,6 +1,7 @@
 -c constraints.txt
 -r reporting.in
 
+responses                           # utility library for mocking out the requests library
 tox
 tox-battery                         # Makes tox aware of requirements file changes
 pytest==3.7.1

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -149,7 +149,11 @@ pytz==2022.1
 pyyaml==5.4.1
     # via awscli
 requests==2.28.0
-    # via snowflake-connector-python
+    # via
+    #   responses
+    #   snowflake-connector-python
+responses==0.21.0
+    # via -r requirements/test-reporting.in
 rsa==4.7.2
     # via awscli
 s3transfer==0.6.0
@@ -188,6 +192,7 @@ urllib3==1.26.9
     #   botocore
     #   py2neo
     #   requests
+    #   responses
 vertica-python==1.1.0
     # via -r requirements/reporting.in
 vine==1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ addopts = --cov enterprise_reporting --cov enterprise_data --cov enterprise_data
 norecursedirs = .* docs requirements node_modules
 
 [testenv]
+setenv = 
+    DJANGO_SETTINGS_MODULE=enterprise_data.settings.test
 deps = 
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1


### PR DESCRIPTION
https://github.com/openedx/public-engineering/issues/41
**Merge checklist:**
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
