### PR TITLE
Revert "refactor: Remove enterprise_catalogs API usages"

### DIFF
--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -40,6 +40,7 @@ class EdxOAuth2APIClient(EdxOAuth2APIMixin):
     ENTERPRISE_CATALOG_ROOT_URL = os.getenv('ENTERPRISE_CATALOG_ROOT_URL', default='https://enterprise-catalog.edx.org')
     LMS_OAUTH_HOST = os.getenv('LMS_OAUTH_HOST', default='')
     API_BASE_URL = LMS_ROOT_URL + '/api/'
+    APPEND_SLASH = False
     ACCESS_TOKEN_EXPIRY_THRESHOLD_IN_SECONDS = 60
 
     DEFAULT_VALUE_SAFEGUARD = object()

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -289,19 +289,19 @@ class EnterpriseReportSender:
         return files
 
     def _generate_enterprise_report_catalog_json(self):
-        """Query the Enterprise Catalog API and transfer the results into a JSON file."""
+        """Query the Enterprise Customer Catalog API and transfer the results into a JSON file."""
         content_metadata = self.__get_content_metadata()
         with open(self.data_report_file_name, 'w') as data_report_file:
             json.dump(list(content_metadata), data_report_file, indent=4)
         return [data_report_file]
 
     def __get_content_metadata(self):
-        """Get content metadata from the Enterprise Catalog API."""
+        """Get content metadata from the Enterprise Customer Catalog API."""
         customer_catalogs = extract_catalog_uuids_from_reporting_config(self.reporting_config)
-        enterprise_catalog_api_client = EnterpriseCatalogAPIClient()
-
         if not customer_catalogs.get('results'):
-            customer_catalogs = enterprise_catalog_api_client.get_customer_catalogs(self.enterprise_customer_uuid)
+            platform_api_client = EnterpriseAPIClient()
+            customer_catalogs = platform_api_client.get_customer_catalogs(self.enterprise_customer_uuid)
 
+        enterprise_catalog_api_client = EnterpriseCatalogAPIClient()
         content_metadata = enterprise_catalog_api_client.get_content_metadata(customer_catalogs)
         return content_metadata


### PR DESCRIPTION
See https://2u-internal.atlassian.net/browse/ENT-6619

This reverts commit e20ab8d53937990eebd01562c327c7bd15d5fd80.

Around the time the original commit was deployed, we noticed that the size of some transmitted catalog metadata dropped precipitously.  Trying a revert to identify root cause.

Note this change only affects the `enterprise_reporting` module, which is used stand-alone from a Jenkins job invocation.  It's not installed into the data-analytics-api runtime, and the reverted commit has no corresponding github/PyPI release - hence, there's no version/changelog update in this PR.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
