### PR TITLE
refactor: Further improvement in SQL queries for leaderboard API endpoint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[9.3.0] - 2024-09-30
+---------------------
+  * refactor: Further improvement in SQL queries for leaderboard API endpoint.
+
 [9.2.2] - 2024-09-27
 ---------------------
   * fix: remove the cache logging on EnterpriseLearnerEnrollmentViewSet.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "9.2.2"
+__version__ = "9.3.0"

--- a/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
@@ -153,6 +153,65 @@ class FactEngagementAdminDashTable(BaseTable):
             as_dict=True,
         )
 
+    def _get_engagement_data_for_leaderboard(
+            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, limit: int, offset: int
+    ):
+        """
+        Get the engagement data for leaderboard.
+
+        The engagement data would include fields like learning time, session length of
+        the enterprise learners to show in the leaderboard.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            start_date (date): The start date.
+            end_date (date): The end date.
+            limit (int): The maximum number of records to return.
+            offset (int): The number of records to skip.
+
+        Returns:
+            list[dict]: The engagement data for leaderboard.
+        """
+        return run_query(
+            query=self.queries.get_engagement_data_for_leaderboard_query(),
+            params={
+                'enterprise_customer_uuid': enterprise_customer_uuid,
+                'start_date': start_date,
+                'end_date': end_date,
+                'limit': limit,
+                'offset': offset,
+            },
+            as_dict=True,
+        )
+
+    def _get_completion_data_for_leaderboard_query(
+            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, email_list: list
+    ):
+        """
+        Get the completion data for leaderboard.
+
+        The completion data would include fields like course completion count of enterprise learners of the
+        given enterprise customer.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            start_date (date): The start date.
+            end_date (date): The end date.
+            email_list (list<str>): List of emails of the enterprise learners.
+
+        Returns:
+            list[dict]: The engagement data for leaderboard.
+        """
+        return run_query(
+            query=self.queries.get_completion_data_for_leaderboard_query(email_list),
+            params={
+                'enterprise_customer_uuid': enterprise_customer_uuid,
+                'start_date': start_date,
+                'end_date': end_date,
+            },
+            as_dict=True,
+        )
+
     def get_all_leaderboard_data(
             self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, limit: int, offset: int
     ):
@@ -169,17 +228,25 @@ class FactEngagementAdminDashTable(BaseTable):
         Returns:
             list[dict]: The leaderboard data.
         """
-        return run_query(
-            query=self.queries.get_all_leaderboard_data_query(),
-            params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
-                'limit': limit,
-                'offset': offset,
-            },
-            as_dict=True,
+        engagement_data = self._get_engagement_data_for_leaderboard(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+            offset=offset,
         )
+        engagement_data_dict = {engagement['email']: engagement for engagement in engagement_data}
+        completion_data = self._get_completion_data_for_leaderboard_query(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            email_list=list(engagement_data_dict.keys()),
+        )
+        for completion in completion_data:
+            email = completion['email']
+            engagement_data_dict[email]['course_completion_count'] = completion['course_completion_count']
+
+        return list(engagement_data_dict.values())
 
     def get_leaderboard_data_count(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
         """


### PR DESCRIPTION
__Jira Ticket:__ [ENT-9542](https://2u-internal.atlassian.net/browse/ENT-9542)

This PR contains further optimizations for SQL queries related to leaderboard API endpoint.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
