### PR TITLE
fix: enterprise data reporting failure

### DIFF
--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -38,9 +38,16 @@ class EnterpriseCatalogAPIClient(EdxOAuth2APIClient):
         formatted_subjects = []
         for subject in subjects:
             try:
-                subject_name = subject.get('name')
-                if subject_name:
-                    formatted_subjects.append(subject_name)
+                if isinstance(subject, str):
+                    formatted_subjects.append(subject)
+                elif isinstance(subject, dict):
+                    subject_name = subject.get('name')
+                    if subject_name:
+                        formatted_subjects.append(subject_name)
+                else:
+                    error_msg = "Subject is not a string or a dictionary: {}".format(subject)
+                    LOGGER.error("[Enterprise Reporting]. %s", error_msg)
+                    raise TypeError(error_msg)
             except AttributeError as error:
                 LOGGER.exception("[Enterprise Reporting]. Item: %s", item)
                 raise error

--- a/enterprise_reporting/tests/test_clients.py
+++ b/enterprise_reporting/tests/test_clients.py
@@ -128,9 +128,87 @@ class TestEnterpriseCatalogAPIClient(TestCase):
         )
         request_catalogs = {
             'results': [{
-                'uuid': self.enterprise_customer_uuid
+                'uuid': self.enterprise_customer_uuid,
             }]
         }
         results = self.client.get_content_metadata(request_catalogs)
         assert results[0]['uuid'] == metadata_api_response['results'][0]['uuid']
         assert results[0]['content_type'] == metadata_api_response['results'][0]['content_type']
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_accepted_subject_in_content_metadata(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
+        metadata_api_response = {
+            'results': [{
+                'key': 'test_key',
+                'uuid': 'test_course_uuid',
+                'content_type': 'course',
+                'subjects': [
+                    {
+                        'name': 'Business & Management',
+                    },
+                    'Communication'
+                ],
+            }]
+        }
+        mocked_get_metadata_endpoint = Mock(return_value=metadata_api_response)
+        url_path = self.client.GET_CONTENT_METADATA_ENDPOINT.format(self.enterprise_customer_uuid)
+        url = urljoin(
+            self.client.API_BASE_URL,
+            f'{url_path}?page_size=1000'
+        )
+        responses.add(
+            responses.GET,
+            url,
+            json=mocked_get_metadata_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        request_catalogs = {
+            'results': [{
+                'uuid': self.enterprise_customer_uuid,
+            }]
+        }
+        results = self.client.get_content_metadata(request_catalogs)
+        assert results[0]['uuid'] == metadata_api_response['results'][0]['uuid']
+
+    @responses.activate
+    @patch('enterprise_reporting.clients.get_oauth_access_token')
+    def test_rejected_subject_format_in_content_metadata(self, mock_get_oauth_access_token):
+        mock_get_oauth_access_token.return_value = ['test_access_token', datetime.now() + timedelta(minutes=60)]
+        metadata_api_response = {
+            'results': [{
+                'key': 'test_key',
+                'uuid': 'test_course_uuid',
+                'content_type': 'course',
+                'subjects': [
+                    [
+                        'Communication'
+                    ]
+                ],
+            }]
+        }
+        mocked_get_metadata_endpoint = Mock(return_value=metadata_api_response)
+        url_path = self.client.GET_CONTENT_METADATA_ENDPOINT.format(self.enterprise_customer_uuid)
+        url = urljoin(
+            self.client.API_BASE_URL,
+            f'{url_path}?page_size=1000'
+        )
+        responses.add(
+            responses.GET,
+            url,
+            json=mocked_get_metadata_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
+        request_catalogs = {
+            'results': [{
+                'uuid': self.enterprise_customer_uuid,
+            }]
+        }
+        expected_error_message = "Subject is not a string or a dictionary: ['Communication']"
+        try:
+            results = self.client.get_content_metadata(request_catalogs)
+        except Exception as e:
+            self.assertEqual(str(e), expected_error_message)


### PR DESCRIPTION
**Problem:**
 The reason for this failure is that the data that we fetch from the enterprise catalog is inconsistent for the subjects field. Sometimes the subjects field is a list of strings and other times it is a list of dict objects.
Example:
The list of strings look like 
```
'subjects': [
    'Business & Management',
    'Communication'
  ],
```

List of dict. look like 
```
'subjects': [
    {
        'name': 'Business & Management',
    }
],
```
**Solution:** 
The solution that I have implemented is to update the logic in the enterprise-data-reporting job to handle both the above-mentioned formats of the subject field.

Here is the ticket [ENT-6752](https://2u-internal.atlassian.net/browse/ENT-6752)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
