### PR TITLE
Allow querying of offers by either new style UUIDs or old style enterprise ID numbers.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.6.9] - 2023-06-14
+--------------------
+  * Allow querying of offers by either new style UUIDs or old style enterprise ID numbers.
+
 [4.6.8] - 2023-06-14
 --------------------
   * Add to_internal_value method for offer_id translation.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,7 +2,7 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.6.8"
+__version__ = "4.6.9"
 
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -2,13 +2,9 @@
 Serializers for enterprise api v1.
 """
 
-import logging
-
 from rest_framework import serializers
 
 from enterprise_data.models import EnterpriseLearner, EnterpriseLearnerEnrollment, EnterpriseOffer
-
-LOGGER = logging.getLogger(__name__)
 
 
 class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
@@ -63,25 +59,6 @@ class EnterpriseOfferSerializer(serializers.ModelSerializer):
         model = EnterpriseOffer
         fields = '__all__'
 
-    # def validate_offer_id(self, value) -> str:
-    #     """
-    #     For a given offer_id string from the requester, determine the best representation to use for db storage.
-    #
-    #     Raises serializers.ValidationError:
-    #         If the given string is not exclusively numeric characters, but also does not parse as a UUID (either because
-    #         it has the wrong length, incorrect dashes, or some other reason).
-    #     """
-    #     LOGGER.warning('Validating offer ID: %s', value)
-    #     if len(value) < 10 and isinstance(value, int):
-    #         LOGGER.warning('Validated offer ID is int: %s', value)
-    #         return value
-    #
-    #     elif isinstance(value, str) and len(value) == 32:
-    #         LOGGER.warning('Validated offer ID is string/UUID: %s', value)
-    #         return value
-    #
-    #     else:
-    #         raise serializers.ValidationError("requested offer_id neither a valid integer nor UUID.")
 
     def to_internal_value(self, data):
         """
@@ -93,31 +70,26 @@ class EnterpriseOfferSerializer(serializers.ModelSerializer):
             If the given string is not exclusively numeric characters, but also does not parse as a UUID (either because
             it has the wrong length, incorrect dashes, or some other reason).
         """
-        LOGGER.warning('Converting offer ID to internal value to_internal_value: %s', data)
         ret = super().to_internal_value(data)
         if ret['offer_id'] is None or ret['offer_id'] == '':
             raise serializers.ValidationError("requested offer_id is None.")
 
         if isinstance(ret['offer_id'], str) and len(ret['offer_id']) == 36:
-            # attempt to remove the dashes
             offer_id = ret['offer_id'].replace('-', '')
-            LOGGER.warning("offer_id after removing dashes: %s", offer_id)
+            # There should only be 4 dashes in the UUID, making the length 32 after removal
             if len(offer_id) == 32:
                 ret['offer_id'] = offer_id
-                LOGGER.warning('Converted offer ID to internal value to_internal_value: %s', ret['offer_id'])
                 return ret
 
             else:
                 raise serializers.ValidationError("requested offer_id neither a valid integer nor UUID.")
 
-        if len(ret['offer_id']) < 10:
-            LOGGER.warning("offer_id is less than 10 characters: %s", ret['offer_id'])
+        if len(ret['offer_id']) < 10:  # All ecommerce offer_ids are at < 1 million.
             try:
                 ret['offer_id'] = int(ret['offer_id'])
-                LOGGER.warning('Converted offer ID to internal value to_internal_value: %s', ret['offer_id'])
                 return ret
-            except ValueError:
-                raise serializers.ValidationError("Requested offer_id not a valid integer.")
+            except ValueError as e:
+                raise serializers.ValidationError("Requested offer_id not a valid integer.") from e
 
         raise serializers.ValidationError("requested offer_id neither a valid integer nor UUID.")
 

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -59,7 +59,6 @@ class EnterpriseOfferSerializer(serializers.ModelSerializer):
         model = EnterpriseOffer
         fields = '__all__'
 
