### PR TITLE
fix: Rename base class as mixin and remove `viewsets.ViewSet` from class list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Unreleased
 ----------
 
 =========================
+[4.2.5] - 2022-04-22
+---------------------
+  * Rename base class to a more appropriate name
+  * Remove `viewsets.ViewSet` from base class
+
 [4.2.4] - 2022-04-18
 ---------------------
   * Make API endpoints readonly.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.2.4"
+__version__ = "4.2.5"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -43,7 +43,7 @@ def subtract_one_month(original_date):
     return one_month_earlier
 
 
-class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
+class EnterpriseViewSetMixin(PermissionRequiredMixin):
     """
     Base class for all Enterprise view sets.
     """
@@ -61,7 +61,7 @@ class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
         return super().paginate_queryset(queryset)  # pylint: disable=no-member
 
 
-class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseEnrollmentsViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise course enrollments.
     """
@@ -232,7 +232,7 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelView
         return Response(content)
 
 
-class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseUsersViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise users.
     """
@@ -330,7 +330,7 @@ class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
         return Response(serializer.data)
 
 
-class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     View to manage enterprise learner completed course enrollments.
     """

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -38,7 +38,7 @@ def subtract_one_month(original_date):
     return one_month_earlier
 
 
-class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
+class EnterpriseViewSetMixin(PermissionRequiredMixin):
     """
     Base class for all Enterprise view sets.
     """
@@ -56,7 +56,7 @@ class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
         return super().paginate_queryset(queryset)  # pylint: disable=no-member
 
 
-class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise course enrollments.
     """
@@ -250,7 +250,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ReadOnlyMod
         return Response(content)
 
 
-class EnterpriseLearnerViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseLearnerViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise Learners.
     """
@@ -355,7 +355,7 @@ class EnterpriseLearnerViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet)
         return Response(serializer.data)
 
 
-class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
+class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     View to manage enterprise learner completed course enrollments.
     """


### PR DESCRIPTION

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
