### PR TITLE
feat: endpoint to get skills aggregated data for an enterprise customer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[8.4.0] - 2024-08-09
+---------------------
+  * feat: endpoint to get skills aggregated data for an enterprise customer
+
 [8.3.1] - 2024-08-06
 ---------------------
   * Dependency updates

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "8.3.1"
+__version__ = "8.4.0"

--- a/enterprise_data/admin_analytics/data_loaders.py
+++ b/enterprise_data/admin_analytics/data_loaders.py
@@ -135,3 +135,48 @@ def fetch_max_enrollment_datetime():
     if not results:
         return None
     return pandas.to_datetime(results[0][0])
+
+
+def fetch_skills_data(enterprise_uuid: str):
+    """
+    Fetch skills data from the database for the given enterprise customer.
+
+    Arguments:
+        enterprise_uuid (str): The UUID of the enterprise customer.
+
+    Returns:
+        (pandas.DataFrame): The skills data.
+    """
+
+    enterprise_uuid = enterprise_uuid.replace('-', '')
+
+    cols = [
+        'course_number',
+        'skill_type',
+        'skill_name',
+        'skill_url',
+        'confidence',
+        'skill_rank',
+        'course_title',
+        'course_key',
+        'level_type',
+        'primary_subject_name',
+        'date',
+        'enterprise_customer_uuid',
+        'enterprise_customer_name',
+        'enrolls',
+        'completions',
+    ]
+    query = get_select_query(
+        table='skills_daily_rollup_admin_dash', columns=cols, enterprise_uuid=enterprise_uuid
+    )
+
+    skills = run_query(query=query)
+
+    if not skills:
+        raise Http404(f'No skills data found for enterprise {enterprise_uuid}')
+
+    skills = pandas.DataFrame(numpy.array(skills), columns=cols)
+    skills['date'] = skills['date'].astype('datetime64[ns]')
+
+    return skills

