### PR TITLE
feat: exponential backoff while obtaining access token

### DIFF
--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -8,7 +8,13 @@ from functools import wraps
 from urllib.parse import parse_qs, urljoin, urlparse
 from edx_rest_api_client.client import get_oauth_access_token
 
+import logging
 import requests
+
+from enterprise_reporting.utils import retry_on_exception
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class EdxOAuth2APIMixin:
@@ -53,6 +59,7 @@ class EdxOAuth2APIClient(EdxOAuth2APIMixin):
         self.expires_at = datetime.utcnow()
         self.access_token = None
 
+    @retry_on_exception(max_retries=3, delay=2, backoff=2)
     def connect(self):
         """
         Connect to the REST API, authenticating with an access token retrieved with our client credentials.

--- a/enterprise_reporting/tests/test_utils.py
+++ b/enterprise_reporting/tests/test_utils.py
@@ -295,3 +295,24 @@ class TestPrepareAttachments(unittest.TestCase):
                 os.path.basename(filename)
             )
             assert attachments[index].get('Content-Disposition') == expected_header
+
+
+class TestRetryOnException(unittest.TestCase):
+    """
+    Test that the decorator `retry_on_exception` works correctly.
+    """
+
+    def test_retry_on_exception(self):
+        """
+        retry_on_exception should retry the function the given
+        number of times if an exception is raised.
+        """
+
+        @utils.retry_on_exception(max_retries=1, delay=1, backoff=1)
+        def raise_exception():
+            raise Exception('test')
+
+        # The function should be retried once after an exception,
+        # then raise the exception.
+        with self.assertRaises(Exception):
+            raise_exception()


### PR DESCRIPTION
**Description:**
This work adds retry mechanism with exponential backoff while trying to obtain access token from the edx-platform. The inspiration for this work were the data reporting failures which were caused by failure in obtaining access token due to the unavailability of edx-platform service for brief amount of time. 

JIRA: [ENT-7274](https://2u-internal.atlassian.net/browse/ENT-7274)

The output of testing this decorator in a standalone script is in the following screenshot. 
<img width="522" alt="Screenshot 2023-07-03 at 4 47 28 PM" src="https://github.com/openedx/edx-enterprise-data/assets/106396899/750c6003-7c70-4120-97b9-498d0859e1bc">

The script is as following. 
```
def retry_on_exception(max_retries=3, delay=2, backoff=2):
    """
    Decorator to retry a function on exception with exponential backoff. The
    function will be retried on exception up to max_retries times. The delay
    between retries will increase exponentially with each retry.

    :param max_retries: maximum number of retries
    :param delay: initial delay in seconds
    :param backoff: backoff multiplier e.g. value of 2 will double the delay

    :return: decorator
    """

    def backoff_time(retry_count):
        """
        Calculate wait time using exponential backoff formula

        :param retry_count: number of retries
        :return: wait time
        """
        return delay * (backoff ** (retry_count - 1))

    def wait(wait_time):
        """
        Wait for wait_time seconds using time.sleep

        :param wait_time: time to wait in seconds
        :return: None
        """
        import time
        time.sleep(wait_time)

    def decorator_retry(func):
        def wrapper(*args, **kwargs):
            retry_count = 0
            while retry_count < max_retries:  # retry loop
                try:
                    return func(*args, **kwargs)
                except Exception as e:
                    retry_count += 1
                    print(f"Retrying after exception: {e}")
                    time = backoff_time(retry_count)
                    wait(time)
            return func(*args, **kwargs)  # last attempt (don't wait)
        return wrapper
    return decorator_retry

@retry_on_exception(max_retries=3, delay=2, backoff=2)
def exception():
    raise Exception("Exception")
```


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
