### PR TITLE
build: remove unnecessary codecov dependency & upgrade GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && (matrix.toxenv=='django32-data' || matrix.toxenv=='django32-reporting')
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,6 +1,6 @@
 # Requirements for running tests in Github actions
 -c constraints.txt
 
-codecov                   # Code coverage reporting
+coverage                  # Calculate code coverage of tests.
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.5.0
     # via codecov
 distlib==0.3.6


### PR DESCRIPTION
Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/

**Merge checklist:**
- ❌ (won't do) Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