--- a/enterprise_data/admin_analytics/utils.py
+++ b/enterprise_data/admin_analytics/utils.py
@@ -2,10 +2,21 @@
 Utility functions for fetching data from the database.
 """
 from datetime import datetime
+from enum import Enum
 
 from edx_django_utils.cache import TieredCache, get_cache_key
 
-from enterprise_data.admin_analytics.data_loaders import fetch_engagement_data, fetch_enrollment_data
+from enterprise_data.admin_analytics.data_loaders import fetch_engagement_data, fetch_enrollment_data, fetch_skills_data
+from enterprise_data.utils import date_filter, primary_subject_truncate
+
+
+class ChartType(Enum):
+    """
+    Chart types.
+    """
+    BUBBLE = 'bubble'
+    TOP_SKILLS_ENROLLMENT = 'top_skills_enrollment'
+    TOP_SKILLS_COMPLETION = 'top_skills_completion'
 
 
 def get_cache_timeout(cache_expiry):
@@ -79,3 +90,168 @@ def fetch_and_cache_engagements_data(enterprise_id, cache_expiry):
             cache_key, engagements, get_cache_timeout(cache_expiry)
         )
         return engagements
+
+
+def fetch_and_cache_skills_data(enterprise_id, cache_expiry):
+    """
+    Helper method to fetch and cache skills data.
+
+    Arguments:
+        enterprise_id (str): UUID of the enterprise customer in string format.
+        cache_expiry (datetime): Datetime object denoting the cache expiry.
+
+    Returns:
+        (pandas.DataFrame): The skills data.
+    """
+    cache_key = get_cache_key(
+        resource='enterprise-admin-analytics-aggregate-skills',
+        enterprise_customer=enterprise_id,
+    )
+    cached_response = TieredCache.get_cached_response(cache_key)
+
+    if cached_response.is_found:
+        return cached_response.value
+    else:
+        skills = fetch_skills_data(enterprise_id)
+        TieredCache.set_all_tiers(
+            cache_key, skills, get_cache_timeout(cache_expiry)
+        )
+        return skills
+
+
+def get_skills_bubble_chart_df(skills_filtered):
+    """ Get the skills data for the bubble chart.
+
+    Args:
+        skills_filtered (list): The skills data.
+
+    Returns:
+        (pandas.DataFrame): The skills data for the bubble chart.
+    """
+
+    # Group by skill_name and skill_type, and aggregate enrolls and completions
+    skills_aggregated = (
+        skills_filtered.groupby(['skill_name', 'skill_type'], as_index=False)
+        .agg(enrolls=('enrolls', 'sum'), completions=('completions', 'sum'))
+    )
+
+    # Convert enrolls and completions to integers
+    skills_aggregated['enrolls'] = skills_aggregated['enrolls'].astype(int)
+    skills_aggregated['completions'] = skills_aggregated['completions'].astype(int)
+
+    # Sort the dataframe by enrolls and completions in descending order
+    skills_aggregated = skills_aggregated.sort_values(by=['enrolls', 'completions'], ascending=False)
+
+    return skills_aggregated
+
+
+def get_top_skills_enrollment(skills_filtered):
+    """ Get the top skills by enrolls.
+
+    Args:
+        skills_filtered (pandas.DataFrame): The skills data.
+
+    Returns:
+        (pandas.DataFrame): The top skills by enrolls data
+    """
+
+    # Get the top 10 skills by enrolls
+    top_skills = (
+        skills_filtered.groupby('skill_name')
+        .enrolls.sum()
+        .sort_values(ascending=False)
+        .head(10)
+        .index
+    )
+
+    # Apply primary_subject_truncate to the primary_subject_name column
+    skills_filtered['primary_subject_name'] = skills_filtered['primary_subject_name'].apply(primary_subject_truncate)
+
+    # Filter data for the top skills and aggregate enrolls by skill_name and primary_subject_name
+    top_skills_enrollment_data = (
+        skills_filtered[skills_filtered.skill_name.isin(top_skills)]
+        .groupby(['skill_name', 'primary_subject_name'], as_index=False)
+        .agg(count=('enrolls', 'sum'))
+    )
+
+    # Sort the dataframe by primary_subject_name
+    top_skills_enrollment_data = top_skills_enrollment_data.sort_values(by="primary_subject_name")
+
+    return top_skills_enrollment_data
+
+
+def get_top_skills_completion(skills_filtered):
+    """ Get the top skills by completions.
+
+    Args:
+        skills_filtered (pandas.DataFrame): The skills data.
+
+    Returns:
+        (pandas.DataFrame): The top skills by completions
+    """
+
+    # Get the top 10 skills by completions
+    top_skills = (
+        skills_filtered.groupby('skill_name')
+        .completions.sum()
+        .sort_values(ascending=False)
+        .head(10)
+        .index
+    )
+
+    # Apply primary_subject_truncate to the primary_subject_name column
+    skills_filtered['primary_subject_name'] = skills_filtered['primary_subject_name'].apply(primary_subject_truncate)
+
+    # Filter data for the top skills and aggregate completions by skill_name and primary_subject_name
+    top_skills_completion_data = (
+        skills_filtered[skills_filtered.skill_name.isin(top_skills)]
+        .groupby(['skill_name', 'primary_subject_name'], as_index=False)
+        .agg(count=('completions', 'sum'))
+    )
+
+    # Sort the dataframe by primary_subject_name
+    top_skills_completion_data = top_skills_completion_data.sort_values(by='primary_subject_name')
+
+    return top_skills_completion_data
+
+
+def get_skills_chart_data(chart_type, start_date, end_date, skills):
+    """
+    Get chart data for skill charts.
+
+    Arguments:
+        chart_type (ChartType): The type of chart to generate.
+        start_date (datetime): The start date for the date filter.
+        end_date (datetime): The end date for the date filter.
+        skills (pandas.DataFrame): The skills data.
+    """
+    skills_filtered = date_filter(start=start_date, end=end_date, data_frame=skills.copy(), date_column='date')
+    if chart_type == ChartType.BUBBLE:
+        return get_skills_bubble_chart_df(skills_filtered=skills_filtered.copy())
+    elif chart_type == ChartType.TOP_SKILLS_ENROLLMENT:
+        return get_top_skills_enrollment(skills_filtered=skills_filtered.copy())
+    elif chart_type == ChartType.TOP_SKILLS_COMPLETION:
+        return get_top_skills_completion(skills_filtered=skills_filtered.copy())
+    else:
+        raise ValueError(f"Invalid chart type: {chart_type}")
+
+
+def get_top_skills_csv_data(skills, start_date, end_date):
+    """ Get the top skills data for CSV download.
+
+    Args:
+        skills (pandas.DataFrame): The skills data.
+        start_date (str): The start date for the date filter.
+        end_date (str): The end date for the date filter.
+
+    Returns:
+        (pandas.DataFrame): The top skills data for CSV download.
+    """
+    dff = get_skills_chart_data(
+        chart_type=ChartType.BUBBLE,
+        start_date=start_date,
+        end_date=end_date,
+        skills=skills.copy(),
+    )
+    dff = dff.sort_values(by='enrolls', ascending=False)
+    return dff

--- a/enterprise_data/api/v1/urls.py
+++ b/enterprise_data/api/v1/urls.py
@@ -47,6 +47,11 @@ urlpatterns = [
         enterprise_admin_views.EnterpriseAdminAnalyticsAggregatesView.as_view(),
         name='enterprise-admin-analytics-aggregates'
     ),
+    re_path(
+        fr'^admin/anlaytics/(?P<enterprise_id>{UUID4_REGEX})/skills/stats',
+        enterprise_admin_views.EnterpriseAdminAnalyticsSkillsView.as_view(),
+        name='enterprise-admin-analytics-skills'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -1,6 +1,7 @@
 """
 Views for enterprise admin api v1.
 """
+
 from datetime import datetime, timedelta
 
 from edx_rbac.decorators import permission_required
@@ -9,8 +10,17 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 from rest_framework.views import APIView
 
+from django.http import HttpResponse
+
 from enterprise_data.admin_analytics.data_loaders import fetch_max_enrollment_datetime
-from enterprise_data.admin_analytics.utils import fetch_and_cache_engagements_data, fetch_and_cache_enrollments_data
+from enterprise_data.admin_analytics.utils import (
+    ChartType,
+    fetch_and_cache_engagements_data,
+    fetch_and_cache_enrollments_data,
+    fetch_and_cache_skills_data,
+    get_skills_chart_data,
+    get_top_skills_csv_data,
+)
 from enterprise_data.api.v1 import serializers
 from enterprise_data.models import EnterpriseAdminLearnerProgress, EnterpriseAdminSummarizeInsights
 from enterprise_data.utils import date_filter
@@ -20,10 +30,13 @@ class EnterpriseAdminInsightsView(APIView):
     """
     API for getting the enterprise admin insights.
     """
-    authentication_classes = (JwtAuthentication,)
-    http_method_names = ['get']
 
-    @permission_required('can_access_enterprise', fn=lambda request, enterprise_id: enterprise_id)
+    authentication_classes = (JwtAuthentication,)
+    http_method_names = ["get"]
+
+    @permission_required(
+        "can_access_enterprise", fn=lambda request, enterprise_id: enterprise_id
+    )
     def get(self, request, enterprise_id):
         """
         HTTP GET endpoint to retrieve the enterprise admin insights
