### PR TITLE
build: run coverage for all unit test checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='django32-data'
+      if: matrix.python-version == '3.8' && (matrix.toxenv=='django32-data' || matrix.toxenv=='django32-reporting')
       uses: codecov/codecov-action@v2
       with:
         flags: unittests


### PR DESCRIPTION
### Description
- In the PR https://github.com/openedx/edx-enterprise-data/pull/299 the coverage check was refactored to run on only `django-data` tests but we need to cover `django-reporting` tests as well so updating the workflow to run the coverage check for both `django-data` and `django-reportinig`.