-
     def to_internal_value(self, data):
         """
         Convert the incoming data offer_id field to a format that can be stored in the db.

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -275,6 +275,11 @@ class EnterpriseOfferViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewS
     )
 
     def get_object(self):
+        """
+        This ensures that UUIDs with dashes are properly handled when requesting info about offers.
+
+        Related to the work in EnterpriseOfferSerializer with `to_internal_value` and `to_representation`
+        """
         self.kwargs['offer_id'] = self.kwargs['offer_id'].replace('-', '')
         return super().get_object()
 

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -267,14 +267,19 @@ class EnterpriseOfferViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewS
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend,)
     ordering_fields = '__all__'
 
+    lookup_field = 'offer_id'
+
     filterset_fields = (
         'offer_id',
         'status'
     )
 
+    def get_object(self):
+        self.kwargs['offer_id'] = self.kwargs['offer_id'].replace('-', '')
+        return super().get_object()
+
     def get_queryset(self):
         enterprise_customer_uuid = self.kwargs['enterprise_id']
-        import pdb; pdb.set_trace()
         return EnterpriseOffer.objects.filter(
             enterprise_customer_uuid=enterprise_customer_uuid,
         )

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -274,6 +274,7 @@ class EnterpriseOfferViewSet(EnterpriseViewSetMixin, viewsets.ReadOnlyModelViewS
 
     def get_queryset(self):
         enterprise_customer_uuid = self.kwargs['enterprise_id']
+        import pdb; pdb.set_trace()
         return EnterpriseOffer.objects.filter(
             enterprise_customer_uuid=enterprise_customer_uuid,
         )

--- a/enterprise_data/tests/api/v1/test_serializers.py
+++ b/enterprise_data/tests/api/v1/test_serializers.py
@@ -52,6 +52,7 @@ class TestEnterpriseOfferSerializer(APITransactionTestCase):
     @ddt.data(
         ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
         ('56a779a5-21ec-4711-830f-6654d3faaa5f', '56a779a521ec4711830f6654d3faaa5f'),
+        ('12345', 12345),
     )
     @ddt.unpack
     def test_deserialize_offer_id_valid(self, offer_id_request, offer_id_db):
@@ -67,7 +68,8 @@ class TestEnterpriseOfferSerializer(APITransactionTestCase):
         # Representations that could be real UUIDs should always be normalized to un-hyphenated UUIDs.
         ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
         ('f0d5fcdbed8e4d408f3b79d1671f967f', 'f0d5fcdb-ed8e-4d40-8f3b-79d1671f967f'),
-        ('c1d39f8a3fd246758bf7f56dd076694d', 'c1d39f8a-3fd2-4675-8bf7-f56dd076694d')
+        ('c1d39f8a3fd246758bf7f56dd076694d', 'c1d39f8a-3fd2-4675-8bf7-f56dd076694d'),
+        ('12345', '12345'),
     )
     @ddt.unpack
     def test_serialize_offer_id_valid(self, offer_id_db, offer_id_serialized):

--- a/enterprise_data/tests/api/v1/test_serializers.py
+++ b/enterprise_data/tests/api/v1/test_serializers.py
@@ -50,54 +50,46 @@ class TestEnterpriseOfferSerializer(APITransactionTestCase):
     """
 
     @ddt.data(
-        ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
-        ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
-        ('11111111111111111111111111111111', '11111111-1111-1111-1111-111111111111'),
-        # fewer or more than 32 characters should serialize into integers.
-        ('1111111111111111111111111111111', '1111111111111111111111111111111'),
-        ('111111111111111111111111111111111', '111111111111111111111111111111111'),
-        # We never want to see the following cases in real life, but at least thye're deterministic and don't crash.
-        ('abc', 'abc'),  # Not exactly 32 characters but also obviously not an integer.
-        ('', ''),
+        ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
+        ('56a779a5-21ec-4711-830f-6654d3faaa5f', '56a779a521ec4711830f6654d3faaa5f'),
     )
     @ddt.unpack
-    def test_serialize_offer_id(self, offer_id_db, offer_id_serialized):
+    def test_deserialize_offer_id_valid(self, offer_id_request, offer_id_db):
+        data = {
+            'offer_id': offer_id_request,
+            'enterprise_customer_uuid': str(uuid.uuid4()),
+        }
+        serialized_offer = EnterpriseOfferSerializer(data=data)
+        assert serialized_offer.is_valid()
+        assert serialized_offer.validated_data['offer_id'] == offer_id_db
+
+    @ddt.data(
+        # Representations that could be real UUIDs should always be normalized to un-hyphenated UUIDs.
+        ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7-f89a-4267-9e2b-fcd299e83918'),
+        ('f0d5fcdbed8e4d408f3b79d1671f967f', 'f0d5fcdb-ed8e-4d40-8f3b-79d1671f967f'),
+        ('c1d39f8a3fd246758bf7f56dd076694d', 'c1d39f8a-3fd2-4675-8bf7-f56dd076694d')
+    )
+    @ddt.unpack
+    def test_serialize_offer_id_valid(self, offer_id_db, offer_id_serialized):
         offer = EnterpriseOfferFactory(offer_id=offer_id_db)
         serialized_offer = EnterpriseOfferSerializer(offer)
         assert serialized_offer.data['offer_id'] == offer_id_serialized
 
