### PR TITLE
ENT-9621: feat: Added management command to pre-warm analytics data.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[10.1.0] - 2024-10-29
+---------------------
+  * Added management command to pre-warm analytics data.
+
 [10.0.1] - 2024-10-25
 ---------------------
   * Same as ``10.0.0`` 

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.0.1"
+__version__ = "10.1.0"

--- a/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
@@ -8,6 +8,18 @@ class FactEnrollmentAdminDashQueries:
     Queries related to the fact_enrollment_admin_dash table.
     """
     @staticmethod
+    def get_top_enterprises_query(count=10):
+        """
+        Get the query to fetch the top enterprises by enrollments.
+        """
+        return f"""
+            SELECT enterprise_customer_uuid
+            FROM fact_enrollment_admin_dash
+            GROUP BY enterprise_customer_uuid
+            ORDER BY COUNT(enterprise_customer_uuid) DESC LIMIT {count};
+        """
+
+    @staticmethod
     def get_enrollment_count_query():
         """
         Get the query to fetch the total number of enrollments for an enterprise customer.

--- a/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
@@ -17,6 +17,22 @@ class FactEnrollmentAdminDashTable(BaseTable):
     """
     queries = FactEnrollmentAdminDashQueries()
 
+    def get_top_enterprises(self, count=10):
+        """
+        Get the top enterprises by enrollments.
+
+        Arguments:
+            count (int): The number of enterprises to return.
+
+        Returns:
+            list<str>: A list of enterprise UUIDs.
+        """
+        result = run_query(
+            query=self.queries.get_top_enterprises_query(count),
+            as_dict=False,
+        )
+        return [row[0] for row in result]
+
     @cache_it()
     def get_enrollment_count(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
         """
@@ -77,7 +93,7 @@ class FactEnrollmentAdminDashTable(BaseTable):
         Get the enrollment date range for the given enterprise customer.
 
         Arguments:
-            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            enterprise_customer_uuid (UUID | str): The UUID of the enterprise customer.
 
         Returns:
             (tuple<date, date>): The minimum and maximum enrollment dates.

--- a/enterprise_data/api/v1/views/analytics_completions.py
+++ b/enterprise_data/api/v1/views/analytics_completions.py
@@ -2,7 +2,7 @@
 Views for enterprise admin completions analytics.
 """
 
-from datetime import datetime
+from datetime import date
 from logging import getLogger
 
 from edx_rbac.decorators import permission_required
@@ -50,7 +50,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
 
         # get values from query params or use default values
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         completions = FactEnrollmentAdminDashTable().get_all_completions(
@@ -132,7 +132,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         )
         # get values from query params or use default
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         with timer('construct_completion_all_stats'):
             data = {
                 'completions_over_time': FactEnrollmentAdminDashTable().get_completions_time_series_data(

--- a/enterprise_data/api/v1/views/analytics_engagements.py
+++ b/enterprise_data/api/v1/views/analytics_engagements.py
@@ -2,7 +2,7 @@
 Views for handling REST endpoints related to Engagements analytics.
 """
 
-from datetime import datetime
+from datetime import date
 from logging import getLogger
 
 from edx_rbac.decorators import permission_required
