### PR TITLE
feat: add optional filter to ignore null course list price

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[4.5.0] - 2022-06-30
+--------------------
+  * Add optional `ignore_null_course_list_price` query parameter to filter out enrollment records that have been refunded.
+
 [4.4.0] - 2022-06-23
 ---------------------
   * Replace EdxRestApiClient with OAuthAPIClient.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -156,6 +156,10 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         if offer_id:
             queryset = queryset.filter(offer_id=offer_id)
 
+        ignore_null_course_list_price = query_filters.get('ignore_null_course_list_price')
+        if ignore_null_course_list_price:
+            queryset = queryset.filter(course_list_price__isnull=False)
+
         return queryset
 
     def filter_active_enrollments(self, queryset):

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -88,13 +88,13 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
             enterprise_customer_uuid=self.enterprise_id
         )
 
-        learner_enrollment_1 = EnterpriseLearnerEnrollmentFactory(
+        EnterpriseLearnerEnrollmentFactory(
             course_list_price=None,
             enterprise_customer_uuid=self.enterprise_id,
             is_consent_granted=True,
             enterprise_user_id=enterprise_learner.enterprise_user_id
         )
-        EnterpriseLearnerEnrollmentFactory(
+        learner_enrollment_with_price = EnterpriseLearnerEnrollmentFactory(
             enterprise_customer_uuid=self.enterprise_id,
             is_consent_granted=True,
             enterprise_user_id=enterprise_learner.enterprise_user_id
@@ -104,7 +104,7 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
         response = self.client.get(url, data={'ignore_null_course_list_price': True})
         results = response.json()['results']
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['enrollment_id'], learner_enrollment_1.enrollment_id)
+        self.assertEqual(results[0]['enrollment_id'], learner_enrollment_with_price.enrollment_id)
 
 
 @ddt.ddt

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -83,6 +83,29 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['enrollment_id'], learner_enrollment_1.enrollment_id)
 
+    def test_filter_by_ignore_null_course_list_price(self):
+        enterprise_learner = EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id
+        )
+
+        learner_enrollment_1 = EnterpriseLearnerEnrollmentFactory(
+            course_list_price=None,
+            enterprise_customer_uuid=self.enterprise_id,
+            is_consent_granted=True,
+            enterprise_user_id=enterprise_learner.enterprise_user_id
+        )
+        EnterpriseLearnerEnrollmentFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_consent_granted=True,
+            enterprise_user_id=enterprise_learner.enterprise_user_id
+        )
+
+        url = reverse('v1:enterprise-learner-enrollment-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url, data={'ignore_null_course_list_price': True})
+        results = response.json()['results']
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['enrollment_id'], learner_enrollment_1.enrollment_id)
+
 
 @ddt.ddt
 @mark.django_db

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -168,6 +168,7 @@ class EnterpriseLearnerEnrollmentFactory(factory.django.DjangoModelFactory):
         start_date='-2M',
         end_date='+2M',
     ))
+    course_list_price = factory.lazy_attribute(lambda x: FAKER.pyfloat(min_value=25.0, max_value=1000.0, right_digits=2, positive=True))
     current_grade = factory.lazy_attribute(
         lambda x: FAKER.pyfloat(right_digits=2, min_value=0, max_value=1)  # pylint: disable=no-member
     )

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -176,9 +176,7 @@ class EnterpriseLearnerEnrollmentFactory(factory.django.DjangoModelFactory):
     )
     letter_grade = factory.lazy_attribute(lambda x: ' '.join(FAKER.words(nb=2)).title())
     progress_status = factory.lazy_attribute(lambda x: ' '.join(FAKER.words(nb=2)).title())
-    enterprise_user_id = factory.lazy_attribute(
-        lambda x: FAKER.random_int(min=1, max=999999)  # pylint: disable=no-member
-    )
+    enterprise_user_id = factory.Sequence(lambda n: n)
     user_email = factory.lazy_attribute(lambda x: FAKER.email())  # pylint: disable=no-member
     user_username = factory.Sequence('robot{}'.format)
     user_account_creation_date = factory.lazy_attribute(lambda x: '2018-01-01')

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -168,7 +168,9 @@ class EnterpriseLearnerEnrollmentFactory(factory.django.DjangoModelFactory):
         start_date='-2M',
         end_date='+2M',
     ))
-    course_list_price = factory.lazy_attribute(lambda x: FAKER.pyfloat(min_value=25.0, max_value=1000.0, right_digits=2, positive=True))
+    course_list_price = factory.lazy_attribute(
+        lambda x: FAKER.pyfloat(min_value=25.0, max_value=1000.0, right_digits=2, positive=True)
+    )
     current_grade = factory.lazy_attribute(
         lambda x: FAKER.pyfloat(right_digits=2, min_value=0, max_value=1)  # pylint: disable=no-member
     )

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -169,7 +169,7 @@ class EnterpriseLearnerEnrollmentFactory(factory.django.DjangoModelFactory):
         end_date='+2M',
     ))
     course_list_price = factory.lazy_attribute(
-        lambda x: FAKER.pyfloat(min_value=25.0, max_value=1000.0, right_digits=2, positive=True)
+        lambda x: FAKER.pyfloat(min_value=25.0, max_value=1000.0, right_digits=2)
     )
     current_grade = factory.lazy_attribute(
         lambda x: FAKER.pyfloat(right_digits=2, min_value=0, max_value=1)  # pylint: disable=no-member


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
