### PR TITLE
feat: fetch enterprise budgets info

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[9.7.0] - 2024-10-23
+---------------------
+  * feat: Add API to fetch enterprise budgets information
+
 [9.6.0] - 2024-10-14
 ---------------------
   * feat: Added caching for API endpoints related to advanced analytics.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "9.6.0"
+__version__ = "9.7.0"

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -240,6 +240,19 @@ class EnterpriseExecEdLCModulePerformanceSerializer(serializers.ModelSerializer)
         return obj.extensions_requested if obj.extensions_requested is not None else 0
 
 
+class EnterpriseBudgetSerializer(serializers.ModelSerializer):
+    """
+    Serializer for EnterpriseSubsidyBudget model.
+    """
+
+    class Meta:
+        model = EnterpriseSubsidyBudget
+        fields = (
+            'subsidy_access_policy_uuid',
+            'subsidy_access_policy_display_name',
+        )
+
+
 class AdvanceAnalyticsQueryParamSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """Serializer for validating query params"""
     RESPONSE_TYPES = [

--- a/enterprise_data/api/v1/urls.py
+++ b/enterprise_data/api/v1/urls.py
@@ -96,6 +96,11 @@ urlpatterns = [
         enterprise_admin_views.EnterpriseAdminAnalyticsSkillsView.as_view(),
         name='enterprise-admin-analytics-skills'
     ),
+    re_path(
+        fr'^enterprise/(?P<enterprise_uuid>{UUID4_REGEX})/budgets',
+        enterprise_admin_views.EnterpriseBudgetView.as_view(),
+        name='enterprise-budgets'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -21,6 +21,7 @@ from enterprise_data.models import (
     EnterpriseAdminLearnerProgress,
     EnterpriseAdminSummarizeInsights,
     EnterpriseExecEdLCModulePerformance,
+    EnterpriseSubsidyBudget,
 )
 from enterprise_data.utils import timer
 
@@ -206,3 +207,26 @@ class EnterpriseExecEdLCModulePerformanceViewSet(EnterpriseViewSetMixin, viewset
         return EnterpriseExecEdLCModulePerformance.objects.filter(
             enterprise_customer_uuid=self.kwargs['enterprise_id'],
         )
+
+
+class EnterpriseBudgetView(APIView):
+    """
+    View for getting budgets information for an enterprise.
+    """
+    authentication_classes = (JwtAuthentication,)
+    http_method_names = ["get"]
+
+    @permission_required("can_access_enterprise", fn=lambda request, enterprise_uuid: enterprise_uuid)
+    def get(self, request, enterprise_uuid):
+        """
+        Return the queryset of EnterpriseSubsidyBudget objects.
+        """
+        budgets = EnterpriseSubsidyBudget.objects.filter(
+            enterprise_customer_uuid=enterprise_uuid,
+        ).values(
+            'subsidy_access_policy_uuid',
+            'subsidy_access_policy_display_name',
+        )
+
+        serializer = serializers.EnterpriseBudgetSerializer(budgets, many=True)
+        return Response(serializer.data)

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -150,6 +150,10 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         if search_start_date:
             queryset = queryset.filter(course_start_date=search_start_date)
 
+        budget_uuid = query_filters.get('budget_uuid')
+        if budget_uuid:
+            queryset = queryset.filter(budget_id=budget_uuid)
+
         offer_id = query_filters.get('offer_id')
         if offer_id:
             queryset = self.filter_by_offer_id(queryset, offer_id)


### PR DESCRIPTION
**Description:** Add api to fetch enterprise budgets
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-9520

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