+
     @ddt.data(
-        # Representations that could be real UUIDs should always be normalized to un-hyphenated UUIDs.
-        ('787f0fa7-f89a-4267-9e2b-fcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
-        ('787f0fa7f89a42679e2bfcd299e83918', '787f0fa7f89a42679e2bfcd299e83918'),
-        # hyphens in the wrong place, but gosh dangit this is a valid UUID!
-        ('787f0fa7-f89a-4267-9e2bfcd299e8391-8', '787f0fa7f89a42679e2bfcd299e83918'),
-        # Representations that are integers should be deserialized verbatim. 31-33 lengths.
-        ('1111111111111111111111111111111', '1111111111111111111111111111111'),
-        ('11111111111111111111111111111111', '11111111111111111111111111111111'),
-        ('111111111111111111111111111111111', '111111111111111111111111111111111'),
+        # The following should fail validation because we want to avoid storing these into the DB.
+        None,  # null values not allowed.
+        '',  # empty values not allowed.
+        'abc',  # Not exactly 36 characters but also obviously not an integer.
+        '787f0fa7f89a42679e2bfcd299e83918',  # Not exactly 36 characters but also obviously not an integer.
+        '11111111111',  # greater than 10 digit integer
+        '111111111111111111111111111111111111',  # 36 digit integer
+        '11111111111111111111111111111111',  # 32 digit integer
     )
-    @ddt.unpack
-    def test_deserialize_offer_id_valid(self, offer_id_request, offer_id_validated):
+    def test_deserialize_offer_id_invalid(self, offer_id_request):
         data = {
             'offer_id': offer_id_request,
             'enterprise_customer_uuid': str(uuid.uuid4()),
         }
         serializer = EnterpriseOfferSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data['offer_id'] == offer_id_validated
-
-    # Commenting out for now, to test a theory on the serializergit sta to_internal_value
-    # @ddt.data(
-    #     # The following should fail validation because we want to avoid storing these into the DB.
-    #     None,  # null values not allowed.
-    #     '',  # empty values not allowed.
-    #     'abc',  # Not exactly 32 characters but also obviously not an integer.
-    # )
-    # def test_deserialize_offer_id_invalid(self, offer_id_request):
-    #     data = {
-    #         'offer_id': offer_id_request,
-    #         'enterprise_customer_uuid': str(uuid.uuid4()),
-    #     }
-    #     serializer = EnterpriseOfferSerializer(data=data)
-    #     assert not serializer.is_valid()
+        assert not serializer.is_valid()

--- a/enterprise_data/tests/api/v1/test_serializers.py
+++ b/enterprise_data/tests/api/v1/test_serializers.py
@@ -77,7 +77,6 @@ class TestEnterpriseOfferSerializer(APITransactionTestCase):
         serialized_offer = EnterpriseOfferSerializer(offer)
         assert serialized_offer.data['offer_id'] == offer_id_serialized
 
-
     @ddt.data(
         # The following should fail validation because we want to avoid storing these into the DB.
         None,  # null values not allowed.

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -126,9 +126,9 @@ class TestEnterpriseOffersViewSet(JWTTestMixin, APITransactionTestCase):
         self.client.force_authenticate(user=self.user)
 
         self.enterprise_customer_uuid_1 = uuid4()
-        self.enterprise_offer_1_offer_id = str(uuid4()).replace('-', '')
+        self.enterprise_offer_1_offer_id = str(uuid4())
         self.enterprise_offer_1 = EnterpriseOfferFactory(
-            offer_id=self.enterprise_offer_1_offer_id,
+            offer_id=self.enterprise_offer_1_offer_id.replace('-', ''),
             enterprise_customer_uuid=self.enterprise_customer_uuid_1
         )
 


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
