### PR TITLE
fix: remove the cache logging on EnterpriseLearnerEnrollmentViewSet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[9.2.2] - 2024-09-27
+---------------------
+  * fix: remove the cache logging on EnterpriseLearnerEnrollmentViewSet.
+
 [9.2.1] - 2024-09-25
 ---------------------
   * fix: Added temporary cache logging on EnterpriseLearnerEnrollmentViewSet.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "9.2.1"
+__version__ = "9.2.2"

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -6,7 +6,6 @@ from datetime import date, timedelta
 from logging import getLogger
 from uuid import UUID
 
-from edx_django_utils.cache import TieredCache
 from rest_framework import filters, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -25,7 +24,7 @@ from enterprise_data.filters import AuditEnrollmentsFilterBackend, AuditUsersEnr
 from enterprise_data.models import EnterpriseLearner, EnterpriseLearnerEnrollment
 from enterprise_data.paginators import EnterpriseEnrollmentsPagination
 from enterprise_data.renderers import EnrollmentsCSVRenderer
-from enterprise_data.utils import get_cache_key, subtract_one_month
+from enterprise_data.utils import subtract_one_month
 
 from .base import EnterpriseViewSetMixin
 
@@ -83,23 +82,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
 
         enterprise_customer_uuid = self.kwargs['enterprise_id']
 
-        # TODO: Created a ticket ENT0-9531 to fix the cache issue
-        # Temporary logging to test cache issue
-        try:
-            LOGGER.info("Trying to get Learner Enrollment data from Cache")
-            cache_key = get_cache_key(
-                resource='enterprise-learner',
-                enterprise_customer=enterprise_customer_uuid,
-            )
-            cached_response = TieredCache.get_cached_response(cache_key)
-            if cached_response.is_found:
-                LOGGER.info("Learner Enrollment data found in Cache for Enterprise: [%s]", enterprise_customer_uuid)
-            else:
-                LOGGER.info("Learner Enrollment data not found in Cache for Enterprise: [%s]", enterprise_customer_uuid)
-                TieredCache.set_all_tiers(cache_key, 'dummy_enrollments', DEFAULT_LEARNER_CACHE_TIMEOUT)
-                LOGGER.info("Cache set for Enterprise: [%s] whose key is: [%s]", enterprise_customer_uuid, cache_key)
-        except Exception as e:
-            LOGGER.error("Memcached connection test failed: %s", e)
+        # TODO: Created a ticket ENT0-9531 to add the cache on this viewset
 
         enrollments = EnterpriseLearnerEnrollment.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid)
         enrollments = self.apply_filters(enrollments)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
