### PR TITLE
refactor: Remove enterprise_catalogs API usages

### DIFF
--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -40,7 +40,6 @@ class EdxOAuth2APIClient(EdxOAuth2APIMixin):
     ENTERPRISE_CATALOG_ROOT_URL = os.getenv('ENTERPRISE_CATALOG_ROOT_URL', default='https://enterprise-catalog.edx.org')
     LMS_OAUTH_HOST = os.getenv('LMS_OAUTH_HOST', default='')
     API_BASE_URL = LMS_ROOT_URL + '/api/'
-    APPEND_SLASH = False
     ACCESS_TOKEN_EXPIRY_THRESHOLD_IN_SECONDS = 60
 
     DEFAULT_VALUE_SAFEGUARD = object()

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -22,12 +22,10 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
     """
     API_BASE_URL = EdxOAuth2APIClient.ENTERPRISE_CATALOG_ROOT_URL + '/api/v1/'
 
-    APPEND_SLASH = True
-    ENTERPRISE_CATALOGS_ENDPOINT = 'enterprise-catalogs'
-    GET_CONTENT_METADATA_ENDPOINT = ENTERPRISE_CATALOGS_ENDPOINT + '/{}/get_content_metadata'
+    ENTERPRISE_CATALOGS_ENDPOINT = 'enterprise-catalogs/'
+    GET_CONTENT_METADATA_ENDPOINT = 'enterprise-catalogs/{}/get_content_metadata'
 
     ENTERPRISE_REPORTING_ENDPOINT = 'enterprise_customer_reporting'
-    ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT = 'enterprise_catalogs'
 
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
@@ -129,6 +127,17 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.
         return list(content_metadata.values())
 
+    def get_customer_catalogs(self, enterprise_customer_uuid):
+        """Return all catalog uuids owned by an Enterprise Customer."""
+        return self._load_data(
+            self.ENTERPRISE_CATALOGS_ENDPOINT,
+            should_traverse_pagination=True,
+            querystring={
+                'enterprise_customer': enterprise_customer_uuid,
+                'page_size': self.PAGE_SIZE,
+            },
+        )
+
 
 class EnterpriseAPIClient(EdxOAuth2APIClient):
     """
@@ -137,7 +146,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
     API_BASE_URL = urljoin(EdxOAuth2APIClient.LMS_ROOT_URL + '/', 'enterprise/api/v1/')
 
     ENTERPRISE_REPORTING_ENDPOINT = 'enterprise_customer_reporting'
-    ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT = 'enterprise_catalogs'
 
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
@@ -160,47 +168,6 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
             querystring={'enterprise_customer': enterprise_customer_uuid},
             should_traverse_pagination=True,
             **kwargs
-        )
-
-    def get_content_metadata(self, enterprise_customer_uuid, reporting_config):
-        """Return all content metadata contained in the catalogs associated with an Enterprise Customer."""
-        content_metadata = OrderedDict()
-
-        enterprise_customer_catalogs = utils.extract_catalog_uuids_from_reporting_config(reporting_config)
-        if not enterprise_customer_catalogs.get('results'):
-            enterprise_customer_catalogs = self._load_data(
-                self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,
-                should_traverse_pagination=True,
-                querystring={
-                    'enterprise_customer': enterprise_customer_uuid,
-                    'page_size': self.PAGE_SIZE,
-                },
-            )
-        for catalog in enterprise_customer_catalogs.get('results', []):
-            catalog_content = self._load_data(
-                self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,
-                resource_id=catalog['uuid'],
-                should_traverse_pagination=True,
-                querystring={'page_size': self.PAGE_SIZE},
-            )
-            # It's possible that there are duplicate items.
-            # Filter them out by assigning common items to their common identifier in a dictionary.
-            for item in catalog_content['results']:
-                key = 'uuid' if item['content_type'] == 'program' else 'key'
-                content_metadata[item[key]] = item
-
-        # We only made this a dictionary to help filter out duplicates by a common key. We just want values now.
-        return list(content_metadata.values())
-
-    def get_customer_catalogs(self, enterprise_customer_uuid):
-        """Return all catalog uuids owned by an Enterprise Customer."""
-        return self._load_data(
-            self.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT,
-            should_traverse_pagination=True,
-            querystring={
-                'enterprise_customer': enterprise_customer_uuid,
-                'page_size': self.PAGE_SIZE,
-            },
         )
 
 

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -289,19 +289,19 @@ class EnterpriseReportSender:
         return files
 
     def _generate_enterprise_report_catalog_json(self):
-        """Query the Enterprise Customer Catalog API and transfer the results into a JSON file."""
+        """Query the Enterprise Catalog API and transfer the results into a JSON file."""
         content_metadata = self.__get_content_metadata()
         with open(self.data_report_file_name, 'w') as data_report_file:
             json.dump(list(content_metadata), data_report_file, indent=4)
         return [data_report_file]
 
     def __get_content_metadata(self):
-        """Get content metadata from the Enterprise Customer Catalog API."""
+        """Get content metadata from the Enterprise Catalog API."""
         customer_catalogs = extract_catalog_uuids_from_reporting_config(self.reporting_config)
