### PR TITLE
feat: Added api response for engagements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Unreleased
 ----------
 
 =========================
+[8.10.0] - 2024-08-27
+---------------------
+  * feat: Added API endpoints for advance analytics engagements data.
 
 [8.9.0] - 2024-08-23
 ---------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "8.9.0"
+__version__ = "8.10.0"

--- a/enterprise_data/admin_analytics/constants.py
+++ b/enterprise_data/admin_analytics/constants.py
@@ -31,3 +31,11 @@ class ResponseType(Enum):
     """Response type choices"""
     JSON = 'json'
     CSV = 'csv'
+
+
+class EngagementChart(Enum):
+    """Response Choices"""
+    ENGAGEMENTS_OVER_TIME = 'engagements_over_time'
+    TOP_COURSES_BY_ENGAGEMENTS = 'top_courses_by_engagements'
+    TOP_SUBJECTS_BY_ENGAGEMENTS = 'top_subjects_by_engagements'
+    INDIVIDUAL_ENGAGEMENTS = 'individual_engagements'

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -5,7 +5,13 @@ from uuid import UUID
 
 from rest_framework import serializers
 
-from enterprise_data.admin_analytics.constants import Calculation, EnrollmentChart, Granularity, ResponseType
+from enterprise_data.admin_analytics.constants import (
+    Calculation,
+    EngagementChart,
+    EnrollmentChart,
+    Granularity,
+    ResponseType,
+)
 from enterprise_data.models import (
     EnterpriseAdminLearnerProgress,
     EnterpriseAdminSummarizeInsights,
@@ -317,6 +323,30 @@ class AdvanceAnalyticsEnrollmentStatsSerializer(
         EnrollmentChart.ENROLLMENTS_OVER_TIME.value,
         EnrollmentChart.TOP_COURSES_BY_ENROLLMENTS.value,
         EnrollmentChart.TOP_SUBJECTS_BY_ENROLLMENTS.value
+    ]
+
+    chart_type = serializers.CharField(required=False)
+
+    def validate_chart_type(self, value):
+        """
+        Validate the chart_type value.
+
+        Raises:
+            serializers.ValidationError: If chart_type is not one of the valid choices
+        """
+        if value not in self.CHART_TYPES:
+            raise serializers.ValidationError(f"chart_type must be one of {self.CHART_TYPES}")
+        return value
+
+
+class AdvanceAnalyticsEngagementStatsSerializer(
+    AdvanceAnalyticsQueryParamSerializer
+):  # pylint: disable=abstract-method
+    """Serializer for validating Advance Analytics Engagements Stats API"""
+    CHART_TYPES = [
+        EngagementChart.ENGAGEMENTS_OVER_TIME.value,
+        EngagementChart.TOP_COURSES_BY_ENGAGEMENTS.value,
+        EngagementChart.TOP_SUBJECTS_BY_ENGAGEMENTS.value
     ]
 
     chart_type = serializers.CharField(required=False)

--- a/enterprise_data/api/v1/urls.py
+++ b/enterprise_data/api/v1/urls.py
@@ -11,6 +11,10 @@ from enterprise_data.api.v1.views import enterprise_admin as enterprise_admin_vi
 from enterprise_data.api.v1.views import enterprise_completions as enterprise_completions_views
 from enterprise_data.api.v1.views import enterprise_learner as enterprise_learner_views
 from enterprise_data.api.v1.views import enterprise_offers as enterprise_offers_views
+from enterprise_data.api.v1.views.analytics_engagements import (
+    AdvanceAnalyticsEngagementStatsView,
+    AdvanceAnalyticsIndividualEngagementsView,
+)
 from enterprise_data.api.v1.views.analytics_enrollments import (
     AdvanceAnalyticsEnrollmentStatsView,
     AdvanceAnalyticsIndividualEnrollmentsView,
@@ -72,6 +76,16 @@ urlpatterns = [
         fr'^admin/analytics/(?P<enterprise_uuid>{UUID4_REGEX})/enrollments$',
         AdvanceAnalyticsIndividualEnrollmentsView.as_view(),
         name='enterprise-admin-analytics-enrollments'
+    ),
+    re_path(
+        fr'^admin/analytics/(?P<enterprise_uuid>{UUID4_REGEX})/engagements/stats$',
+        AdvanceAnalyticsEngagementStatsView.as_view(),
+        name='enterprise-admin-analytics-engagements-stats'
+    ),
+    re_path(
+        fr'^admin/analytics/(?P<enterprise_uuid>{UUID4_REGEX})/engagements$',
+        AdvanceAnalyticsIndividualEngagementsView.as_view(),
+        name='enterprise-admin-analytics-engagements'
     ),
     re_path(
         fr'^admin/analytics/(?P<enterprise_id>{UUID4_REGEX})/skills/stats',

--- a/enterprise_data/api/v1/views/analytics_engagements.py
+++ b/enterprise_data/api/v1/views/analytics_engagements.py
@@ -1,0 +1,395 @@
+"""Advance Analytics for Engagements"""
+from datetime import datetime
+
+from edx_rbac.decorators import permission_required
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework import status as rest_status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from django.http import HttpResponse, StreamingHttpResponse
+
+from enterprise_data.admin_analytics.constants import Calculation, EngagementChart, Granularity, ResponseType
+from enterprise_data.admin_analytics.utils import (
+    calculation_aggregation,
+    fetch_and_cache_engagements_data,
+    fetch_and_cache_enrollments_data,
+    fetch_enrollments_cache_expiry_timestamp,
+    granularity_aggregation,
+)
+from enterprise_data.api.v1 import serializers
+from enterprise_data.api.v1.paginators import AdvanceAnalyticsPagination
+from enterprise_data.renderers import IndividualEngagementsCSVRenderer
+from enterprise_data.utils import date_filter
+
+
+class AdvanceAnalyticsIndividualEngagementsView(APIView):
+    """
+    API for getting the advance analytics individual engagements data.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    pagination_class = AdvanceAnalyticsPagination
+    http_method_names = ["get"]
+
+    @permission_required('can_access_enterprise', fn=lambda request, enterprise_uuid: enterprise_uuid)
+    def get(self, request, enterprise_uuid):
+        """
+        HTTP GET endpoint to retrieve the enterprise engagements data.
+        """
+        serializer = serializers.AdvanceAnalyticsEngagementStatsSerializer(data=request.GET)
+        serializer.is_valid(raise_exception=True)
+        cache_expiry = fetch_enrollments_cache_expiry_timestamp()
+
+        enrollment_df = fetch_and_cache_enrollments_data(enterprise_uuid, cache_expiry).copy()
+        engagement_df = fetch_and_cache_engagements_data(enterprise_uuid, cache_expiry).copy()
+        # Use start and end date if provided by the client, if client has not provided then use
+        # 1. minimum enrollment date from the data as the start_date
+        # 2. today's date as the end_date
+        start_date = serializer.data.get('start_date', enrollment_df.enterprise_enrollment_date.min())
+        end_date = serializer.data.get('end_date', datetime.now())
+        response_type = request.query_params.get('response_type', ResponseType.JSON.value)
+        # Date filtering.
+        engagements = date_filter(
+            start=start_date, end=end_date, data_frame=engagement_df.copy(), date_column='activity_date'
+        )
+        engagements["learning_time_hours"] = engagements["learning_time_seconds"] / 60 / 60
+        engagements = engagements[engagements["learning_time_hours"] > 0]
+        engagements["learning_time_hours"] = round(engagements["learning_time_hours"].astype(float), 1)
+
+        # Select only the columns that will be in the table.
+        engagements = engagements[
+            [
+                "email",
+                "course_title",
+                "activity_date",
+                "course_subject",
+                "learning_time_hours",
+            ]
+        ]
+        engagements["activity_date"] = engagements["activity_date"].dt.date
+        engagements = engagements.sort_values(by="activity_date", ascending=False).reset_index(drop=True)
+        if response_type == ResponseType.CSV.value:
+            response = StreamingHttpResponse(
+                IndividualEngagementsCSVRenderer().render(self._stream_serialized_data(engagements)),
+                content_type="text/csv"
+            )
+            start_date = start_date.strftime('%Y/%m/%d')
+            end_date = end_date.strftime('%Y/%m/%d')
+            filename = f"""Individual Engagements, {start_date} - {end_date}.csv"""
+            response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            response['Access-Control-Expose-Headers'] = 'Content-Disposition'
+            return response
+
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(engagements, request)
+        serialized_data = page.data.to_dict(orient='records')
+        response = paginator.get_paginated_response(serialized_data)
+
+        return response
+
+    def _stream_serialized_data(self, engagements, chunk_size=50000):
+        """
+        Stream the serialized data.
+        """
+        total_rows = engagements.shape[0]
+        for start_index in range(0, total_rows, chunk_size):
+            end_index = min(start_index + chunk_size, total_rows)
+            chunk = engagements.iloc[start_index:end_index]
+            yield from chunk.to_dict(orient='records')
+
+
+class AdvanceAnalyticsEngagementStatsView(APIView):
+    """
+    API for getting the advance analytics engagements statistics data.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    http_method_names = ["get"]
+
+    @permission_required('can_access_enterprise', fn=lambda request, enterprise_uuid: enterprise_uuid)
+    def get(self, request, enterprise_uuid):
+        """
+        HTTP GET endpoint to retrieve the enterprise engagements statistics data.
+        """
+        serializer = serializers.AdvanceAnalyticsEngagementStatsSerializer(data=request.GET)
+        serializer.is_valid(raise_exception=True)
+
+        cache_expiry = fetch_enrollments_cache_expiry_timestamp()
+
+        enrollment_df = fetch_and_cache_enrollments_data(enterprise_uuid, cache_expiry).copy()
+        engagement_df = fetch_and_cache_engagements_data(enterprise_uuid, cache_expiry).copy()
+        # Use start and end date if provided by the client, if client has not provided then use
+        # 1. minimum enrollment date from the data as the start_date
+        # 2. today's date as the end_date
+        start_date = serializer.data.get('start_date', enrollment_df.enterprise_enrollment_date.min())
+        end_date = serializer.data.get('end_date', datetime.now())
+        granularity = serializer.data.get('granularity', Granularity.DAILY.value)
+        calculation = serializer.data.get('calculation', Calculation.TOTAL.value)
+        chart_type = serializer.data.get('chart_type')
+
+        if chart_type is None:
+            data = {
+                "engagements_over_time": self.construct_engagements_over_time(
+                    engagement_df.copy(),
+                    start_date,
+                    end_date,
+                    granularity,
+                    calculation,
+                ),
+                "top_courses_by_engagement": self.construct_top_courses_by_engagements(
+                    engagement_df.copy(),
+                    start_date,
+                    end_date,
+                ),
+                "top_subjects_by_engagement": self.construct_top_subjects_by_engagements(
+                    engagement_df.copy(),
+                    start_date,
+                    end_date,
+                ),
+            }
+            return Response(data)
+        elif chart_type == EngagementChart.ENGAGEMENTS_OVER_TIME.value:
+            return self.construct_engagements_over_time_csv(
+                engagement_df.copy(),
+                start_date,
+                end_date,
+                granularity,
+                calculation,
+            )
+        elif chart_type == EngagementChart.TOP_COURSES_BY_ENGAGEMENTS.value:
+            return self.construct_top_courses_by_engagements_csv(
+                engagement_df.copy(),
+                start_date,
+                end_date,
+            )
+        elif chart_type == EngagementChart.TOP_SUBJECTS_BY_ENGAGEMENTS.value:
+            return self.construct_top_subjects_by_engagements_csv(
+                engagement_df.copy(),
+                start_date,
+                end_date,
+            )
+        return Response(data='Not Found', status=rest_status.HTTP_400_BAD_REQUEST)
+
+    def engagements_over_time_common(self, engagements_df, start_date, end_date, granularity, calculation):
+        """
+        Common method for constructing engagements over time data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+            granularity {str} -- Granularity of the data. One of Granularity choices
+            calculation {str} -- Calculation of the data. One of Calculation choices
+        """
+        engagements_df["learning_time_hours"] = engagements_df["learning_time_seconds"] / 60 / 60
+        engagements_df = engagements_df[engagements_df["learning_time_hours"] > 0]
+        engagements_df["learning_time_hours"] = round(engagements_df["learning_time_hours"].astype(float), 1)
+
+        engagements_df = engagements_df[["activity_date", "enroll_type", "learning_time_hours"]]
+
+        # Date filtering.
+        engagements_df = date_filter(
+            start=start_date, end=end_date, data_frame=engagements_df, date_column="activity_date"
+        )
+
+        # Date aggregation.
+        engagements_df = granularity_aggregation(
+            level=granularity,
+            group=["activity_date", "enroll_type"],
+            date="activity_date",
+            data_frame=engagements_df,
+            aggregation_type="sum",
+        )
+
+        # Calculating metric.
+        engagements = calculation_aggregation(calc=calculation, aggregation_type="sum", data_frame=engagements_df)
+        return engagements
+
+    def construct_engagements_over_time(self, engagements_df, start_date, end_date, granularity, calculation):
+        """
+        Construct engagements over time data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+            granularity {str} -- Granularity of the data. One of Granularity choices
+            calculation {str} -- Calculation of the data. One of Calculation choices
+        """
+        engagements = self.engagements_over_time_common(engagements_df, start_date, end_date, granularity, calculation)
+        # convert dataframe to a list of records
+        return engagements.to_dict(orient='records')
+
+    def construct_engagements_over_time_csv(self, engagements_df, start_date, end_date, granularity, calculation):
+        """
+        Construct engagements over time CSV.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+            granularity {str} -- Granularity of the data. One of Granularity choices
+            calculation {str} -- Calculation of the data. One of Calculation choices
+        """
+        engagements = self.engagements_over_time_common(engagements_df, start_date, end_date, granularity, calculation)
+
+        engagements = engagements.pivot(
+            index="activity_date", columns="enroll_type", values="sum"
+        )
+
+        filename = f"Engagement Timeseries, {start_date} - {end_date} ({granularity} {calculation}).csv"
+        return self.construct_csv_response(engagements, filename)
+
+    def top_courses_by_engagements_common(self, engagements_df, start_date, end_date):
+        """
+        Common method for constructing top courses by engagements data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+            group_by_columns {list} -- List of columns to group by
+            columns {list} -- List of column for the final result
+        """
+        engagements_df["learning_time_hours"] = engagements_df["learning_time_seconds"] / 60 / 60
+        engagements_df["learning_time_hours"] = engagements_df["learning_time_hours"].astype("float")
+
+        # Date filtering.
+        engagements = date_filter(
+            start=start_date, end=end_date, data_frame=engagements_df, date_column="activity_date"
+        )
+
+        courses = list(
+            engagements.groupby(["course_key"])
+            .learning_time_hours.sum()
+            .sort_values(ascending=False)[:10]
+            .index
+        )
+
+        engagements = (
+            engagements_df[engagements_df.course_key.isin(courses)]
+            .groupby(["course_key", "course_title", "enroll_type"])
+            .learning_time_hours.sum()
+            .reset_index()
+        )
+
+        engagements.columns = ["course_key", "course_title", "enroll_type", "count"]
+
+        return engagements
+
+    def construct_top_courses_by_engagements(self, engagements_df, start_date, end_date):
+        """
+        Construct top courses by engagements data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+        """
+        engagements = self.top_courses_by_engagements_common(
+            engagements_df,
+            start_date,
+            end_date
+        )
+
+        # convert dataframe to a list of records
+        return engagements.to_dict(orient='records')
+
+    def construct_top_courses_by_engagements_csv(self, engagements_df, start_date, end_date):
+        """
+        Construct top courses by engagements CSV.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+        """
+        engagements = self.top_courses_by_engagements_common(
+            engagements_df,
+            start_date,
+            end_date
+        )
+
+        engagements = engagements.pivot(
+            index=["course_key", "course_title"], columns="enroll_type", values="count"
+        )
+
+        filename = f"Top 10 Courses by Learning Hours, {start_date} - {end_date}.csv"
+        return self.construct_csv_response(engagements, filename)
+
+    def top_subjects_by_engagements_common(self, engagements_df, start_date, end_date):
+        """
+        Common method for constructing top subjects by engagements data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+        """
+        engagements_df["learning_time_hours"] = engagements_df["learning_time_seconds"] / 60 / 60
+        engagements_df["learning_time_hours"] = engagements_df["learning_time_hours"].astype("float")
+
+        # Date filtering.
+        engagements = date_filter(
+            start=start_date, end=end_date, data_frame=engagements_df, date_column="activity_date"
+        )
+
+        subjects = list(
+            engagements.groupby(["course_subject"])
+            .learning_time_hours.sum()
+            .sort_values(ascending=False)[:10]
+            .index
+        )
+
+        engagements = (
+            engagements[engagements.course_subject.isin(subjects)]
+            .groupby(["course_subject", "enroll_type"])
+            .learning_time_hours.sum()
+            .reset_index()
+        )
+        engagements.columns = ["course_subject", "enroll_type", "count"]
+
+        return engagements
+
+    def construct_top_subjects_by_engagements(self, engagements_df, start_date, end_date):
+        """
+        Construct top subjects by engagements data.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+        """
+        engagements = self.top_subjects_by_engagements_common(engagements_df, start_date, end_date)
+        # convert dataframe to a list of records
+        return engagements.to_dict(orient='records')
+
+    def construct_top_subjects_by_engagements_csv(self, engagements_df, start_date, end_date):
+        """
+        Construct top subjects by engagements CSV.
+
+        Arguments:
+            engagements_df {DataFrame} -- DataFrame of engagements
+            start_date {datetime} -- Engagement start date in the format 'YYYY-MM-DD'
+            end_date {datetime} -- Engagement end date in the format 'YYYY-MM-DD'
+        """
+        engagements = self.top_subjects_by_engagements_common(engagements_df, start_date, end_date)
+        engagements = engagements.pivot(index="course_subject", columns="enroll_type", values="count")
+        filename = f"Top 10 Subjects by Learning Hours, {start_date} - {end_date}.csv"
+        return self.construct_csv_response(engagements, filename)
+
+    def construct_csv_response(self, engagements, filename):
+        """
+        Construct CSV response.
+
+        Arguments:
+            engagements {DataFrame} -- DataFrame of engagements
+            filename {str} -- Filename for the CSV
+        """
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response['Access-Control-Expose-Headers'] = 'Content-Disposition'
+        engagements.to_csv(path_or_buf=response)
+
+        return response

--- a/enterprise_data/api/v1/views/analytics_enrollments.py
+++ b/enterprise_data/api/v1/views/analytics_enrollments.py
@@ -382,6 +382,7 @@ class AdvanceAnalyticsEnrollmentStatsView(APIView):
         """
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response['Access-Control-Expose-Headers'] = 'Content-Disposition'
         enrollments.to_csv(path_or_buf=response)
 
         return response

--- a/enterprise_data/api/v1/views/analytics_leaderboard.py
+++ b/enterprise_data/api/v1/views/analytics_leaderboard.py
@@ -120,7 +120,10 @@ class AdvanceAnalyticsLeaderboardView(APIView):
             return StreamingHttpResponse(
                 LeaderboardCSVRenderer().render(self._stream_serialized_data(leaderboard_df)),
                 content_type="text/csv",
-                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+                headers={
+                    "Content-Disposition": f'attachment; filename="{filename}"',
+                    "Access-Control-Expose-Headers": "Content-Disposition"
+                },
             )
 
         paginator = self.pagination_class()

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -208,6 +208,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
             response = HttpResponse(content_type='text/csv')
             filename = f"Skills by Enrollment and Completion, {start_date} - {end_date}.csv"
             response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            response['Access-Control-Expose-Headers'] = 'Content-Disposition'
             csv_data.to_csv(path_or_buf=response, index=False)
             return response
 

--- a/enterprise_data/api/v1/views/enterprise_completions.py
+++ b/enterprise_data/api/v1/views/enterprise_completions.py
@@ -90,6 +90,7 @@ class EnterrpiseAdminCompletionsStatsView(APIView):
                     )
             filename = csv_data['filename']
             response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            response['Access-Control-Expose-Headers'] = 'Content-Disposition'
             csv_data['data'].to_csv(path_or_buf=response)
             return response
 
@@ -187,6 +188,7 @@ class EnterrpiseAdminCompletionsView(APIView):
             response = HttpResponse(content_type='text/csv')
             filename = f"Individual Completions, {start_date} - {end_date}.csv"
             response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            response['Access-Control-Expose-Headers'] = 'Content-Disposition'
             dff.to_csv(path_or_buf=response, index=False)
             return response
 

--- a/enterprise_data/renderers.py
+++ b/enterprise_data/renderers.py
@@ -57,3 +57,17 @@ class LeaderboardCSVRenderer(CSVStreamingRenderer):
         'average_session_length',
         'course_completions',
     ]
+
+
+class IndividualEngagementsCSVRenderer(CSVStreamingRenderer):
+    """
+    Custom streaming csv renderer for advance analytics individual engagements data.
+    """
+
+    header = [
+        'email',
+        'course_title',
+        'activity_date',
+        'course_subject',
+        'learning_time_hours',
+    ]

--- a/enterprise_data/tests/admin_analytics/mock_analytics_data.py
+++ b/enterprise_data/tests/admin_analytics/mock_analytics_data.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from enterprise_data.admin_analytics.constants import EnrollmentChart
+from enterprise_data.admin_analytics.constants import EngagementChart, EnrollmentChart
 from enterprise_data.admin_analytics.utils import ChartType
 
 ENROLLMENTS = [
@@ -339,6 +339,30 @@ ENROLLMENT_STATS_CSVS = {
     )
 }
 
+ENGAGEMENT_STATS_CSVS = {
+    EngagementChart.ENGAGEMENTS_OVER_TIME.value: (
+        b'activity_date,certificate\n'
+        b'2021-07-19,0.0\n'
+        b'2021-07-26,4.4\n'
+        b'2021-07-27,1.2\n'
+        b'2021-08-05,3.6\n'
+        b'2021-08-21,2.7\n'
+        b'2021-09-02,1.3\n'
+        b'2021-09-21,1.5\n'
+        b'2022-05-17,0.0\n'
+    ),
+    EngagementChart.TOP_COURSES_BY_ENGAGEMENTS.value: (
+        b'course_key,course_title,certificate\n'
+        b'Kcpr+XoR30,Assimilated even-keeled focus group,0.0\n'
+        b'luGg+KNt30,Synergized reciprocal encoding,14.786944444444444\n'
+    ),
+    EngagementChart.TOP_SUBJECTS_BY_ENGAGEMENTS.value: (
+        b'course_subject,certificate\n'
+        b'business-management,14.786944444444444\n'
+        b'engineering,0.0\n'
+    )
+}
+
 
 def enrollments_dataframe():
     """Return a DataFrame of enrollments."""
@@ -509,3 +533,19 @@ COMPLETIONS_STATS_CSVS = {
         b'business-management,2\n'
     )
 }
+
+
+def engagements_csv_content():
+    """Return the CSV content of engagements."""
+    return (
+        b'email,course_title,activity_date,course_subject,learning_time_hours\r\n'
+        b'graceperez@example.com,Synergized reciprocal encoding,2022-05-17,business-management,0.0\r\n'
+        b'webertodd@example.com,Synergized reciprocal encoding,2021-09-21,business-management,1.5\r\n'
+        b'yferguson@example.net,Synergized reciprocal encoding,2021-09-02,business-management,1.3\r\n'
+        b'seth57@example.org,Synergized reciprocal encoding,2021-08-21,business-management,2.7\r\n'
+        b'padillamichelle@example.org,Synergized reciprocal encoding,2021-08-05,business-management,1.0\r\n'
+        b'weaverpatricia@example.net,Synergized reciprocal encoding,2021-08-05,business-management,2.6\r\n'
+        b'yallison@example.org,Synergized reciprocal encoding,2021-07-27,business-management,1.2\r\n'
+        b'paul77@example.org,Synergized reciprocal encoding,2021-07-26,business-management,4.4\r\n'
+        b'samanthaclarke@example.org,Synergized reciprocal encoding,2021-07-19,business-management,0.0\r\n'
+    )

--- a/enterprise_data/tests/admin_analytics/test_analytics_engagements.py
+++ b/enterprise_data/tests/admin_analytics/test_analytics_engagements.py
@@ -1,0 +1,390 @@
+"""Unittests for analytics_enrollments.py"""
+
+from datetime import datetime
+
+import ddt
+from mock import patch
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITransactionTestCase
+
+from enterprise_data.admin_analytics.constants import EngagementChart, ResponseType
+from enterprise_data.api.v1.serializers import AdvanceAnalyticsEngagementStatsSerializer as EngagementSerializer
+from enterprise_data.tests.admin_analytics.mock_analytics_data import (
+    ENGAGEMENT_STATS_CSVS,
+    ENGAGEMENTS,
+    engagements_csv_content,
+    engagements_dataframe,
+    enrollments_dataframe,
+)
+from enterprise_data.tests.mixins import JWTTestMixin
+from enterprise_data.tests.test_utils import UserFactory
+from enterprise_data_roles.constants import ENTERPRISE_DATA_ADMIN_ROLE
+from enterprise_data_roles.models import EnterpriseDataFeatureRole, EnterpriseDataRoleAssignment
+
+INVALID_CALCULATION_ERROR = (
+    f"Calculation must be one of {EngagementSerializer.CALCULATION_CHOICES}"
+)
+INVALID_GRANULARITY_ERROR = (
+    f"Granularity must be one of {EngagementSerializer.GRANULARITY_CHOICES}"
+)
+INVALID_CSV_ERROR1 = f"chart_type must be one of {EngagementSerializer.CHART_TYPES}"
+
+
+@ddt.ddt
+class TestIndividualEngagementsAPI(JWTTestMixin, APITransactionTestCase):
+    """Tests for AdvanceAnalyticsIndividualEngagementsView."""
+
+    def setUp(self):
+        """
+        Setup method.
+        """
+        super().setUp()
+        self.user = UserFactory(is_staff=True)
+        role, __ = EnterpriseDataFeatureRole.objects.get_or_create(
+            name=ENTERPRISE_DATA_ADMIN_ROLE
+        )
+        self.role_assignment = EnterpriseDataRoleAssignment.objects.create(
+            role=role, user=self.user
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.enterprise_uuid = "ee5e6b3a-069a-4947-bb8d-d2dbc323396c"
+        self.set_jwt_cookie()
+
+        self.url = reverse(
+            "v1:enterprise-admin-analytics-engagements",
+            kwargs={"enterprise_uuid": self.enterprise_uuid},
+        )
+
+        fetch_max_enrollment_datetime_patcher = patch(
+            'enterprise_data.admin_analytics.utils.fetch_max_enrollment_datetime',
+            return_value=datetime.now()
+        )
+
+        fetch_max_enrollment_datetime_patcher.start()
+        self.addCleanup(fetch_max_enrollment_datetime_patcher.stop)
+
+    def verify_engagement_data(self, results, results_count):
+        """Verify the received engagement data."""
+        attrs = [
+            "email",
+            "course_title",
+            "activity_date",
+            "course_subject",
+        ]
+
+        assert len(results) == results_count
+
+        filtered_data = []
+        for engagement in ENGAGEMENTS:
+            for result in results:
+                if engagement["email"] == result["email"]:
+                    data = {attr: engagement[attr] for attr in attrs}
+                    data["learning_time_hours"] = round(engagement["learning_time_seconds"] / 3600, 1)
+                    filtered_data.append(data)
+                    break
+
+        received_data = sorted(results, key=lambda x: x["email"])
+        expected_data = sorted(filtered_data, key=lambda x: x["email"])
+        assert received_data == expected_data
+
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_enrollments_data"
+    )
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_engagements_data"
+    )
+    def test_get(self, mock_fetch_and_cache_engagements_data, mock_fetch_and_cache_enrollments_data):
+        """
+        Test the GET method for the AdvanceAnalyticsIndividualEngagementsView works.
+        """
+        mock_fetch_and_cache_enrollments_data.return_value = enrollments_dataframe()
+        mock_fetch_and_cache_engagements_data.return_value = engagements_dataframe()
+
+        response = self.client.get(self.url, {"page_size": 2})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["next"] == f"http://testserver{self.url}?page=2&page_size=2"
+        assert data["previous"] is None
+        assert data["current_page"] == 1
+        assert data["num_pages"] == 5
+        assert data["count"] == 9
+        self.verify_engagement_data(data["results"], 2)
+
+        response = self.client.get(self.url, {"page_size": 2, "page": 2})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["next"] == f"http://testserver{self.url}?page=3&page_size=2"
+        assert data["previous"] == f"http://testserver{self.url}?page_size=2"
+        assert data["current_page"] == 2
+        assert data["num_pages"] == 5
+        assert data["count"] == 9
+        self.verify_engagement_data(data["results"], 2)
+
+        response = self.client.get(self.url, {"page_size": 2, "page": 5})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["next"] is None
+        assert data["previous"] == f"http://testserver{self.url}?page=4&page_size=2"
+        assert data["current_page"] == 5
+        assert data["num_pages"] == 5
+        assert data["count"] == 9
+        self.verify_engagement_data(data["results"], 1)
+
+        response = self.client.get(self.url, {"page_size": 9})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["next"] is None
+        assert data["previous"] is None
+        assert data["current_page"] == 1
+        assert data["num_pages"] == 1
+        assert data["count"] == 9
+        self.verify_engagement_data(data["results"], 9)
+
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_enrollments_data"
+    )
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_engagements_data"
+    )
+    def test_get_csv(self, mock_fetch_and_cache_engagements_data, mock_fetch_and_cache_enrollments_data):
+        """
+        Test the GET method for the AdvanceAnalyticsIndividualEngagementsView return correct CSV data.
+        """
+        mock_fetch_and_cache_enrollments_data.return_value = enrollments_dataframe()
+        mock_fetch_and_cache_engagements_data.return_value = engagements_dataframe()
+        start_date = enrollments_dataframe().enterprise_enrollment_date.min().strftime('%Y/%m/%d')
+        end_date = datetime.now().strftime('%Y/%m/%d')
+        response = self.client.get(self.url, {"response_type": ResponseType.CSV.value})
+        assert response.status_code == status.HTTP_200_OK
+
+        # verify the response headers
+        assert response["Content-Type"] == "text/csv"
+        filename = f"""Individual Engagements, {start_date} - {end_date}.csv"""
+        assert (
+            response["Content-Disposition"] == f'attachment; filename="{filename}"'
+        )
+
+        # verify the response content
+        content = b"".join(response.streaming_content)
+        assert content == engagements_csv_content()
+
+    @ddt.data(
+        {
+            "params": {"start_date": 1},
+            "error": {
+                "start_date": [
+                    "Date has wrong format. Use one of these formats instead: YYYY-MM-DD."
+                ]
+            },
+        },
+        {
+            "params": {"end_date": 2},
+            "error": {
+                "end_date": [
+                    "Date has wrong format. Use one of these formats instead: YYYY-MM-DD."
+                ]
+            },
+        },
+        {
+            "params": {"start_date": "2024-01-01", "end_date": "2023-01-01"},
+            "error": {
+                "non_field_errors": [
+                    "start_date should be less than or equal to end_date."
+                ]
+            },
+        },
+        {
+            "params": {"calculation": "invalid"},
+            "error": {"calculation": [INVALID_CALCULATION_ERROR]},
+        },
+        {
+            "params": {"granularity": "invalid"},
+            "error": {"granularity": [INVALID_GRANULARITY_ERROR]},
+        },
+        {"params": {"chart_type": "invalid"}, "error": {"chart_type": [INVALID_CSV_ERROR1]}},
+    )
+    @ddt.unpack
+    def test_get_invalid_query_params(self, params, error):
+        """
+        Test the GET method return correct error if any query param value is incorrect.
+        """
+        response = self.client.get(self.url, params)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == error
+
+
+@ddt.ddt
+class TestEngagementStatsAPI(JWTTestMixin, APITransactionTestCase):
+    """Tests for AdvanceAnalyticsEngagementStatsView."""
+
+    def setUp(self):
+        """
+        Setup method.
+        """
+        super().setUp()
+        self.user = UserFactory(is_staff=True)
+        role, __ = EnterpriseDataFeatureRole.objects.get_or_create(
+            name=ENTERPRISE_DATA_ADMIN_ROLE
+        )
+        self.role_assignment = EnterpriseDataRoleAssignment.objects.create(
+            role=role, user=self.user
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.enterprise_uuid = "ee5e6b3a-069a-4947-bb8d-d2dbc323396c"
+        self.set_jwt_cookie()
+
+        self.url = reverse(
+            "v1:enterprise-admin-analytics-engagements-stats",
+            kwargs={"enterprise_uuid": self.enterprise_uuid},
+        )
+
+        fetch_max_enrollment_datetime_patcher = patch(
+            'enterprise_data.admin_analytics.utils.fetch_max_enrollment_datetime',
+            return_value=datetime.now()
+        )
+
+        fetch_max_enrollment_datetime_patcher.start()
+        self.addCleanup(fetch_max_enrollment_datetime_patcher.stop)
+
+    def verify_engagement_data(self, results):
+        """Verify the received engagement data."""
+        attrs = [
+            "email",
+            "course_title",
+            "activity_date",
+            "course_subject",
+        ]
+
+        filtered_data = []
+        for engagement in ENGAGEMENTS:
+            for result in results:
+                if engagement["email"] == result["email"]:
+                    data = {attr: engagement[attr] for attr in attrs}
+                    data["learning_time_hours"] = round(engagement["learning_time_seconds"] / 3600, 1)
+                    filtered_data.append(data)
+                    break
+
+        received_data = sorted(results, key=lambda x: x["email"])
+        expected_data = sorted(filtered_data, key=lambda x: x["email"])
+        assert received_data == expected_data
+
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_enrollments_data"
+    )
+    @patch(
+        "enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_engagements_data"
+    )
+    def test_get(self, mock_fetch_and_cache_engagements_data, mock_fetch_and_cache_enrollments_data):
+        """
+        Test the GET method for the AdvanceAnalyticsEnrollmentStatsView works.
+        """
+        mock_fetch_and_cache_enrollments_data.return_value = enrollments_dataframe()
+        mock_fetch_and_cache_engagements_data.return_value = engagements_dataframe()
+
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == {
+            'engagements_over_time': [
+                {'activity_date': '2021-07-19T00:00:00', 'enroll_type': 'certificate', 'sum': 0.0},
+                {'activity_date': '2021-07-26T00:00:00', 'enroll_type': 'certificate', 'sum': 4.4},
+                {'activity_date': '2021-07-27T00:00:00', 'enroll_type': 'certificate', 'sum': 1.2},
+                {'activity_date': '2021-08-05T00:00:00', 'enroll_type': 'certificate', 'sum': 3.6},
+                {'activity_date': '2021-08-21T00:00:00', 'enroll_type': 'certificate', 'sum': 2.7},
+                {'activity_date': '2021-09-02T00:00:00', 'enroll_type': 'certificate', 'sum': 1.3},
+                {'activity_date': '2021-09-21T00:00:00', 'enroll_type': 'certificate', 'sum': 1.5},
+                {'activity_date': '2022-05-17T00:00:00', 'enroll_type': 'certificate', 'sum': 0.0}
+            ],
+            'top_courses_by_engagement': [
+                {
+                    'course_key': 'Kcpr+XoR30',
+                    'course_title': 'Assimilated even-keeled focus group',
+                    'enroll_type': 'certificate',
+                    'count': 0.0
+                },
+                {
+                    'course_key': 'luGg+KNt30',
+                    'course_title': 'Synergized reciprocal encoding',
+                    'enroll_type': 'certificate',
+                    'count': 14.786944444444444
+                }
+            ],
+            'top_subjects_by_engagement': [
+                {
+                    'course_subject': 'business-management',
+                    'enroll_type': 'certificate',
+                    'count': 14.786944444444444
+                },
+                {
+                    'course_subject': 'engineering',
+                    'enroll_type': 'certificate',
+                    'count': 0.0
+                }
+            ]
+        }
+
+    @patch("enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_enrollments_data")
+    @patch("enterprise_data.api.v1.views.analytics_engagements.fetch_and_cache_engagements_data")
+    @ddt.data(
+        EngagementChart.ENGAGEMENTS_OVER_TIME.value,
+        EngagementChart.TOP_COURSES_BY_ENGAGEMENTS.value,
+        EngagementChart.TOP_SUBJECTS_BY_ENGAGEMENTS.value,
+    )
+    def test_get_csv(self, chart_type, mock_fetch_and_cache_engagements_data, mock_fetch_and_cache_enrollments_data):
+        """
+        Test that AdvanceAnalyticsEngagementStatsView return correct CSV data.
+        """
+        mock_fetch_and_cache_enrollments_data.return_value = enrollments_dataframe()
+        mock_fetch_and_cache_engagements_data.return_value = engagements_dataframe()
+        response = self.client.get(self.url, {"response_type": ResponseType.CSV.value, "chart_type": chart_type})
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "text/csv"
+        # verify the response content
+        assert response.content == ENGAGEMENT_STATS_CSVS[chart_type]
+
+    @ddt.data(
+        {
+            "params": {"start_date": 1},
+            "error": {
+                "start_date": [
+                    "Date has wrong format. Use one of these formats instead: YYYY-MM-DD."
+                ]
+            },
+        },
+        {
+            "params": {"end_date": 2},
+            "error": {
+                "end_date": [
+                    "Date has wrong format. Use one of these formats instead: YYYY-MM-DD."
+                ]
+            },
+        },
+        {
+            "params": {"start_date": "2024-01-01", "end_date": "2023-01-01"},
+            "error": {
+                "non_field_errors": [
+                    "start_date should be less than or equal to end_date."
+                ]
+            },
+        },
+        {
+            "params": {"calculation": "invalid"},
+            "error": {"calculation": [INVALID_CALCULATION_ERROR]},
+        },
+        {
+            "params": {"granularity": "invalid"},
+            "error": {"granularity": [INVALID_GRANULARITY_ERROR]},
+        },
+        {"params": {"chart_type": "invalid"}, "error": {"chart_type": [INVALID_CSV_ERROR1]}},
+    )
+    @ddt.unpack
+    def test_get_invalid_query_params(self, params, error):
+        """
+        Test the GET method return correct error if any query param value is incorrect.
+        """
+        response = self.client.get(self.url, params)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == error


### PR DESCRIPTION
**Description:** This PR adds the api response for engagements data.

**Endpoints:** 
```
# /admin/analytics/<enterprise-customer-uuid>/engagements
{
    "count": 1023,
    "next": "https://api.example.org/admin/analytics/9cc8a8ed-b675-4db4-94e5-7435c66c852e/engagement?limit=100&offset=500",
    "previous": "https://api.example.org/admin/analytics/9cc8a8ed-b675-4db4-94e5-7435c66c852e/engagement?limit=100&offset=300",
    "results": [
        ...
    ]
}

# /admin/analytics/<enterprise-customer-uuid>/engagements/stats
{
    "engagement_over_time": [...]
    "top_courses_by_engagement": [...]
    "top_subjects_by_engagement": [...]
}
```

**JIRA**: [ENT-9231](https://2u-internal.atlassian.net/browse/ENT-9231)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
