### PR TITLE
docs: bump package version to 10.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 =========================
 
+[10.0.1] - 2024-10-25
+---------------------
+  * Same as ``10.0.0`` 
+  * Bumping the version so a new tag can be created in the GitHub 
+
 [10.0.0] - 2024-10-25
 ---------------------
   * feat!: Python 3.12 Upgrade

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "9.7.0"
+__version__ = "10.0.1"


### PR DESCRIPTION
## Description
- Tag ``10.0.0`` failed to be pushed to PyPI because version was not updated correctly in the previous PR https://github.com/openedx/edx-enterprise-data/pull/524.
- Bumping the version to `10.0.1` to create a new tag and publish to PyPI.