@@ -33,16 +46,24 @@ class EnterpriseAdminInsightsView(APIView):
         learner_engagement = {}
 
         try:
-            learner_progress = EnterpriseAdminLearnerProgress.objects.get(enterprise_customer_uuid=enterprise_id)
-            learner_progress = serializers.EnterpriseAdminLearnerProgressSerializer(learner_progress).data
-            response_data['learner_progress'] = learner_progress
+            learner_progress = EnterpriseAdminLearnerProgress.objects.get(
+                enterprise_customer_uuid=enterprise_id
+            )
+            learner_progress = serializers.EnterpriseAdminLearnerProgressSerializer(
+                learner_progress
+            ).data
+            response_data["learner_progress"] = learner_progress
         except EnterpriseAdminLearnerProgress.DoesNotExist:
             pass
 
         try:
-            learner_engagement = EnterpriseAdminSummarizeInsights.objects.get(enterprise_customer_uuid=enterprise_id)
-            learner_engagement = serializers.EnterpriseAdminSummarizeInsightsSerializer(learner_engagement).data
-            response_data['learner_engagement'] = learner_engagement
+            learner_engagement = EnterpriseAdminSummarizeInsights.objects.get(
+                enterprise_customer_uuid=enterprise_id
+            )
+            learner_engagement = serializers.EnterpriseAdminSummarizeInsightsSerializer(
+                learner_engagement
+            ).data
+            response_data["learner_engagement"] = learner_engagement
         except EnterpriseAdminSummarizeInsights.DoesNotExist:
             pass
 
@@ -57,53 +78,156 @@ class EnterpriseAdminAnalyticsAggregatesView(APIView):
     """
     API for getting the enterprise admin analytics aggregates.
     """
-    authentication_classes = (JwtAuthentication,)
-    http_method_names = ['get']
 
