### PR TITLE
maint: changing enterprise reporting content metadata source to the enterprise catalog service

### DIFF
--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -16,6 +16,7 @@ class EdxOAuth2APIClient:
     """
 
     LMS_ROOT_URL = os.getenv('LMS_ROOT_URL', default='')
+    ENTERPRISE_CATALOG_ROOT_URL = os.getenv('ENTERPRISE_CATALOG_ROOT_URL', default='https://enterprise-catalog.edx.org')
     LMS_OAUTH_HOST = os.getenv('LMS_OAUTH_HOST', default='')
     API_BASE_URL = LMS_ROOT_URL + '/api/'
     APPEND_SLASH = False

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -3,11 +3,114 @@ Client for connecting to the LMS Enterprise endpoints.
 """
 
 
-
+import logging
 import os
 from collections import OrderedDict
+from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 
 from enterprise_reporting.clients import EdxOAuth2APIClient
+from enterprise_reporting import utils
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
+    """
+    Client for connect to the Enterprise Catalog Service API.
+    """
+    API_BASE_URL = EdxOAuth2APIClient.ENTERPRISE_CATALOG_ROOT_URL + '/api/v1/'
+
+    APPEND_SLASH = True
+    ENTERPRISE_CATALOGS_ENDPOINT = 'enterprise-catalogs'
+    GET_CONTENT_METADATA_ENDPOINT = ENTERPRISE_CATALOGS_ENDPOINT + '/{}/get_content_metadata'
+
+    ENTERPRISE_REPORTING_ENDPOINT = 'enterprise_customer_reporting'
+    ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT = 'enterprise_catalogs'
+
+    PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
+
+    def traverse_get_content_metadata(self, endpoint, query, catalog_uuid):
+        """
+        Helper method to traverse over a paginated response from the enterprise-catalog service's `get_content_metadata`
+        endpoint.
+        """
+        content_metadata = OrderedDict()
+        try:
+            response = endpoint.get(**query)
+            for item in utils.traverse_pagination(response, endpoint):
+                content_id = utils.get_content_metadata_item_id(item)
+                # This code used to rely on the LMS enterprise API endpoints who's responses contained less data than
+                # the enterprise catalog services, so we need to massage the response ie filter out new, not expected
+                # fields
+                item_crs = item.get('course_runs')
+                formatted_course_runs = []
+                for cr in item_crs:
+                    formatted_course_run = {
+                        'key': cr.get('key'),
+                        'enrollment_start': cr.get('enrollment_start'),
+                        'go_live_date': cr.get('go_live_date'),
+                        'start': cr.get('start'),
+                        'end': cr.get('end'),
+                        'modified': cr.get('modified'),
+                        'availability': cr.get('availability'),
+                        'status': cr.get('status'),
+                        'pacing_type': cr.get('pacing_type'),
+                        # New endpoint uses `type` instead of enrollment mode
+                        'enrollment_mode': cr.get('type'),
+                        'min_effort': cr.get('min_effort'),
+                        'max_effort': cr.get('max_effort'),
+                        'weeks_to_complete': cr.get('weeks_to_complete'),
+                        'estimated_hours': cr.get('estimated_hours'),
+                        'first_enrollable_paid_seat_price': cr.get('first_enrollable_paid_seat_price'),
+                        'is_enrollable': cr.get('is_enrollable'),
+                    }
+                    formatted_course_runs.append(formatted_course_run)
+                formatted_metadata = {
+                    'active': item.get('active'),
+                    'aggregation_key': item.get('aggregation_key'),
+                    'card_image_url': item.get('card_image_url'),
+                    'content_type': item.get('content_type'),
+                    'course_ends': item.get('course_ends'),
+                    'course_runs': formatted_course_runs,
+                    'end_date': item.get('end_date'),
+                    'enrollment_url': item.get('enrollment_url'),
+                    'full_description': item.get('full_description'),
+                    'image_url': item.get('image_url'),
+                    'key': item.get('key'),
+                    'languages': item.get('languages'),
+                    'organizations': item.get('organizations'),
+                    'seat_types': item.get('seat_types'),
+                    'short_description': item.get('short_description'),
+                    'skill_names': item.get('skill_names'),
+                    'skills': item.get('skills'),
+                    'subjects': item.get('subjects'),
+                    'title': item.get('title'),
+                    'uuid': item.get('uuid'),
+                }
+                content_metadata[content_id] = formatted_metadata
+        except (ConnectionError, Timeout):
+            LOGGER.exception(
+                f'Failed to get content metadata for Catalog {catalog_uuid} in enterprise-catalog',
+                exc_info=True,
+            )
+            raise
+
+        return content_metadata
+
+    @EdxOAuth2APIClient.refresh_token
+    def get_content_metadata(self, enterprise_customer_uuid, reporting_config):
+        """Return all content metadata contained in the catalogs associated with a reporting config."""
+        content_metadata = OrderedDict()
+
+        enterprise_customer_catalogs = extract_catalog_uuids_from_reporting_config(reporting_config)
+        for catalog in enterprise_customer_catalogs.get('results', []):
+            endpoint = getattr(self.client, self.GET_CONTENT_METADATA_ENDPOINT.format(catalog['uuid']))
+            query = {'page_size': self.PAGE_SIZE}
+            traversed_metadata = self.traverse_get_content_metadata(endpoint, query, catalog['uuid'])
+            content_metadata.update(traversed_metadata)
+
+        # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.
+        return list(content_metadata.values())
 
 
 class EnterpriseAPIClient(EdxOAuth2APIClient):

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -14,7 +14,8 @@ from enterprise_reporting.clients.enterprise import (
     AnalyticsDataApiClient,
     EnterpriseAPIClient,
     EnterpriseDataApiClient,
-    EnterpriseDataV1ApiClient
+    EnterpriseDataV1ApiClient,
+    EnterpriseCatalogAPIClient,
 )
 from enterprise_reporting.clients.s3 import S3Client
 from enterprise_reporting.clients.vertica import VerticaClient
@@ -289,11 +290,9 @@ class EnterpriseReportSender:
 
     def __get_content_metadata(self):
         """Get content metadata from the Enterprise Customer Catalog API."""
-        enterprise_api_client = EnterpriseAPIClient()
-        LOGGER.info('Gathering all catalog content metadata...')
-        content_metadata = enterprise_api_client.get_content_metadata(
+        enterprise_catalog_api_client = EnterpriseCatalogAPIClient()
+        content_metadata = enterprise_catalog_api_client.get_content_metadata(
             self.enterprise_customer_uuid,
             self.reporting_config,
         )
-        LOGGER.debug(f'Gathered this content metadata: {content_metadata}')
         return content_metadata


### PR DESCRIPTION
enterprise LMS platform is no longer the source of truth for catalog metadata. The customer reporting jobs should query the enterprise catalog service instead of platform.

There is no staging instance and SRE advised- enterprise catalog services prod base URL is hardcoded.

Tested and verified locally

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