-        if not customer_catalogs.get('results'):
-            platform_api_client = EnterpriseAPIClient()
-            customer_catalogs = platform_api_client.get_customer_catalogs(self.enterprise_customer_uuid)
-
         enterprise_catalog_api_client = EnterpriseCatalogAPIClient()
+
+        if not customer_catalogs.get('results'):
+            customer_catalogs = enterprise_catalog_api_client.get_customer_catalogs(self.enterprise_customer_uuid)
+
         content_metadata = enterprise_catalog_api_client.get_content_metadata(customer_catalogs)
         return content_metadata

--- a/enterprise_reporting/tests/test_clients.py
+++ b/enterprise_reporting/tests/test_clients.py
@@ -10,7 +10,7 @@ import responses
 from django.conf import settings
 from django.test import TestCase
 
-from enterprise_reporting.clients.enterprise import EnterpriseAPIClient
+from enterprise_reporting.clients.enterprise import EnterpriseAPIClient, EnterpriseCatalogAPIClient
 
 
 class TestEnterpriseAPIClient(TestCase):
@@ -20,7 +20,6 @@ class TestEnterpriseAPIClient(TestCase):
 
     def setUp(self):
         self.enterprise_customer_uuid = 'test-enterprise-customer-uuid'
-        self.reporting_config = {}
         self.api_response = {
             'results': [{
                 'enterprise_name': 'Test Enterprise',
@@ -65,52 +64,73 @@ class TestEnterpriseAPIClient(TestCase):
         results = self.client.get_enterprise_reporting_configs(self.enterprise_customer_uuid)
         assert results['results'] == self.api_response['results']
 
+
+class TestEnterpriseCatalogAPIClient(TestCase):
+    """
+    Test Enterprise Catalog API client used to connect to the Enterprise API.
+    """
+
+    def setUp(self):
+        self.enterprise_customer_uuid = 'test-enterprise-customer-uuid'
+        self.program_uuid = 'test-program_uuid'
+        self.client = EnterpriseCatalogAPIClient(  # pylint: disable=attribute-defined-outside-init
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )
+        self.client.API_BASE_URL = 'http://localhost-test:8000/'
+        super().setUp()
+
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_customer_catalogs(self, mock_get_oauth_access_token):
         mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
-        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT)
+        api_response = {
+            'results': [{
+                'enterprise_name': 'Test Enterprise',
+                'enterprise_id': 'test-id'
+            }]
+        }
+        mocked_get_endpoint = Mock(return_value=api_response)
+        url = urljoin(self.client.API_BASE_URL, self.client.ENTERPRISE_CATALOGS_ENDPOINT)
+        url = f'{url}?enterprise_customer={self.enterprise_customer_uuid}&page_size=1000'
         responses.add(
             responses.GET,
             url,
-            json=self.mocked_get_endpoint(),
+            json=mocked_get_endpoint(),
             status=200,
             content_type='application/json'
         )
         results = self.client.get_customer_catalogs(self.enterprise_customer_uuid)
-        assert results['results'] == self.api_response['results']
+        assert results['results'] == api_response['results']
 
     @responses.activate
     @patch('enterprise_reporting.clients.get_oauth_access_token')
     def test_get_content_metadata(self, mock_get_oauth_access_token):
         mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
-        mocked_get_endpoint = Mock(return_value={
+        metadata_api_response = {
             'results': [{
-                'uuid': self.enterprise_customer_uuid
-            }]
-        })
-        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT)
-        responses.add(
-            responses.GET,
-            url,
-            json=mocked_get_endpoint(),
-            status=200,
-            content_type='application/json'
-        )
-        api_response = {
-            'results': [{
-                'uuid': self.enterprise_customer_uuid,
+                'uuid': self.program_uuid,
                 'content_type': 'program',
             }]
         }
-        mocked_get_endpoint = Mock(return_value=api_response)
-        url = urljoin(self.client.API_BASE_URL + '/', self.client.ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT + '/' + self.enterprise_customer_uuid)
+        mocked_get_metadata_endpoint = Mock(return_value=metadata_api_response)
+        url_path = self.client.GET_CONTENT_METADATA_ENDPOINT.format(self.enterprise_customer_uuid)
+        url = urljoin(
+            self.client.API_BASE_URL,
+            f'{url_path}?page_size=1000'
+        )
         responses.add(
             responses.GET,
             url,
-            json=mocked_get_endpoint(),
+            json=mocked_get_metadata_endpoint(),
             status=200,
             content_type='application/json'
         )
-        results = self.client.get_content_metadata(self.enterprise_customer_uuid, self.reporting_config)
-        assert results == api_response['results']
+        request_catalogs = {
+            'results': [{
+                'uuid': self.enterprise_customer_uuid
+            }]
+        }
+        results = self.client.get_content_metadata(request_catalogs)
+        assert results[0]['uuid'] == metadata_api_response['results'][0]['uuid']
+        assert results[0]['content_type'] == metadata_api_response['results'][0]['content_type']


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