-    @permission_required('can_access_enterprise', fn=lambda request, enterprise_id: enterprise_id)
+    authentication_classes = (JwtAuthentication,)
+    http_method_names = ["get"]
+
+    @permission_required(
+        "can_access_enterprise", fn=lambda request, enterprise_id: enterprise_id
+    )
     def get(self, request, enterprise_id):
         """
         HTTP GET endpoint to retrieve the enterprise admin aggregate data.
         """
-        serializer = serializers.AdminAnalyticsAggregatesQueryParamsSerializer(data=request.GET)
+        serializer = serializers.AdminAnalyticsAggregatesQueryParamsSerializer(
+            data=request.GET
+        )
         serializer.is_valid(raise_exception=True)
 
         last_updated_at = fetch_max_enrollment_datetime()
-        cache_expiry = last_updated_at + timedelta(days=1) if last_updated_at else datetime.now()
+        cache_expiry = (
+            last_updated_at + timedelta(days=1) if last_updated_at else datetime.now()
+        )
 
-        enrollment = fetch_and_cache_enrollments_data(enterprise_id, cache_expiry).copy()
-        engagement = fetch_and_cache_engagements_data(enterprise_id, cache_expiry).copy()
+        enrollment = fetch_and_cache_enrollments_data(
+            enterprise_id, cache_expiry
+        ).copy()
+        engagement = fetch_and_cache_engagements_data(
+            enterprise_id, cache_expiry
+        ).copy()
         # Use start and end date if provided by the client, if client has not provided then use
         # 1. minimum enrollment date from the data as the start_date
         # 2. today's date as the end_date
-        start_date = serializer.data.get('start_date', enrollment.enterprise_enrollment_date.min())
-        end_date = serializer.data.get('end_date', datetime.now())
+        start_date = serializer.data.get(
+            "start_date", enrollment.enterprise_enrollment_date.min()
+        )
+        end_date = serializer.data.get("end_date", datetime.now())
 
         # Date filtering.
         dff = date_filter(
-            start=start_date, end=end_date, data_frame=enrollment.copy(), date_column='enterprise_enrollment_date'
+            start=start_date,
+            end=end_date,
+            data_frame=enrollment.copy(),
+            date_column="enterprise_enrollment_date",
         )
 
         enrolls = len(dff)
         courses = len(dff.course_key.unique())
 
-        dff = date_filter(start=start_date, end=end_date, data_frame=enrollment.copy(), date_column='passed_date')
+        dff = date_filter(
+            start=start_date,
+            end=end_date,
+            data_frame=enrollment.copy(),
+            date_column="passed_date",
+        )
 
         completions = dff.has_passed.sum()
 
         # Date filtering.
-        dff = date_filter(start=start_date, end=end_date, data_frame=engagement.copy(), date_column='activity_date')
+        dff = date_filter(
+            start=start_date,
+            end=end_date,
+            data_frame=engagement.copy(),
+            date_column="activity_date",
+        )
 
         hours = round(dff.learning_time_seconds.sum() / 60 / 60, 1)
         sessions = dff.is_engaged.sum()
 
