### PR TITLE
feat: improve queries and implement caching for EnterpriseLearnerEnr…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.6.10] - 2023-06-20
+---------------------
+  * Improve querries and implement caching for EnterpriseLearnerEnrollmentViewSet.
+
 [4.6.9] - 2023-06-14
 --------------------
   * Allow querying of offers by either new style UUIDs or old style enterprise ID numbers.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,7 +2,7 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.6.9"
+__version__ = "4.6.10"
 
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -7,6 +7,7 @@ from datetime import date, timedelta
 from logging import getLogger
 
 from django_filters.rest_framework import DjangoFilterBackend
+from edx_django_utils.cache import TieredCache
 from edx_rbac.mixins import PermissionRequiredMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.paginators import DefaultPagination
@@ -24,8 +25,10 @@ from enterprise_data.constants import ANALYTICS_API_VERSION_1
 from enterprise_data.filters import AuditEnrollmentsFilterBackend, AuditUsersEnrollmentFilterBackend
 from enterprise_data.models import EnterpriseLearner, EnterpriseLearnerEnrollment, EnterpriseOffer
 from enterprise_data.paginators import EnterpriseEnrollmentsPagination
+from enterprise_data.utils import get_cache_key
 
 LOGGER = getLogger(__name__)
+DEFAULT_LEARNER_CACHE_TIMEOUT = 60 * 10
 
 
 def subtract_one_month(original_date):
@@ -103,20 +106,29 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
             return EnterpriseLearnerEnrollment.objects.none()
 
         enterprise_customer_uuid = self.kwargs['enterprise_id']
+        cache_key = get_cache_key(
+            resource='enterprise-learner',
+            enterprise_customer=enterprise_customer_uuid,
+        )
+        cached_response = TieredCache.get_cached_response(cache_key)
+        if cached_response.is_found:
+            return cached_response.value
+        else:
+            enterprise = EnterpriseLearner.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid).exists()
 
-        enterprise = EnterpriseLearner.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid)
-        if not enterprise:
-            LOGGER.warning(
-                "[Data Overview Failure] Wrong Enterprise UUID. UUID [%s], Endpoint ['%s'], User: [%s]",
-                enterprise_customer_uuid,
-                self.request.get_full_path(),
-                self.request.user.username,
-            )
+            if not enterprise:
+                LOGGER.warning(
+                    "[Data Overview Failure] Wrong Enterprise UUID. UUID [%s], Endpoint ['%s'], User: [%s]",
+                    enterprise_customer_uuid,
+                    self.request.get_full_path(),
+                    self.request.user.username,
+                )
 
-        enrollments = EnterpriseLearnerEnrollment.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid)
+            enrollments = EnterpriseLearnerEnrollment.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid)
 
-        enrollments = self.apply_filters(enrollments)
-        return enrollments
+            enrollments = self.apply_filters(enrollments)
+            TieredCache.set_all_tiers(cache_key, enrollments, DEFAULT_LEARNER_CACHE_TIMEOUT)
+            return enrollments
 
     def apply_filters(self, queryset):
         """

--- a/enterprise_data/apps.py
+++ b/enterprise_data/apps.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 """
 Enterprise Data Django application initialization.
 """
@@ -11,3 +12,9 @@ class EnterpriseDataAppConfig(AppConfig):
     """
 
     name = "enterprise_data"
+
+    def ready(self) -> None:
+        """
+        Perform tasks when the Django application is ready.
+        """
+        import enterprise_data.signals

--- a/enterprise_data/signals.py
+++ b/enterprise_data/signals.py
@@ -1,0 +1,33 @@
+# pylint: skip-file
+
+"""
+Signals for enterprise-data.
+"""
+
+
+from edx_django_utils.cache import TieredCache
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from enterprise_data.models import EnterpriseLearner, EnterpriseLearnerEnrollment
+from enterprise_data.utils import get_cache_key
+
+
+@receiver([post_save, post_delete], sender=[EnterpriseLearner, EnterpriseLearnerEnrollment])
+def clear_cache(instance, **kwargs):
+    """
+    Signal receiver function to clear the cache of specified model.
+    """
+    cache_key = get_cache_key(
+        resource='enterprise-learner',
+        enterprise_customer=instance.enterprise_customer_uuid,
+    )
+    TieredCache.delete_all_tiers(cache_key)
+
+
+# connecting signal with reciever.
+post_save.connect(clear_cache, sender=EnterpriseLearner)
+post_save.connect(clear_cache, sender=EnterpriseLearnerEnrollment)
+post_delete.connect(clear_cache, sender=EnterpriseLearner)
+post_delete.connect(clear_cache, sender=EnterpriseLearnerEnrollment)


### PR DESCRIPTION
**Description**
we are getting performance issues on `EnterpriseLearnerEnrollmentViewSet`. So after diagnosing I have updated the query of getting learner to make it more efficient and apply caching on `EnterpriseLearnerEnrollmentViewSet` to make results fast.

[JIRA-4727](https://2u-internal.atlassian.net/browse/ENT-4727)
…ollmentViewSet

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
