### PR TITLE
temp: Add logs for enterprise reporting

### DIFF
--- a/enterprise_reporting/tests/test_utils.py
+++ b/enterprise_reporting/tests/test_utils.py
@@ -16,6 +16,9 @@ from enterprise_reporting import utils
 
 from .utils import create_files, verify_compressed
 
+import pytz
+import datetime
+
 
 @ddt.ddt
 class TestUtilities(unittest.TestCase):
@@ -154,6 +157,19 @@ class TestUtilities(unittest.TestCase):
         """The dictionary, when weird, raises an error."""
         with self.assertRaises(NotImplementedError):
             utils.flatten_dict(dictionary)
+
+    def test_is_current_time_in_schedule(self):
+        """
+        Verify that is_current_time_in_schedule works as expected for daily frequency.
+        """
+        est_timezone = pytz.timezone('US/Eastern')
+        current_est_time = datetime.datetime.now(est_timezone)
+        assert utils.is_current_time_in_schedule(
+            utils.FREQUENCY_TYPE_DAILY,
+            current_est_time.hour,
+            current_est_time.day,
+            current_est_time.weekday()
+        )
 
 
 @ddt.ddt

--- a/enterprise_reporting/utils.py
+++ b/enterprise_reporting/utils.py
@@ -159,6 +159,9 @@ def is_current_time_in_schedule(frequency, hour_of_day, day_of_month=None, day_o
     current_day_of_week = current_est_time.weekday()
     current_day_of_month = current_est_time.day
 
+    LOGGER.info(f'Job Current EST: [{current_hour_of_day}-{current_day_of_week}-{current_day_of_month}]')
+    LOGGER.info(f'Enterprise Report Schedule: [{frequency}-{hour_of_day}-{day_of_week}-{day_of_month}]')
+
     # All configurations have an hour of the day, so the hour must always match in order to send a report.
     if hour_of_day == current_hour_of_day:
         # If reports should be sent monthly and today is the same as the day configured, return True


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