-        return Response(data={
-            'enrolls': enrolls,
-            'courses': courses,
-            'completions': completions,
-            'hours': hours,
-            'sessions': sessions,
-            'last_updated_at': last_updated_at.date() if last_updated_at else None,
-            'min_enrollment_date': enrollment.enterprise_enrollment_date.min().date(),
-            'max_enrollment_date': enrollment.enterprise_enrollment_date.max().date(),
-        }, status=HTTP_200_OK)
+        return Response(
+            data={
+                "enrolls": enrolls,
+                "courses": courses,
+                "completions": completions,
+                "hours": hours,
+                "sessions": sessions,
+                "last_updated_at": last_updated_at.date() if last_updated_at else None,
+                "min_enrollment_date": enrollment.enterprise_enrollment_date.min().date(),
+                "max_enrollment_date": enrollment.enterprise_enrollment_date.max().date(),
+            },
+            status=HTTP_200_OK,
+        )
+
+
+class EnterpriseAdminAnalyticsSkillsView(APIView):
+    """
+    API for getting the enterprise admin analytics skills data.
+    """
+    authentication_classes = (JwtAuthentication,)
+    http_method_names = ['get']
+
+    @permission_required(
+        'can_access_enterprise', fn=lambda request, enterprise_id: enterprise_id
+    )
+    def get(self, request, enterprise_id):
+        """HTTP GET endpoint to retrieve the enterprise admin skills aggregated data.
+
+        Args:
+            request (HttpRequest): request object
+            enterprise_id (str): UUID of the enterprise customer
+
+        Returns:
+            response(HttpResponse): response object
+        """
+        serializer = serializers.AdminAnalyticsAggregatesQueryParamsSerializer(
+            data=request.GET
+        )
+        serializer.is_valid(raise_exception=True)
+
+        start_date = serializer.data.get("start_date")
+        end_date = serializer.data.get("end_date", datetime.now())
+
+        last_updated_at = fetch_max_enrollment_datetime()
+        cache_expiry = (
+            last_updated_at + timedelta(days=1) if last_updated_at else datetime.now()
+        )
+        skills = fetch_and_cache_skills_data(enterprise_id, cache_expiry).copy()
+
+        if request.GET.get("format") == "csv":
+            csv_data = get_top_skills_csv_data(skills, start_date, end_date)
+            response = HttpResponse(content_type='text/csv')
+            filename = f"Skills by Enrollment and Completion, {start_date} - {end_date}.csv"
+            response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            csv_data.to_csv(path_or_buf=response, index=False)
+            return response
+
+        top_skills = get_skills_chart_data(
+            chart_type=ChartType.BUBBLE,
+            start_date=start_date,
+            end_date=end_date,
+            skills=skills,
+        )
+        top_skills_enrollments = get_skills_chart_data(
+            chart_type=ChartType.TOP_SKILLS_ENROLLMENT,
+            start_date=start_date,
+            end_date=end_date,
+            skills=skills,
+        )
+        top_skills_by_completions = get_skills_chart_data(
+            chart_type=ChartType.TOP_SKILLS_COMPLETION,
+            start_date=start_date,
+            end_date=end_date,
+            skills=skills,
+        )
+
+        response_data = {
+            "top_skills": top_skills.to_dict(orient="records"),
+            "top_skills_by_enrollments": top_skills_enrollments.to_dict(
+                orient="records"
+            ),
+            "top_skills_by_completions": top_skills_by_completions.to_dict(
+                orient="records"
+            ),
+        }
+
+        return Response(data=response_data, status=HTTP_200_OK)

--- a/enterprise_data/tests/admin_analytics/test_data_loaders.py
+++ b/enterprise_data/tests/admin_analytics/test_data_loaders.py
@@ -13,8 +13,13 @@ from enterprise_data.admin_analytics.data_loaders import (
     fetch_engagement_data,
     fetch_enrollment_data,
     fetch_max_enrollment_datetime,
+    fetch_skills_data,
 )
-from enterprise_data.tests.test_utils import get_dummy_engagements_data, get_dummy_enrollments_data
+from enterprise_data.tests.test_utils import (
+    get_dummy_engagements_data,
+    get_dummy_enrollments_data,
+    get_dummy_skills_data,
+)
 
 
 class TestDataLoaders(TestCase):
@@ -84,3 +89,27 @@ class TestDataLoaders(TestCase):
             with pytest.raises(Http404) as error:
                 fetch_enrollment_data(enterprise_uuid)
             error.value.message = f'No enrollment data found for enterprise {enterprise_uuid}'
+
+    def test_fetch_skills_data(self):
+        """
+        Validate the fetch_skills_data function.
+        """
+        with patch('enterprise_data.admin_analytics.data_loaders.run_query') as mock_run_query:
+            enterprise_uuid = str(uuid4())
+            mock_run_query.return_value = [
+                list(item.values()) for item in get_dummy_skills_data(enterprise_uuid)
+            ]
+
+            skills_data = fetch_skills_data(enterprise_uuid)
+            self.assertEqual(skills_data.shape, (10, 15))
+
+    def test_fetch_skills_data_empty_data(self):
+        """
+        Validate the fetch_skills_data function behavior when no data is returned from the query.
+        """
+        with patch('enterprise_data.admin_analytics.data_loaders.run_query') as mock_run_query:
+            mock_run_query.return_value = []
+            enterprise_uuid = str(uuid4())
+            with pytest.raises(Http404) as error:
+                fetch_skills_data(enterprise_uuid)
+            error.value.message = f'No skills data found for enterprise {enterprise_uuid}'

