### PR TITLE
fix: accounting for multiple catalogs in catalog reporting

### DIFF
--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -20,7 +20,7 @@ from enterprise_reporting.clients.enterprise import (
 from enterprise_reporting.clients.s3 import S3Client
 from enterprise_reporting.clients.vertica import VerticaClient
 from enterprise_reporting.delivery_method import SFTPDeliveryMethod, SMTPDeliveryMethod
-from enterprise_reporting.utils import decrypt_string, generate_data
+from enterprise_reporting.utils import decrypt_string, generate_data, extract_catalog_uuids_from_reporting_config
 
 LOGGER = logging.getLogger(__name__)
 NOW = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -290,9 +290,11 @@ class EnterpriseReportSender:
 
     def __get_content_metadata(self):
         """Get content metadata from the Enterprise Customer Catalog API."""
+        customer_catalogs = extract_catalog_uuids_from_reporting_config(self.reporting_config)
+        if not customer_catalogs.get('results'):
+            platform_api_client = EnterpriseAPIClient()
+            customer_catalogs = platform_api_client.get_customer_catalogs(self.enterprise_customer_uuid)
+
         enterprise_catalog_api_client = EnterpriseCatalogAPIClient()
-        content_metadata = enterprise_catalog_api_client.get_content_metadata(
-            self.enterprise_customer_uuid,
-            self.reporting_config,
-        )
+        content_metadata = enterprise_catalog_api_client.get_content_metadata(customer_catalogs)
         return content_metadata

--- a/enterprise_reporting/tests/test_enterprise_client.py
+++ b/enterprise_reporting/tests/test_enterprise_client.py
@@ -7,7 +7,7 @@ import unittest
 
 import json
 
-from enterprise_reporting.clients.enterprise import (
+from enterprise_reporting.utils import (
     extract_catalog_uuids_from_reporting_config,
 )
 

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -331,3 +331,18 @@ def traverse_pagination(response, endpoint):
         next_page = response.get('next')
 
     return results
+
+
+def extract_catalog_uuids_from_reporting_config(reporting_config):
+    """
+    Helper method to extract uuids from reporting config
+
+    Returns a dict with 1 key, 'results', whose value is a list of
+    dicts containing a key-value pair of 'uuid' and some uuid
+    """
+    enterprise_customer_catalogs = {'results': [
+        {'uuid': catalog['uuid']}
+        for catalog in reporting_config.get('enterprise_customer_catalogs', [])
+        ]
+    }
+    return enterprise_customer_catalogs


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
