### PR TITLE
ENT-7675: Added retry mechanism for failed requests while sending reports.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[5.5.1] - 2024-01-10
+---------------------
+  * Added retry mechanism for failed report deliveries.
+
 [5.5.0] - 2023-10-19
 ---------------------
   * Add data export timestamp

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "5.5.0"
+__version__ = "5.5.1"

--- a/enterprise_reporting/reporter.py
+++ b/enterprise_reporting/reporter.py
@@ -20,7 +20,12 @@ from enterprise_reporting.clients.enterprise import (
 from enterprise_reporting.clients.s3 import S3Client
 from enterprise_reporting.clients.vertica import VerticaClient
 from enterprise_reporting.delivery_method import SFTPDeliveryMethod, SMTPDeliveryMethod
-from enterprise_reporting.utils import decrypt_string, extract_catalog_uuids_from_reporting_config, generate_data
+from enterprise_reporting.utils import (
+    decrypt_string,
+    extract_catalog_uuids_from_reporting_config,
+    generate_data,
+    retry_on_exception,
+)
 
 LOGGER = logging.getLogger(__name__)
 NOW = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -115,6 +120,7 @@ class EnterpriseReportSender:
         """Get a full path to the report file that can be modified with arbitrary formatting."""
         return '_{}.'.join(self.data_report_file_name.rsplit('.'))
 
+    @retry_on_exception(max_retries=2, delay=1, backoff=2)
     def send_enterprise_report(self):
         """Generate the report file of the appropriate type and send it through the configured delivery method."""
         LOGGER.info(f'Starting process to send report to {self.enterprise_customer_name}')


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7675](https://2u-internal.atlassian.net/browse/ENT-7675)

__Description:__
This PR Adds retry mechanism for failed requests while sending reports


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
