### PR TITLE
Change EnterpriseOfferViewSet URL to have offer_id in path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ geckodriver/
 
 # Visual Studio Code
 .vscode
+
+# pyenv
+.python-version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.6.7] - 2023-06-14
+--------------------
+  * Add support for offer_id to be either an integer or a UUID.
+
 [4.6.6] - 2023-06-12
 --------------------
   * Migrate offer_id to a varchar field in the EnterpriseOffer and EnterpriseLearnerEnrollment models.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,7 +2,7 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.6.6"
+__version__ = "4.6.7"
 
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/tests/api/v1/test_serializers.py
+++ b/enterprise_data/tests/api/v1/test_serializers.py
@@ -2,12 +2,18 @@
 Tests for the `edx-enterprise` api v1 serializer module.
 """
 
+import uuid
+
 import ddt
 from pytest import mark
 from rest_framework.test import APITransactionTestCase
 
-from enterprise_data.api.v1.serializers import EnterpriseLearnerEnrollmentSerializer
-from enterprise_data.tests.test_utils import EnterpriseLearnerEnrollmentFactory, EnterpriseLearnerFactory
+from enterprise_data.api.v1.serializers import EnterpriseLearnerEnrollmentSerializer, EnterpriseOfferSerializer
+from enterprise_data.tests.test_utils import (
+    EnterpriseLearnerEnrollmentFactory,
+    EnterpriseLearnerFactory,
+    EnterpriseOfferFactory,
+)
 
 
 @mark.django_db
@@ -35,3 +41,62 @@ class TestEnterpriseLearnerEnrollmentSerializer(APITransactionTestCase):
         self.enrollment.save()
         serializer = EnterpriseLearnerEnrollmentSerializer(self.enrollment)
         assert serializer.data['total_learning_time_hours'] == expected_total_learning_time_seconds
+
+
+@ddt.ddt
+class TestEnterpriseOfferSerializer(APITransactionTestCase):
+    """
+    Tests for `enterprise_offer` API serializer.
+    """
+
+    @ddt.data(
+        ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
+        ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
+        ('11111111111111111111111111111111', '11111111-1111-1111-1111-111111111111'),
+        # fewer or more than 32 characters should serialize into integers.
+        ('1111111111111111111111111111111', '1111111111111111111111111111111'),
+        ('111111111111111111111111111111111', '111111111111111111111111111111111'),
+        # We never want to see the following cases in real life, but at least thye're deterministic and don't crash.
+        ('abc', 'abc'),  # Not exactly 32 characters but also obviously not an integer.
+        ('', ''),
+    )
+    @ddt.unpack
+    def test_serialize_offer_id(self, offer_id_db, offer_id_serialized):
+        offer = EnterpriseOfferFactory(offer_id=offer_id_db)
+        serialized_offer = EnterpriseOfferSerializer(offer)
+        assert serialized_offer.data['offer_id'] == offer_id_serialized
+
+    @ddt.data(
+        # Representations that could be real UUIDs should always be normalized to un-hyphenated UUIDs.
+        ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
+        ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
+        # hyphens in the wrong place, but gosh dangit this is a valid UUID!
+        ('787f0fa7-f89a-4267-9e2bfcd299e8391-8', '787f0fa7f89a42679e2bfcd299e83918'),
+        # Representations that are integers should be deserialized verbatim. 31-33 lengths.
+        ('1111111111111111111111111111111', '1111111111111111111111111111111'),
+        ('11111111111111111111111111111111', '11111111111111111111111111111111'),
+        ('111111111111111111111111111111111', '111111111111111111111111111111111'),
+    )
+    @ddt.unpack
+    def test_deserialize_offer_id_valid(self, offer_id_request, offer_id_validated):
+        data = {
+            'offer_id': offer_id_request,
+            'enterprise_customer_uuid': str(uuid.uuid4()),
+        }
+        serializer = EnterpriseOfferSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data['offer_id'] == offer_id_validated
+
+    @ddt.data(
+        # The following should fail validation because we want to avoid storing these into the DB.
+        None,  # null values not allowed.
+        '',  # empty values not allowed.
+        'abc',  # Not exactly 32 characters but also obviously not an integer.
+    )
+    def test_deserialize_offer_id_invalid(self, offer_id_request):
+        data = {
+            'offer_id': offer_id_request,
+            'enterprise_customer_uuid': str(uuid.uuid4()),
+        }
+        serializer = EnterpriseOfferSerializer(data=data)
+        assert not serializer.is_valid()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,21 +6,21 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
     #   oscrypto
     #   snowflake-connector-python
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -37,7 +37,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
@@ -91,12 +91,12 @@ docutils==0.16
     # via awscli
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -106,16 +106,14 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 factory-boy==3.2.1
     # via -r requirements/base.in
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via snowflake-connector-python
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via
     #   requests
@@ -140,7 +138,7 @@ packaging==23.1
     #   snowflake-connector-python
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 pbr==5.11.1
     # via stevedore
@@ -156,14 +154,10 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via
-    #   pyjwkest
-    #   snowflake-connector-python
+pycryptodomex==3.18.0
+    # via snowflake-connector-python
 pygments==2.15.1
     # via py2neo
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -178,7 +172,7 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
 python-dateutil==2.8.2
     # via
@@ -195,12 +189,11 @@ pytz==2023.3
     #   snowflake-connector-python
 pyyaml==5.4.1
     # via awscli
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   slumber
     #   snowflake-connector-python
 rsa==4.7.2
@@ -220,24 +213,27 @@ six==1.16.0
     #   interchange
     #   pansi
     #   py2neo
-    #   pyjwkest
     #   python-dateutil
     #   vertica-python
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.5.0
-    # via snowflake-connector-python
+typing-extensions==4.6.3
+    # via
+    #   asgiref
+    #   snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-coverage==7.2.5
+coverage==7.2.7
     # via -r requirements/ci.in
 distlib==0.3.6
     # via virtualenv
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -29,9 +29,7 @@ tox==3.28.0
     #   -c requirements/constraints.txt
     #   -r requirements/ci.in
     #   tox-battery
-tox-battery==0.5.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.in
+tox-battery==0.6.1
+    # via -r requirements/ci.in
 virtualenv==20.23.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,10 +13,4 @@
 # Stick to the latest LTS version of Django
 Django>=3.2,<4.0
 
-# it's experimental, so keep it pinned
-tox-battery==0.5.2
-
-# Constrain until https://github.com/datadriventests/ddt/issues/83 is fixed.
-ddt<1.4.0
-
 tox<4.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
@@ -16,7 +16,7 @@ astroid==2.15.5
     # via
     #   pylint
     #   pylint-celery
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
@@ -24,9 +24,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -47,7 +47,7 @@ cffi==1.15.1
     #   snowflake-connector-python
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
@@ -74,7 +74,7 @@ cryptography==40.0.2
     #   pyopenssl
     #   secretstorage
     #   snowflake-connector-python
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/dev-enterprise_data.in
 dill==0.3.6
     # via pylint
@@ -120,12 +120,12 @@ docutils==0.16
     #   readme-renderer
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -141,19 +141,17 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 factory-boy==3.2.1
     # via -r requirements/base.in
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via
     #   requests
@@ -190,9 +188,9 @@ kombu==4.6.11
     # via celery
 lazy-object-proxy==1.9.0
     # via astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
@@ -214,7 +212,7 @@ packaging==23.1
     #   tox
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 path==16.6.0
     # via edx-i18n-tools
@@ -226,7 +224,7 @@ pip-tools==6.13.0
     # via -r requirements/dev-enterprise_data.in
 pkginfo==1.9.6
     # via twine
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   pylint
     #   virtualenv
@@ -250,10 +248,8 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via
-    #   pyjwkest
-    #   snowflake-connector-python
+pycryptodomex==3.18.0
+    # via snowflake-connector-python
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.15.1
@@ -262,8 +258,6 @@ pygments==2.15.1
     #   py2neo
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -280,7 +274,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.8.1
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
@@ -292,7 +286,7 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
 pyproject-hooks==1.0.0
     # via build
@@ -318,12 +312,11 @@ pyyaml==5.4.1
     #   edx-i18n-tools
 readme-renderer==37.3
     # via twine
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-toolbelt
     #   slumber
     #   snowflake-connector-python
@@ -332,7 +325,7 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.2
     # via twine
 rsa==4.7.2
     # via awscli
@@ -355,7 +348,6 @@ six==1.16.0
     #   interchange
     #   pansi
     #   py2neo
-    #   pyjwkest
     #   python-dateutil
     #   tox
     #   vertica-python
@@ -363,8 +355,10 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.2.0
     # via pydocstyle
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -389,21 +383,20 @@ tox==3.28.0
     #   -c requirements/constraints.txt
     #   -r requirements/dev-enterprise_data.in
     #   tox-battery
-tox-battery==0.5.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev-enterprise_data.in
+tox-battery==0.6.1
+    # via -r requirements/dev-enterprise_data.in
 twine==4.0.2
     # via -r requirements/dev-enterprise_data.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   asgiref
     #   astroid
     #   pylint
     #   rich
     #   snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 # Core dependencies for installing other packages
 -c constraints.txt
 
-pip==20.0.2
+pip
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.0.2
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.7.2
+setuptools==67.8.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,7 +6,7 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
@@ -16,7 +16,7 @@ astroid==2.15.5
     # via
     #   pylint
     #   pylint-celery
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
@@ -24,9 +24,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -47,7 +47,7 @@ cffi==1.15.1
     #   snowflake-connector-python
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
@@ -64,7 +64,7 @@ code-annotations==1.3.0
     # via edx-lint
 colorama==0.4.4
     # via awscli
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==40.0.2
     # via
@@ -76,11 +76,9 @@ cryptography==40.0.2
     #   pyopenssl
     #   secretstorage
     #   snowflake-connector-python
-ddt==1.3.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-diff-cover==7.5.0
+ddt==1.6.0
+    # via -r requirements/test.in
+diff-cover==7.6.0
     # via -r requirements/dev-enterprise_data.in
 dill==0.3.6
     # via pylint
@@ -127,12 +125,12 @@ docutils==0.16
     #   readme-renderer
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -148,7 +146,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 exceptiongroup==1.1.1
     # via pytest
@@ -156,9 +154,9 @@ factory-boy==3.2.1
     # via
     #   -r requirements/base.in
     #   -r requirements/test.in
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   snowflake-connector-python
     #   tox
@@ -167,8 +165,6 @@ flaky==3.7.0
     # via -r requirements/test.in
 freezegun==1.2.2
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via
     #   requests
@@ -207,9 +203,9 @@ kombu==4.6.11
     # via celery
 lazy-object-proxy==1.9.0
     # via astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
@@ -234,7 +230,7 @@ packaging==23.1
     #   tox
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 path==16.6.0
     # via edx-i18n-tools
@@ -246,7 +242,7 @@ pip-tools==6.13.0
     # via -r requirements/dev-enterprise_data.in
 pkginfo==1.9.6
     # via twine
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   pylint
     #   virtualenv
@@ -271,10 +267,8 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via
-    #   pyjwkest
-    #   snowflake-connector-python
+pycryptodomex==3.18.0
+    # via snowflake-connector-python
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.15.1
@@ -283,8 +277,6 @@ pygments==2.15.1
     #   py2neo
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -301,7 +293,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.8.1
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
@@ -313,15 +305,15 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -349,12 +341,11 @@ pyyaml==5.4.1
     #   responses
 readme-renderer==37.3
     # via twine
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-toolbelt
     #   responses
     #   slumber
@@ -366,7 +357,7 @@ responses==0.23.1
     # via -r requirements/test.in
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.2
     # via twine
 rsa==4.7.2
     # via awscli
@@ -389,7 +380,6 @@ six==1.16.0
     #   interchange
     #   pansi
     #   py2neo
-    #   pyjwkest
     #   python-dateutil
     #   tox
     #   vertica-python
@@ -397,8 +387,10 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.2.0
     # via pydocstyle
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -427,23 +419,22 @@ tox==3.28.0
     #   -c requirements/constraints.txt
     #   -r requirements/dev-enterprise_data.in
     #   tox-battery
-tox-battery==0.5.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev-enterprise_data.in
+tox-battery==0.6.1
+    # via -r requirements/dev-enterprise_data.in
 twine==4.0.2
     # via -r requirements/dev-enterprise_data.in
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   asgiref
     #   astroid
     #   pylint
     #   rich
     #   snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -6,21 +6,21 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
     #   oscrypto
     #   snowflake-connector-python
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -37,7 +37,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
@@ -45,7 +45,7 @@ click==8.1.3
     # via edx-django-utils
 colorama==0.4.4
     # via awscli
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==40.0.2
     # via
@@ -56,10 +56,8 @@ cryptography==40.0.2
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
-ddt==1.3.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
+ddt==1.6.0
+    # via -r requirements/test.in
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -99,12 +97,12 @@ docutils==0.16
     # via awscli
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   -r requirements/test-master.in
@@ -115,7 +113,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 exceptiongroup==1.1.1
     # via pytest
@@ -123,16 +121,14 @@ factory-boy==3.2.1
     # via
     #   -r requirements/base.in
     #   -r requirements/test.in
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via snowflake-connector-python
 flaky==3.7.0
     # via -r requirements/test.in
 freezegun==1.2.2
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via
     #   requests
@@ -162,7 +158,7 @@ packaging==23.1
     #   snowflake-connector-python
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 pbr==5.11.1
     # via stevedore
@@ -180,14 +176,10 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via
-    #   pyjwkest
-    #   snowflake-connector-python
+pycryptodomex==3.18.0
+    # via snowflake-connector-python
 pygments==2.15.1
     # via py2neo
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -202,13 +194,13 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -230,12 +222,11 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   responses
     #   slumber
     #   snowflake-connector-python
@@ -258,13 +249,14 @@ six==1.16.0
     #   interchange
     #   pansi
     #   py2neo
-    #   pyjwkest
     #   python-dateutil
     #   vertica-python
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -277,13 +269,15 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
-    # via snowflake-connector-python
+typing-extensions==4.6.3
+    # via
+    #   asgiref
+    #   snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -14,15 +14,15 @@ atomicwrites==1.4.1
     # via pytest
 attrs==23.1.0
     # via pytest
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -39,13 +39,13 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
 colorama==0.4.4
     # via awscli
-coverage==7.2.5
+coverage==7.2.7
     # via pytest-cov
 cryptography==40.0.2
     # via
@@ -55,14 +55,12 @@ cryptography==40.0.2
     #   pyopenssl
     #   snowflake-connector-python
 ddt==1.1.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-reporting.in
+    # via -r requirements/test-reporting.in
 distlib==0.3.6
     # via virtualenv
 docutils==0.16
     # via awscli
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   snowflake-connector-python
     #   tox
@@ -94,13 +92,13 @@ packaging==23.1
     #   tox
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 pbr==5.11.1
     # via mock
 pgpy==0.6.0
     # via -r requirements/reporting.in
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -118,7 +116,7 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via snowflake-connector-python
 pygments==2.15.1
     # via py2neo
@@ -128,7 +126,7 @@ pyminizip==0.2.6
     # via -r requirements/reporting.in
 pynacl==1.5.0
     # via paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
 pytest==3.7.1
     # via
@@ -149,7 +147,7 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   responses
     #   snowflake-connector-python
@@ -171,8 +169,10 @@ six==1.16.0
     #   python-dateutil
     #   tox
     #   vertica-python
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 tomli==2.0.1
     # via tox
 tox==3.28.0
@@ -180,17 +180,15 @@ tox==3.28.0
     #   -c requirements/constraints.txt
     #   -r requirements/test-reporting.in
     #   tox-battery
-tox-battery==0.5.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-reporting.in
-types-pyyaml==6.0.12.9
+tox-battery==0.6.1
+    # via -r requirements/test-reporting.in
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,21 +6,21 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
     #   oscrypto
     #   snowflake-connector-python
-awscli==1.27.134
+awscli==1.27.153
     # via -r requirements/reporting.in
 bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
-boto3==1.26.134
+boto3==1.26.153
     # via -r requirements/reporting.in
-botocore==1.29.134
+botocore==1.29.153
     # via
     #   awscli
     #   boto3
@@ -37,7 +37,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   requests
     #   snowflake-connector-python
@@ -45,7 +45,7 @@ click==8.1.3
     # via edx-django-utils
 colorama==0.4.4
     # via awscli
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==40.0.2
     # via
@@ -56,10 +56,8 @@ cryptography==40.0.2
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
-ddt==1.3.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
+ddt==1.6.0
+    # via -r requirements/test.in
 django==3.2.19
     # via
     #   -c requirements/constraints.txt
@@ -98,12 +96,12 @@ docutils==0.16
     # via awscli
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -113,7 +111,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 exceptiongroup==1.1.1
     # via pytest
@@ -121,16 +119,14 @@ factory-boy==3.2.1
     # via
     #   -r requirements/base.in
     #   -r requirements/test.in
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via snowflake-connector-python
 flaky==3.7.0
     # via -r requirements/test.in
 freezegun==1.2.2
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via
     #   requests
@@ -160,7 +156,7 @@ packaging==23.1
     #   snowflake-connector-python
 pansi==2020.7.3
     # via py2neo
-paramiko==3.1.0
+paramiko==3.2.0
     # via -r requirements/reporting.in
 pbr==5.11.1
     # via stevedore
@@ -178,14 +174,10 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via
-    #   pyjwkest
-    #   snowflake-connector-python
+pycryptodomex==3.18.0
+    # via snowflake-connector-python
 pygments==2.15.1
     # via py2neo
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -200,13 +192,13 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via snowflake-connector-python
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -228,12 +220,11 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   responses
     #   slumber
     #   snowflake-connector-python
@@ -256,13 +247,14 @@ six==1.16.0
     #   interchange
     #   pansi
     #   py2neo
-    #   pyjwkest
     #   python-dateutil
     #   vertica-python
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==3.0.3
+snowflake-connector-python==3.0.4
     # via -r requirements/reporting.in
+sortedcontainers==2.4.0
+    # via snowflake-connector-python
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -275,13 +267,15 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
-    # via snowflake-connector-python
+typing-extensions==4.6.3
+    # via
+    #   asgiref
+    #   snowflake-connector-python
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   py2neo


### PR DESCRIPTION
## Background

The latest release of new learner credit aggregate reporting mixes 2 data types in to a single field `offer_id`. There are Integers from the ecommerce system and UUIDs from the new subsidy service. Typically we pass UUIDs between systems in their usual format; 36 characters long, with dashes. We store UUIDs in the database without the dashes. Since this column has both UUIDs and integers in the column, we can not use the django UUID type and do not get the free conversion between dashed and no dashed versions. 

This PR is an attempt to add the hyphens and de-hyphenate to the serialize to allow us to:
- Continue storing UUIDs with no hyphens
- Pass UUIDs between systems with hyphens
- Allow continued querying of this data for ecommerce offers. 

## TODO
- This could use a good test 
- Does this make sense?

### Example call from learner portal
Here is an example call to this API from the admin portal using a UUID with dashes:
<img width="785" alt="Screenshot 2023-06-13 at 9 12 05 PM" src="https://github.com/openedx/edx-enterprise-data/assets/67862/de6506e5-9bf2-44ba-a83e-445e2653e83f">



**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
