### PR TITLE
temp: add log in report delivery logic

### DIFF
--- a/enterprise_reporting/send_enterprise_reports.py
+++ b/enterprise_reporting/send_enterprise_reports.py
@@ -65,6 +65,13 @@ def should_deliver_report(args, reporting_config):
         reporting_config['day_of_month'],
         reporting_config['day_of_week']
     )
+    LOGGER.info("Report Delivery Logic. Active: [%s], ValidDataType: [%s], MeetSchedule: [%s], EnterpriseInArgs: [%s]",
+        reporting_config['active'],
+        valid_data_type,
+        meets_schedule_requirement,
+        enterprise_customer_specified,
+    )
+
     return reporting_config['active'] and \
            valid_data_type and \
            (enterprise_customer_specified or meets_schedule_requirement)

--- a/enterprise_reporting/tests/test_send_enterprise_reports.py
+++ b/enterprise_reporting/tests/test_send_enterprise_reports.py
@@ -2,10 +2,35 @@
 Test send enterprise reports.
 """
 
+import datetime
 import unittest
+from collections import namedtuple
 
-from enterprise_reporting import send_enterprise_reports
+import pytz
+
+from enterprise_reporting.send_enterprise_reports import should_deliver_report
+from enterprise_reporting.utils import FREQUENCY_TYPE_DAILY
 
 
 class TestSendEnterpriseReports(unittest.TestCase):
-	pass
+
+	def test_should_deliver_report(self):
+		"""
+		Verify that `should_deliver_report` works.
+		"""
+		est_timezone = pytz.timezone('US/Eastern')
+		current_est_time = datetime.datetime.now(est_timezone)
+		reporting_config = {
+			'active': True,
+			'data_type': 'progress_v3',
+			'frequency': FREQUENCY_TYPE_DAILY,
+			'hour_of_day': current_est_time.hour,
+			'day_of_month': current_est_time.day,
+			'day_of_week': current_est_time.weekday(),
+		}
+		# these are passed from jenkins when we manually execute an enterprise report job
+		# in case of automated jobs, these are empty
+		Command = namedtuple("Command", "data_type enterprise_customer")
+		args = Command('', '')
+
+		assert should_deliver_report(args, reporting_config)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
