### PR TITLE
fix: Calling refresh token on request level so that it can be checked before every request.

### DIFF
--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -114,7 +114,6 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
 
         return content_metadata
 
-    @EdxOAuth2APIClient.refresh_token
     def get_content_metadata(self, enterprise_customer_catalogs):
         """Return all content metadata contained in the catalogs associated with a reporting config."""
         content_metadata = OrderedDict()
@@ -142,7 +141,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
 
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
-    @EdxOAuth2APIClient.refresh_token
     def get_all_enterprise_reporting_configs(self, **kwargs):
         """
         Query the enterprise customer reporting endpoint for all available configs.
@@ -153,7 +151,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
             **kwargs
         )
 
-    @EdxOAuth2APIClient.refresh_token
     def get_enterprise_reporting_configs(self, enterprise_customer_uuid, **kwargs):
         """
         Query the enterprise customer reporting endpoint for a given enterprise customer.
@@ -165,7 +162,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
             **kwargs
         )
 
-    @EdxOAuth2APIClient.refresh_token
     def get_content_metadata(self, enterprise_customer_uuid, reporting_config):
         """Return all content metadata contained in the catalogs associated with an Enterprise Customer."""
         content_metadata = OrderedDict()
@@ -196,7 +192,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
         # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.
         return list(content_metadata.values())
 
-    @EdxOAuth2APIClient.refresh_token
     def get_customer_catalogs(self, enterprise_customer_uuid):
         """Return all catalog uuids owned by an Enterprise Customer."""
         return self._load_data(
@@ -217,7 +212,6 @@ class EnterpriseDataApiClient(EdxOAuth2APIClient):
     API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'enterprise/api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
-    @EdxOAuth2APIClient.refresh_token
     def get_enterprise_enrollments(self, enterprise_customer_uuid):
         return self._load_data(
             'enterprise',
@@ -244,7 +238,6 @@ class AnalyticsDataApiClient(EdxOAuth2APIClient):
     API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
-    @EdxOAuth2APIClient.refresh_token
     def get_enterprise_engagements(self, enterprise_customer_uuid):
         return self._load_data(
             'enterprise',

--- a/enterprise_reporting/tests/test_clients.py
+++ b/enterprise_reporting/tests/test_clients.py
@@ -3,6 +3,7 @@ Tests for clients in enterprise_reporting.
 """
 from unittest.mock import Mock, patch
 from urllib.parse import urljoin
+from datetime import datetime, timedelta
 
 import responses
 
@@ -37,10 +38,7 @@ class TestEnterpriseAPIClient(TestCase):
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_all_enterprise_reporting_configs(self, mock_get_oauth_access_token):
-        mock_get_oauth_access_token.return_value = {
-            'access_token': 'test_access_token',
-            'expires_in': 10,
-        }
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
         url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_REPORTING_ENDPOINT)
         responses.add(
             responses.GET,
@@ -55,10 +53,7 @@ class TestEnterpriseAPIClient(TestCase):
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_enterprise_reporting_configs(self, mock_get_oauth_access_token):
-        mock_get_oauth_access_token.return_value = {
-            'access_token': 'test_access_token',
-            'expires_in': 10,
-        }
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
         url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_REPORTING_ENDPOINT)
         responses.add(
             responses.GET,
@@ -73,10 +68,7 @@ class TestEnterpriseAPIClient(TestCase):
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_customer_catalogs(self, mock_get_oauth_access_token):
-        mock_get_oauth_access_token.return_value = {
-            'access_token': 'test_access_token',
-            'expires_in': 10,
-        }
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
         url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT)
         responses.add(
             responses.GET,
@@ -91,10 +83,7 @@ class TestEnterpriseAPIClient(TestCase):
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_content_metadata(self, mock_get_oauth_access_token):
-        mock_get_oauth_access_token.return_value = {
-            'access_token': 'test_access_token',
-            'expires_in': 10,
-        }
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
         mocked_get_endpoint = Mock(return_value={
             'results': [{
                 'uuid': self.enterprise_customer_uuid


### PR DESCRIPTION
[ENT-6481](https://2u-internal.atlassian.net/browse/ENT-6481)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