@@ -50,7 +50,7 @@ class AdvanceAnalyticsEngagementView(AnalyticsPaginationMixin, ViewSet):
 
         # get values from query params or use default values
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         engagements = FactEngagementAdminDashTable().get_all_engagements(
@@ -132,7 +132,7 @@ class AdvanceAnalyticsEngagementView(AnalyticsPaginationMixin, ViewSet):
         )
         # get values from query params or use default
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         with timer('construct_engagement_all_stats'):
             data = {
                 'engagement_over_time': FactEngagementAdminDashTable().get_engagement_time_series_data(

--- a/enterprise_data/api/v1/views/analytics_enrollments.py
+++ b/enterprise_data/api/v1/views/analytics_enrollments.py
@@ -1,7 +1,7 @@
 """
 Advance Analytics for API endpoints to fetch enterprise enrollments data.
 """
-from datetime import datetime
+from datetime import date
 from logging import getLogger
 
 from edx_rbac.decorators import permission_required
@@ -49,7 +49,7 @@ class AdvanceAnalyticsEnrollmentsView(AnalyticsPaginationMixin, ViewSet):
 
         # get values from query params or use default values
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         enrollments = FactEnrollmentAdminDashTable().get_all_enrollments(
@@ -131,7 +131,7 @@ class AdvanceAnalyticsEnrollmentsView(AnalyticsPaginationMixin, ViewSet):
         )
         # get values from query params or use default
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         with timer('construct_enrollment_all_stats'):
             data = {
                 'enrollments_over_time': FactEnrollmentAdminDashTable().get_enrolment_time_series_data(

--- a/enterprise_data/api/v1/views/analytics_leaderboard.py
+++ b/enterprise_data/api/v1/views/analytics_leaderboard.py
@@ -2,7 +2,7 @@
 Views for fetching leaderboard data.
 """
 
-from datetime import datetime
+from datetime import date
 from logging import getLogger
 
 from edx_rbac.decorators import permission_required
@@ -46,7 +46,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
 
         # get values from query params or use default values
         start_date = serializer.data.get('start_date', min_enrollment_date)
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         leaderboard = FactEngagementAdminDashTable().get_all_leaderboard_data(

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -1,7 +1,7 @@
 """
 Views for enterprise admin api v1.
 """
-from datetime import datetime
+from datetime import date, datetime
 
 from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -160,7 +160,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
         if (start_date := serializer.data.get('start_date')) is None:
             start_date, _ = FactEnrollmentAdminDashTable().get_enrollment_date_range(enterprise_id)
 
-        end_date = serializer.data.get('end_date', datetime.now())
+        end_date = serializer.data.get('end_date', date.today())
 
         with timer('top_skills'):
             skills = SkillsDailyRollupAdminDashTable().get_top_skills(enterprise_id, start_date, end_date)

--- a/enterprise_data/management/commands/pre_warm_analytics_cache.py
+++ b/enterprise_data/management/commands/pre_warm_analytics_cache.py
@@ -1,0 +1,218 @@
+"""
+Management command for pre-warming the analytics cache for large enterprises.
+"""
+from datetime import date
+
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise_data.admin_analytics.database.tables import (
+    FactEngagementAdminDashTable,
+    FactEnrollmentAdminDashTable,
+    SkillsDailyRollupAdminDashTable,
+)
+
+
+class Command(BaseCommand):
+    """
+    Add cache entries for analytics related data for a large enterprise.
+
+    The top enterprises will be the ones with the most enrollments.
+    """
+    help = 'Pre-warm the analytics cache for a large enterprises.'
+
+    @staticmethod
+    def __cache_enrollment_data(enterprise_customer_uuid):
+        """
+        Helper method to cache all the enrollment related data for the given enterprise.
+
+        Arguments:
+            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+        """
+        enterprise_enrollment_table = FactEnrollmentAdminDashTable()
+        start_date, _ = enterprise_enrollment_table.get_enrollment_date_range(
+            enterprise_customer_uuid,
+        )
+        end_date = date.today()
+        enterprise_enrollment_table.get_enrollment_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        page_size = 100
+        enterprise_enrollment_table.get_all_enrollments(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            limit=page_size,
+            offset=0,
+        )
+        enterprise_enrollment_table.get_enrollment_and_course_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_completion_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_top_courses_by_enrollments(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_top_subjects_by_enrollments(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_enrolment_time_series_data(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    @staticmethod
+    def __cache_completions_data(enterprise_customer_uuid):
+        """
+        Helper method to cache all the completions related data for the given enterprise.
+
+        Arguments:
+            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+        """
+        enterprise_enrollment_table = FactEnrollmentAdminDashTable()
+        start_date, _ = enterprise_enrollment_table.get_enrollment_date_range(
+            enterprise_customer_uuid,
+        )
+        end_date = date.today()
+
+        page_size = 100
+        enterprise_enrollment_table.get_all_completions(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            limit=page_size,
+            offset=0,
+        )
+        enterprise_enrollment_table.get_completion_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_top_courses_by_completions(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_top_subjects_by_completions(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_enrollment_table.get_completions_time_series_data(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    @staticmethod
+    def __cache_engagement_data(enterprise_customer_uuid):
+        """
+        Helper method to cache all the engagement related data for the given enterprise.
+
+        Arguments:
+            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+        """
+        start_date, _ = FactEnrollmentAdminDashTable().get_enrollment_date_range(
+            enterprise_customer_uuid,
+        )
+        end_date = date.today()
+        enterprise_engagement_table = FactEngagementAdminDashTable()
+        enterprise_engagement_table.get_learning_hours_and_daily_sessions(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_engagement_table.get_engagement_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        page_size = 100
+        enterprise_engagement_table.get_all_engagements(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            limit=page_size,
+            offset=0,
+        )
+        enterprise_engagement_table.get_top_courses_by_engagement(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_engagement_table.get_top_subjects_by_engagement(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_engagement_table.get_engagement_time_series_data(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        enterprise_engagement_table.get_all_leaderboard_data(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            limit=page_size,
+            offset=0,
+        )
+        enterprise_engagement_table.get_leaderboard_data_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    @staticmethod
+    def __cache_skills_data(enterprise_customer_uuid):
+        """
+        Helper method to cache all the skills related data for the given enterprise.
+
+        Arguments:
+            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+        """
+        start_date, _ = FactEnrollmentAdminDashTable().get_enrollment_date_range(
+            enterprise_customer_uuid,
+        )
+        end_date = date.today()
+        skills_table = SkillsDailyRollupAdminDashTable()
+        skills_table.get_top_skills(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        skills_table.get_top_skills_by_enrollment(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        skills_table.get_top_skills_by_completion(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def handle(self, *args, **options):
+        for enterprise_customer_uuid in FactEnrollmentAdminDashTable().get_top_enterprises():
+            try:
+                self.__cache_enrollment_data(enterprise_customer_uuid)
+                self.__cache_completions_data(enterprise_customer_uuid)
+                self.__cache_engagement_data(enterprise_customer_uuid)
+                self.__cache_skills_data(enterprise_customer_uuid)
+            except Exception as exc:
+                info = (
+                    'Error trying to add cache entries for enterprise '
+                    '{}: {}'.format(enterprise_customer_uuid, exc)
+                )
+                raise CommandError(info) from exc

--- a/enterprise_data/management/commands/tests/test_pre_warm_analytics_cache.py
+++ b/enterprise_data/management/commands/tests/test_pre_warm_analytics_cache.py
@@ -1,0 +1,51 @@
+"""
+Tests for `./manage.py pre_warm_analytics_cache` management command.
+"""
+from datetime import datetime
+from unittest import TestCase
+
+from mock import MagicMock, patch
+from pytest import mark
+
+from django.core.management import call_command
+
+
+@mark.django_db
+class Test(TestCase):
+    """
+    Tests to validate the behavior of `./manage.py pre_warm_analytics_cache` management command.
+    """
+    def setUp(self):
+        """
+        Setup method.
+        """
+        super().setUp()
+        self.enterprise_uuid = 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
+
+        get_enrollment_date_range_patcher = patch(
+            'enterprise_data.api.v1.views.analytics_enrollments.FactEnrollmentAdminDashTable.get_enrollment_date_range',
+            return_value=(datetime.now(), datetime.now())
+        )
+
+        get_enrollment_date_range_patcher.start()
+        self.addCleanup(get_enrollment_date_range_patcher.stop)
+
+    @patch('enterprise_data.admin_analytics.database.tables.fact_engagement_admin_dash.run_query', MagicMock())
+    @patch('enterprise_data.admin_analytics.database.tables.fact_enrollment_admin_dash.run_query', MagicMock())
+    @patch('enterprise_data.admin_analytics.database.tables.skills_daily_rollup_admin_dash.run_query', MagicMock())
+    @patch('enterprise_data.api.v1.views.analytics_enrollments.FactEnrollmentAdminDashTable.get_top_enterprises')
+    @patch('enterprise_data.cache.decorators.cache.set')
+    @patch('enterprise_data.cache.decorators.cache.get')
+    def test_pre_warm_analytics_cache(self, mock_get_cache, mock_set_cache, mock_get_top_enterprises):
+        """
+        Validate that the command caches the analytics data for a large enterprise.
+        """
+        mock_get_top_enterprises.return_value = [
+            self.enterprise_uuid
+        ]
+        mock_get_cache.return_value = MagicMock(is_found=False)
+
+        call_command('pre_warm_analytics_cache')
+
+        assert mock_get_cache.call_count == 24
+        assert mock_set_cache.call_count == 24


### PR DESCRIPTION
__Jira Ticket:__ [ENT-9621](https://2u-internal.atlassian.net/browse/ENT-9621)

__Description:__
This PR adds a new management command to pre-warm cache for large enterprises. Large enterprises are the ones with most enrollments.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
