### PR TITLE
fix: update EnterpriseCatalogAPIClient to not use self.client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+ 
+[4.5.1] - 2022-07-12
+--------------------
+  * Replace `self.client` in `EnterpriseCatalogAPIClient` with `self._load_data` to account for OAuth client changes in enterprise_reporting.
 
 [4.5.0] - 2022-06-30
 --------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -42,10 +42,6 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         """
         content_metadata = OrderedDict()
         for item in traversed_metadata:
-            # print("transform_get_content_metadata")
-            # print(dir(item))
-            # print(item)
-            LOGGER.info('transform_get_content_metadata', type(item), dir(item), item)
             content_id = utils.get_content_metadata_item_id(item)
 
             # Check if the item is a courserun
@@ -128,7 +124,6 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
                 should_traverse_pagination=True,
                 querystring={'page_size': self.PAGE_SIZE},
             )
-            LOGGER.info('get_content_metadata', dir(traversed_metadata), type(traversed_metadata))
             transformed_metadata = self.transform_get_content_metadata(traversed_metadata.get('results'))
             content_metadata.update(transformed_metadata)
 

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -33,7 +33,7 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
 
     def transform_get_content_metadata(self, traversed_metadata):
         """
-        Helper method to traverse over a paginated response from the enterprise-catalog service's `get_content_metadata`
+        Helper method to transform a response (already traversed pagination) from the enterprise-catalog service's `get_content_metadata`.
         endpoint.
 
         Note: as of June 2022 the data source for content metadata changed from edx platform to the enterprise catalog
@@ -42,6 +42,9 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         """
         content_metadata = OrderedDict()
         for item in traversed_metadata:
+            print("transform_get_content_metadata")
+            print(dir(item))
+            print(item)
             content_id = utils.get_content_metadata_item_id(item)
 
             # Check if the item is a courserun

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -31,7 +31,7 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
 
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
-    def transform_get_content_metadata(self, traversed_metadata, catalog_uuid):
+    def transform_get_content_metadata(self, traversed_metadata):
         """
         Helper method to traverse over a paginated response from the enterprise-catalog service's `get_content_metadata`
         endpoint.
@@ -124,10 +124,7 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
                 should_traverse_pagination=True,
                 querystring={'page_size': self.PAGE_SIZE},
             )
-            transformed_metadata = self.transform_get_content_metadata(
-                traversed_metadata=traversed_metadata,
-                catalog_uuid=catalog['uuid'],
-            )
+            transformed_metadata = self.transform_get_content_metadata(traversed_metadata)
             content_metadata.update(transformed_metadata)
 
         # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -41,83 +41,76 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         the old endpoints data structure.
         """
         content_metadata = OrderedDict()
-        try:
-            for item in traversed_metadata:
-                content_id = utils.get_content_metadata_item_id(item)
+        for item in traversed_metadata:
+            content_id = utils.get_content_metadata_item_id(item)
 
-                # Check if the item is a courserun
-                if item.get('content_type') == 'courserun':
-                    # Courserun content metadata needs no massaging as it's the same in platform as it is in the
-                    # enterprise catalog service
-                    formatted_metadata = item
-                else:
-                    # Course content metadata differs slightly between platform and the catalog service, so we need to
-                    # massage the response ie filter out new, not expected fields
-                    item_crs = item.get('course_runs', [])
-                    formatted_course_runs = []
-                    for cr in item_crs:
-                        # While courseruns as a content metadata item did not change between old and new api endpoints,
-                        # the courserun attribute of a course did, so we need to do some formatting.
-                        formatted_course_run = {
-                            'key': cr.get('key'),
-                            'enrollment_start': cr.get('enrollment_start'),
-                            'enrollment_end': cr.get('enrollment_end'),
-                            'go_live_date': cr.get('go_live_date'),
-                            'start': cr.get('start'),
-                            'end': cr.get('end'),
-                            'modified': cr.get('modified'),
-                            'availability': cr.get('availability'),
-                            'status': cr.get('status'),
-                            'pacing_type': cr.get('pacing_type'),
-                            # New endpoint uses `type` instead of enrollment mode
-                            'enrollment_mode': cr.get('type'),
-                            'min_effort': cr.get('min_effort'),
-                            'max_effort': cr.get('max_effort'),
-                            'weeks_to_complete': cr.get('weeks_to_complete'),
-                            'estimated_hours': cr.get('estimated_hours'),
-                            'first_enrollable_paid_seat_price': cr.get('first_enrollable_paid_seat_price'),
-                            'is_enrollable': cr.get('is_enrollable'),
-                        }
-                        formatted_course_runs.append(formatted_course_run)
-
-                    # Subject attributes also need reformatting
-                    subjects = item.get('subjects', [])
-                    formatted_subjects = []
-                    for subject in subjects:
-                        subject_name = subject.get('name')
-                        if subject_name:
-                            formatted_subjects.append(subject_name)
-
-                    formatted_metadata = {
-                        'active': item.get('active'),
-                        'aggregation_key': item.get('aggregation_key'),
-                        'card_image_url': item.get('card_image_url'),
-                        'content_type': item.get('content_type'),
-                        'course_ends': item.get('course_ends'),
-                        'course_runs': formatted_course_runs,
-                        'end_date': item.get('end_date'),
-                        'enrollment_url': item.get('enrollment_url'),
-                        'full_description': item.get('full_description'),
-                        'image_url': item.get('image_url'),
-                        'key': item.get('key'),
-                        'languages': item.get('languages'),
-                        'organizations': item.get('organizations'),
-                        'seat_types': item.get('seat_types'),
-                        'short_description': item.get('short_description'),
-                        'skill_names': item.get('skill_names'),
-                        'skills': item.get('skills'),
-                        'subjects': formatted_subjects,
-                        'title': item.get('title'),
-                        'uuid': item.get('uuid'),
+            # Check if the item is a courserun
+            if item.get('content_type') == 'courserun':
+                # Courserun content metadata needs no massaging as it's the same in platform as it is in the
+                # enterprise catalog service
+                formatted_metadata = item
+            else:
+                # Course content metadata differs slightly between platform and the catalog service, so we need to
+                # massage the response ie filter out new, not expected fields
+                item_crs = item.get('course_runs', [])
+                formatted_course_runs = []
+                for cr in item_crs:
+                    # While courseruns as a content metadata item did not change between old and new api endpoints,
+                    # the courserun attribute of a course did, so we need to do some formatting.
+                    formatted_course_run = {
+                        'key': cr.get('key'),
+                        'enrollment_start': cr.get('enrollment_start'),
+                        'enrollment_end': cr.get('enrollment_end'),
+                        'go_live_date': cr.get('go_live_date'),
+                        'start': cr.get('start'),
+                        'end': cr.get('end'),
+                        'modified': cr.get('modified'),
+                        'availability': cr.get('availability'),
+                        'status': cr.get('status'),
+                        'pacing_type': cr.get('pacing_type'),
+                        # New endpoint uses `type` instead of enrollment mode
+                        'enrollment_mode': cr.get('type'),
+                        'min_effort': cr.get('min_effort'),
+                        'max_effort': cr.get('max_effort'),
+                        'weeks_to_complete': cr.get('weeks_to_complete'),
+                        'estimated_hours': cr.get('estimated_hours'),
+                        'first_enrollable_paid_seat_price': cr.get('first_enrollable_paid_seat_price'),
+                        'is_enrollable': cr.get('is_enrollable'),
                     }
+                    formatted_course_runs.append(formatted_course_run)
 
-                content_metadata[content_id] = formatted_metadata
-        except (ConnectionError, Timeout):
-            LOGGER.exception(
-                f'Failed to get content metadata for Catalog {catalog_uuid} in enterprise-catalog',
-                exc_info=True,
-            )
-            raise
+                # Subject attributes also need reformatting
+                subjects = item.get('subjects', [])
+                formatted_subjects = []
+                for subject in subjects:
+                    subject_name = subject.get('name')
+                    if subject_name:
+                        formatted_subjects.append(subject_name)
+
+                formatted_metadata = {
+                    'active': item.get('active'),
+                    'aggregation_key': item.get('aggregation_key'),
+                    'card_image_url': item.get('card_image_url'),
+                    'content_type': item.get('content_type'),
+                    'course_ends': item.get('course_ends'),
+                    'course_runs': formatted_course_runs,
+                    'end_date': item.get('end_date'),
+                    'enrollment_url': item.get('enrollment_url'),
+                    'full_description': item.get('full_description'),
+                    'image_url': item.get('image_url'),
+                    'key': item.get('key'),
+                    'languages': item.get('languages'),
+                    'organizations': item.get('organizations'),
+                    'seat_types': item.get('seat_types'),
+                    'short_description': item.get('short_description'),
+                    'skill_names': item.get('skill_names'),
+                    'skills': item.get('skills'),
+                    'subjects': formatted_subjects,
+                    'title': item.get('title'),
+                    'uuid': item.get('uuid'),
+                }
+
+            content_metadata[content_id] = formatted_metadata
 
         return content_metadata
 

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -42,9 +42,10 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         """
         content_metadata = OrderedDict()
         for item in traversed_metadata:
-            print("transform_get_content_metadata")
-            print(dir(item))
-            print(item)
+            # print("transform_get_content_metadata")
+            # print(dir(item))
+            # print(item)
+            LOGGER.info('transform_get_content_metadata', type(item), dir(item), item)
             content_id = utils.get_content_metadata_item_id(item)
 
             # Check if the item is a courserun

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -128,6 +128,7 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
                 should_traverse_pagination=True,
                 querystring={'page_size': self.PAGE_SIZE},
             )
+            LOGGER.info('get_content_metadata', dir(traversed_metadata), type(traversed_metadata), traversed_metadata)
             transformed_metadata = self.transform_get_content_metadata(traversed_metadata)
             content_metadata.update(transformed_metadata)
 

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -128,8 +128,8 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
                 should_traverse_pagination=True,
                 querystring={'page_size': self.PAGE_SIZE},
             )
-            LOGGER.info('get_content_metadata', dir(traversed_metadata), type(traversed_metadata), traversed_metadata)
-            transformed_metadata = self.transform_get_content_metadata(traversed_metadata)
+            LOGGER.info('get_content_metadata', dir(traversed_metadata), type(traversed_metadata))
+            transformed_metadata = self.transform_get_content_metadata(traversed_metadata.get('results'))
             content_metadata.update(transformed_metadata)
 
         # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -303,6 +303,8 @@ def get_content_metadata_item_id(content_metadata_item):
     """
     if content_metadata_item['content_type'] == 'program':
         return content_metadata_item['uuid']
+    if content_metadata_item['content_type'] == 'learnerpathway':
+        return content_metadata_item['uuid']
     return content_metadata_item['key']
 
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/CR-4990

`self.client` was removed on the `EdxOAuth2APIClient` due to `self.client` using the deprecated, now-removed `EdxRestApiClient`. It was replaced with using `requests` directly instead.

This change was accounted for in the `EnterpriseAPIClient` within `enterprise_reporting`, likely because tests/CI failed to the presence of tests. However, it does not seem `EnterpriseCatalogAPIClient` has any existing tests, which is why it wasn't caught automatically during the DEPR work.

This PR refactors the use of `self.client` in the `EnterpriseCatalogAPIClient` to use `self._load_data` similar to how the `EnterpriseAPIClient` is now working.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