--- a/enterprise_data/tests/admin_analytics/test_utils.py
+++ b/enterprise_data/tests/admin_analytics/test_utils.py
@@ -3,6 +3,7 @@ Test the utility functions in the admin_analytics app.
 """
 from datetime import datetime, timedelta
 
+import pandas
 from mock import patch
 
 from django.test import TestCase
@@ -10,8 +11,13 @@ from django.test import TestCase
 from enterprise_data.admin_analytics.utils import (
     fetch_and_cache_engagements_data,
     fetch_and_cache_enrollments_data,
+    fetch_and_cache_skills_data,
     get_cache_timeout,
+    get_skills_bubble_chart_df,
+    get_top_skills_completion,
+    get_top_skills_enrollment,
 )
+from enterprise_data.utils import date_filter
 
 
 class TestUtils(TestCase):
@@ -100,3 +106,136 @@ class TestUtils(TestCase):
                 self.assertEqual(enrollments, 'cached-engagements')
                 self.assertEqual(mock_tiered_cache.get_cached_response.call_count, 1)
                 self.assertEqual(mock_tiered_cache.set_all_tiers.call_count, 0)
+
+    def test_fetch_and_cache_skills_data(self):
+        """
+        Validate the fetch_and_cache_skills_data function.
+        """
+        with patch('enterprise_data.admin_analytics.utils.fetch_skills_data') as mock_fetch_skills_data:
+            with patch('enterprise_data.admin_analytics.utils.TieredCache') as mock_tiered_cache:
+                # Simulate the scenario where the data is not found in the cache.
+                mock_tiered_cache.get_cached_response.return_value.is_found = False
+                mock_fetch_skills_data.return_value = 'skills'
+                skills = fetch_and_cache_skills_data('enterprise_id', datetime.now() + timedelta(seconds=10))
+                self.assertEqual(skills, 'skills')
+                self.assertEqual(mock_tiered_cache.get_cached_response.call_count, 1)
+                self.assertEqual(mock_tiered_cache.set_all_tiers.call_count, 1)
+
+    def test_fetch_and_cache_skills_data_with_data_cache_found(self):
+        """
+        Validate the fetch_and_cache_skills_data function.
+        """
+        with patch('enterprise_data.admin_analytics.utils.fetch_skills_data') as mock_fetch_skills_data:
+            with patch('enterprise_data.admin_analytics.utils.TieredCache') as mock_tiered_cache:
+                # Simulate the scenario where the data is found in the cache.
+                mock_tiered_cache.get_cached_response.return_value.is_found = True
+                mock_tiered_cache.get_cached_response.return_value.value = 'cached-skills'
+                mock_fetch_skills_data.return_value = 'skills'
+
+                skills = fetch_and_cache_skills_data('enterprise_id', datetime.now() + timedelta(seconds=10))
+                self.assertEqual(skills, 'cached-skills')
+                self.assertEqual(mock_tiered_cache.get_cached_response.call_count, 1)
+                self.assertEqual(mock_tiered_cache.set_all_tiers.call_count, 0)
+
+    def test_get_skills_bubble_chart_df(self):
+        """
+        Validate the get_skills_bubble_chart_df function.
+        """
+        # Mock skills data
+        skills = pandas.DataFrame({
+            'skill_name': ['Skill A', 'Skill B', 'Skill C'],
+            'skill_type': ['Type 1', 'Type 2', 'Type 1'],
+            'enrolls': [100, 200, 150],
+            'completions': [50, 100, 75],
+            'date': [datetime.now(), datetime.now(), datetime.now()],
+        })
+
+        # Define the expected result
+        expected_result = pandas.DataFrame({
+            'skill_name': ['Skill B', 'Skill C', 'Skill A'],
+            'skill_type': ['Type 2', 'Type 1', 'Type 1'],
+            'enrolls': [200, 150, 100],
+            'completions': [100, 75, 50]
+        })
+        # Reset the index for the expected result
+        expected_result = expected_result.reset_index(drop=True)
+
+        start_date = datetime.now() - timedelta(days=10)
+        end_date = datetime.now()
+        filtered_skills = date_filter(start_date, end_date, skills, 'date')
+        # Call the function
+        result = get_skills_bubble_chart_df(filtered_skills)
+
+        # Reset the index for the result
+        result = result.reset_index(drop=True)
+
+        # Assert the result
+        pandas.testing.assert_frame_equal(result, expected_result)
+
+    def test_get_top_skills_enrollment(self):
+        """
+        Validate the get_top_skills_enrollment function.
+        """
+        # Mock skills data
+        skills = pandas.DataFrame({
+            'primary_subject_name': ['engineering', 'communication', 'engineering', 'other'],
+            'skill_name': ['Skill A', 'Skill B', 'Skill A', 'Skill D'],
+            'enrolls': [100, 200, 150, 300],
+            'completions': [50, 100, 75, 150],
+            'date': [datetime.now(), datetime.now(), datetime.now(), datetime.now()],
+        })
+
+        # Define the expected result
+        expected_result = pandas.DataFrame({
+            'skill_name': ['Skill B', 'Skill A', 'Skill D'],
+            'primary_subject_name': ['communication', 'engineering', 'other'],
+            'count': [200, 250, 300]
+        })
+        # Reset the index for the expected result
+        expected_result = expected_result.reset_index(drop=True)
+        start_date = datetime.now() - timedelta(days=10)
+        end_date = datetime.now()
+        filtered_skills = date_filter(start_date, end_date, skills, 'date')
+
+        # Call the function
+        result = get_top_skills_enrollment(filtered_skills)
+
+        # Reset the index for the result
+        result = result.reset_index(drop=True)
+
+        # Assert the result
+        pandas.testing.assert_frame_equal(result, expected_result)
+
+    def test_get_top_skills_completion(self):
+        """
+        Validate the get_top_skills_completion function.
+        """
+        # Mock skills data
+        skills = pandas.DataFrame({
+            'skill_name': ['Skill A', 'Skill B', 'Skill C', 'Skill D'],
+            'primary_subject_name': ['communication', 'engineering', 'communication', 'other'],
+            'enrolls': [100, 200, 150, 300],
+            'completions': [50, 100, 75, 150],
+            'date': [datetime.now(), datetime.now(), datetime.now(), datetime.now()]
+        })
+
+        # Define the expected result
+        expected_result = pandas.DataFrame({
+            'skill_name': ['Skill A', 'Skill C', 'Skill B', 'Skill D'],
+            'primary_subject_name': ['communication', 'communication', 'engineering', 'other'],
+            'count': [50, 75, 100, 150]
+        })
+        # Reset the index for the expected result
+        expected_result = expected_result.reset_index(drop=True)
+        start_date = datetime.now() - timedelta(days=10)
+        end_date = datetime.now()
+        filtered_skills = date_filter(start_date, end_date, skills, 'date')
+
+        # Call the function
+        result = get_top_skills_completion(filtered_skills)
+
+        # Reset the index for the result
+        result = result.reset_index(drop=True)
+
+        # Assert the result
+        pandas.testing.assert_frame_equal(result, expected_result)

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -2,6 +2,7 @@
 Test cases for enterprise_admin views
 """
 from unittest import mock
+from uuid import uuid4
 
 import ddt
 from mock import patch
@@ -16,6 +17,7 @@ from enterprise_data.tests.test_utils import (
     get_dummy_engagements_data,
     get_dummy_enrollments_data,
     get_dummy_enterprise_api_data,
+    get_dummy_skills_data,
 )
 from enterprise_data_roles.constants import ENTERPRISE_DATA_ADMIN_ROLE
 from enterprise_data_roles.models import EnterpriseDataFeatureRole, EnterpriseDataRoleAssignment
@@ -80,3 +82,50 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
             assert 'last_updated_at' in response.json()
             assert 'min_enrollment_date' in response.json()
             assert 'max_enrollment_date' in response.json()
+
+
+@ddt.ddt
+@mark.django_db
+class TestEnterpriseAdminAnalyticsSkillsView(JWTTestMixin, APITransactionTestCase):
+    """
+    Tests for EnterpriseAdminAnalyticsSkillsView.
+    """
+
+    def setUp(self):
+        """
+        Setup method.
+        """
+        super().setUp()
+        self.user = UserFactory()
+        self.enterprise_id = uuid4()
+        self.set_jwt_cookie(context=f'{self.enterprise_id}')
+
+    def _mock_run_query(self, query):
+        """
+        mock implementation of run_query.
+        """
+        if 'skills_daily_rollup_admin_dash' in query:
+            return [
+                list(item.values()) for item in get_dummy_skills_data(self.enterprise_id)
+            ]
+        else:
+            return [
+                list(item.values()) for item in get_dummy_skills_data(self.enterprise_id)
+            ]
+
+    def test_get_admin_analytics_skills(self):
+        """
+        Test to get admin analytics skills.
+        """
+        params = {'start_date': '2021-01-01', 'end_date': '2025-12-31'}
+        url = reverse('v1:enterprise-admin-analytics-skills', kwargs={'enterprise_id': self.enterprise_id})
+        with patch('enterprise_data.admin_analytics.data_loaders.run_query', side_effect=self._mock_run_query):
+            response = self.client.get(url, params)
+            assert response.status_code == status.HTTP_200_OK
+            data = response.json()
+            assert 'top_skills' in data
+            assert 'top_skills_by_enrollments' in data
+            assert 'top_skills_by_completions' in data
+            assert len(data['top_skills']) == 10
+            assert len(data['top_skills_by_enrollments']) == 10
+            assert len(data['top_skills_by_completions']) == 10

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -418,3 +418,31 @@ def get_dummy_enrollments_data(enterprise_uuid: str, count=10):
             'has_passed': FAKER.boolean(),
         } for _ in range(count)
     ]
+
+
+def get_dummy_skills_data(enterprise_uuid: str, count=10):
+    """
+    Utility method to get dummy skills data.
+    """
+    return [
+        {
+            'course_number': FAKER.random_int(min=1),
+            'skill_type': 'skill_type',
+            'skill_name': ' '.join(FAKER.words(nb=2)).title(),
+            'skill_url': FAKER.url(),
+            'confidence': FAKER.random_int(min=1),
+            'skill_rank': FAKER.random_int(min=1),
+            'course_title': ' '.join(FAKER.words(nb=5)).title(),
+            'course_key': FAKER.slug(),
+            'level_type': 'level_type',
+            'primary_subject_name': ' '.join(FAKER.words(nb=2)).title(),
+            'date': FAKER.date_time_between(
+                start_date='-2M',
+                end_date='+2M',
+            ),
+            'enterprise_customer_uuid': enterprise_uuid,
+            'enterprise_customer_name': ' '.join(FAKER.words(nb=2)).title(),
+            'enrolls': FAKER.random_int(min=1),
+            'completions': FAKER.random_int(min=1),
+        } for _ in range(count)
+    ]

--- a/enterprise_data/utils.py
+++ b/enterprise_data/utils.py
@@ -82,3 +82,19 @@ def date_filter(start, end, data_frame, date_column):
         (pandas.DataFrame): The filtered DataFrame.
     """
     return data_frame[(start <= data_frame[date_column]) & (data_frame[date_column] <= end)]
+
+
+def primary_subject_truncate(x):
+    """
+    Truncate primary subject to a few categories.
+    """
+    if x in [
+        "business-management",
+        "computer-science",
+        "data-analysis-statistics",
+        "engineering",
+        "communication",
+    ]:
+        return x
+    else:
+        return "other"


### PR DESCRIPTION
**Description**
`http://localhost:19001/enterprise/api/v1/admin/anlaytics/9e4ce45148c44c2c86a9bb3ddd138d6b/skills/stats?start_date=2024-01-01&end_date=2024-01-31`
Response:
```json

{
    "top_skills": [
        {
            "skill_name": "Firewall",
            "skill_type": "Specialized Skill",
            "enrolls": 1,
            "completions": 1
        },
        {
            "skill_name": "Governance",
            "skill_type": "Common Skill",
            "enrolls": 1,
            "completions": 1
        },
        {
            "skill_name": "Bitcoin",
            "skill_type": "Specialized Skill",
            "enrolls": 1,
            "completions": 0
        }
    ],
    "top_skills_by_enrollments": [
        {
            "skill_name": "Bitcoin",
            "primary_subject_name": "business-management",
            "count": 1
        },
        {
            "skill_name": "Firewall",
            "primary_subject_name": "computer-science",
            "count": 1
        },
        {
            "skill_name": "Governance",
            "primary_subject_name": "engineering",
            "count": 1
        }
    ],
    "top_skills_by_completions": [
        {
            "skill_name": "Bitcoin",
            "primary_subject_name": "business-management",
            "count": 0
        },
        {
            "skill_name": "Firewall",
            "primary_subject_name": "computer-science",
            "count": 1
        },
        {
            "skill_name": "Governance",
            "primary_subject_name": "engineering",
            "count": 1
        }
    ]
}
```

`http://localhost:19001/enterprise/api/v1/admin/anlaytics/9e4ce45148c44c2c86a9bb3ddd138d6b/skills/stats?start_date=2024-01-01&end_date=2024-01-31&format=csv`
Response:
```json
[
  {
    "skill_name": "Firewall",
    "skill_type": "Specialized Skill",
    "enrolls": 1,
    "completions": 1
  },
  {
    "skill_name": "Governance",
    "skill_type": "Common Skill",
    "enrolls": 1,
    "completions": 1
  },
  {
    "skill_name": "Bitcoin",
    "skill_type": "Specialized Skill",
    "enrolls": 1,
    "completions": 0
  }
]
```

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
