### PR TITLE
ENT-9704: fix: Fixed null email issue for leaderboard.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 =========================
 
+[10.2.0] - 2024-11-12
+---------------------
+  * Fixed null email issue for leaderboard.
+
+
 [10.1.0] - 2024-10-29
 ---------------------
   * Added management command to pre-warm analytics data.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.1.0"
+__version__ = "10.2.0"

--- a/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
@@ -164,6 +164,55 @@ class FactEngagementAdminDashQueries:
         """
 
     @staticmethod
+    def get_engagement_data_for_leaderboard_null_email_only_query():
+        """
+        Get the query to fetch the engagement data for leaderboard for NULL emails only.
+
+        Query should fetch the engagement data for like learning time, session length of
+        the enterprise learners to show in the leaderboard.
+
+        Returns:
+            (str): Query to fetch the engagement data for leaderboard.
+        """
+        return """
+            SELECT
+                email,
+                ROUND(SUM(learning_time_seconds) / 3600, 1) as learning_time_hours,
+                SUM(is_engaged) as session_count,
+                CASE
+                    WHEN SUM(is_engaged) = 0 THEN 0.0
+                    ELSE ROUND(SUM(learning_time_seconds) / 3600 / SUM(is_engaged), 1)
+                END AS average_session_length
+            FROM fact_enrollment_engagement_day_admin_dash
+            WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
+                (activity_date BETWEEN %(start_date)s AND %(end_date)s) AND
+                is_engaged = 1 AND
+                email is NULL
+            GROUP BY email;
+        """
+
+    @staticmethod
+    def get_completion_data_for_leaderboard_null_email_only_query():
+        """
+        Get the query to fetch the completions data for leaderboard for NULL emails.
+
+        Query should fetch the completion data for like course completion count of
+        the enterprise learners to show in the leaderboard.
+
+        Returns:
+            (list<str>): Query to fetch the completions data for leaderboard.
+        """
+        return """
+            SELECT email, count(course_key) as course_completion_count
+            FROM fact_enrollment_admin_dash
+            WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
+                (passed_date BETWEEN %(start_date)s AND %(end_date)s) AND
+                has_passed = 1 AND
+                email is NULL
+            GROUP BY email;
+        """
+
+    @staticmethod
     def get_leaderboard_data_count_query():
         """
         Get the query to fetch the leaderboard row count and null email counter.

--- a/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
@@ -5,6 +5,7 @@ from datetime import date
 from uuid import UUID
 
 from enterprise_data.cache.decorators import cache_it
+from enterprise_data.utils import find_first
 
 from ..queries import FactEngagementAdminDashQueries
 from ..utils import run_query
@@ -168,7 +169,14 @@ class FactEngagementAdminDashTable(BaseTable):
 
     @cache_it()
     def _get_engagement_data_for_leaderboard(
-            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, limit: int, offset: int
+            self,
+            enterprise_customer_uuid: UUID,
+            start_date: date,
+            end_date: date,
+            limit: int,
+            offset: int,
+            include_null_email: bool,
+
     ):
         """
         Get the engagement data for leaderboard.
@@ -182,11 +190,12 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             limit (int): The maximum number of records to return.
             offset (int): The number of records to skip.
+            include_null_email (bool): If True, only fetch data for NULL emails.
 
         Returns:
             list[dict]: The engagement data for leaderboard.
         """
-        return run_query(
+        engagements = run_query(
             query=self.queries.get_engagement_data_for_leaderboard_query(),
             params={
                 'enterprise_customer_uuid': enterprise_customer_uuid,
@@ -198,9 +207,27 @@ class FactEngagementAdminDashTable(BaseTable):
             as_dict=True,
         )
 
+        if include_null_email:
+            engagement_for_null_email = run_query(
+                query=self.queries.get_engagement_data_for_leaderboard_null_email_only_query(),
+                params={
+                    'enterprise_customer_uuid': enterprise_customer_uuid,
+                    'start_date': start_date,
+                    'end_date': end_date,
+                },
+                as_dict=True,
+            )
+            engagements += engagement_for_null_email
+        return engagements
+
     @cache_it()
     def _get_completion_data_for_leaderboard_query(
-            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, email_list: list
+            self,
+            enterprise_customer_uuid: UUID,
+            start_date: date,
+            end_date: date,
+            email_list: list,
+            include_null_email: bool,
     ):
         """
         Get the completion data for leaderboard.
@@ -213,11 +240,13 @@ class FactEngagementAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             email_list (list<str>): List of emails of the enterprise learners.
+            include_null_email (bool): If True, only fetch data for NULL emails.
 
         Returns:
             list[dict]: The engagement data for leaderboard.
         """
-        return run_query(
+
+        completions = run_query(
             query=self.queries.get_completion_data_for_leaderboard_query(email_list),
             params={
                 'enterprise_customer_uuid': enterprise_customer_uuid,
@@ -227,8 +256,28 @@ class FactEngagementAdminDashTable(BaseTable):
             as_dict=True,
         )
 
+        if include_null_email:
+            completions_for_null_email = run_query(
+                query=self.queries.get_completion_data_for_leaderboard_null_email_only_query(),
+                params={
+                    'enterprise_customer_uuid': enterprise_customer_uuid,
+                    'start_date': start_date,
+                    'end_date': end_date,
+                },
+                as_dict=True,
+            )
+            completions += completions_for_null_email
+
+        return completions
+
     def get_all_leaderboard_data(
-            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, limit: int, offset: int
+            self,
+            enterprise_customer_uuid: UUID,
+            start_date: date,
+            end_date: date,
+            limit: int,
+            offset: int,
+            total_count: int,
     ):
         """
         Get the leaderboard data for the given enterprise customer.
@@ -239,31 +288,47 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             limit (int): The maximum number of records to return.
             offset (int): The number of records to skip.
+            total_count (int): The total number of records.
 
         Returns:
             list[dict]: The leaderboard data.
         """
+        include_null_email = False
+        # If this is the last or only page, we need to include NULL emails record.
+        if total_count <= offset + limit:
+            include_null_email = True
+
         engagement_data = self._get_engagement_data_for_leaderboard(
             enterprise_customer_uuid=enterprise_customer_uuid,
             start_date=start_date,
             end_date=end_date,
             limit=limit,
             offset=offset,
+            include_null_email=include_null_email,
         )
         # If there is no data, no need to proceed.
         if not engagement_data:
             return []
 
-        engagement_data_dict = {engagement['email']: engagement for engagement in engagement_data}
+        engagement_data_dict = {
+            engagement['email']: engagement for engagement in engagement_data if engagement['email']
+        }
         completion_data = self._get_completion_data_for_leaderboard_query(
             enterprise_customer_uuid=enterprise_customer_uuid,
             start_date=start_date,
             end_date=end_date,
             email_list=list(engagement_data_dict.keys()),
+            include_null_email=include_null_email,
         )
         for completion in completion_data:
             email = completion['email']
             engagement_data_dict[email]['course_completion_count'] = completion['course_completion_count']
+
+        if include_null_email:
+            engagement_data_dict['None'] = find_first(engagement_data, lambda x: x['email'] is None) or {}
+            completion = find_first(completion_data, lambda x: x['email'] is None) or \
+                {'course_completion_count': 'Unknown'}
+            engagement_data_dict['None']['course_completion_count'] = completion['course_completion_count']
 
         return list(engagement_data_dict.values())
 

--- a/enterprise_data/api/v1/views/analytics_leaderboard.py
+++ b/enterprise_data/api/v1/views/analytics_leaderboard.py
@@ -49,17 +49,18 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
+        total_count = FactEngagementAdminDashTable().get_leaderboard_data_count(
+            enterprise_customer_uuid=enterprise_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
         leaderboard = FactEngagementAdminDashTable().get_all_leaderboard_data(
             enterprise_customer_uuid=enterprise_uuid,
             start_date=start_date,
             end_date=end_date,
             limit=page_size,
             offset=(page - 1) * page_size,
-        )
-        total_count = FactEngagementAdminDashTable().get_leaderboard_data_count(
-            enterprise_customer_uuid=enterprise_uuid,
-            start_date=start_date,
-            end_date=end_date,
+            total_count=total_count,
         )
         response_type = request.query_params.get('response_type', ResponseType.JSON.value)
 
@@ -102,6 +103,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
                 end_date=end_date,
                 limit=page_size,
                 offset=offset,
+                total_count=total_count,
             )
             yield from leaderboard
             offset += page_size

--- a/enterprise_data/management/commands/pre_warm_analytics_cache.py
+++ b/enterprise_data/management/commands/pre_warm_analytics_cache.py
@@ -161,17 +161,18 @@ class Command(BaseCommand):
             start_date=start_date,
             end_date=end_date,
         )
+        total_count = enterprise_engagement_table.get_leaderboard_data_count(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
         enterprise_engagement_table.get_all_leaderboard_data(
             enterprise_customer_uuid=enterprise_customer_uuid,
             start_date=start_date,
             end_date=end_date,
             limit=page_size,
             offset=0,
-        )
-        enterprise_engagement_table.get_leaderboard_data_count(
-            enterprise_customer_uuid=enterprise_customer_uuid,
-            start_date=start_date,
-            end_date=end_date,
+            total_count=total_count,
         )
 
     @staticmethod

--- a/enterprise_data/management/commands/tests/test_pre_warm_analytics_cache.py
+++ b/enterprise_data/management/commands/tests/test_pre_warm_analytics_cache.py
@@ -30,9 +30,18 @@ class Test(TestCase):
         get_enrollment_date_range_patcher.start()
         self.addCleanup(get_enrollment_date_range_patcher.stop)
 
-    @patch('enterprise_data.admin_analytics.database.tables.fact_engagement_admin_dash.run_query', MagicMock())
-    @patch('enterprise_data.admin_analytics.database.tables.fact_enrollment_admin_dash.run_query', MagicMock())
-    @patch('enterprise_data.admin_analytics.database.tables.skills_daily_rollup_admin_dash.run_query', MagicMock())
+    @patch(
+        'enterprise_data.admin_analytics.database.tables.fact_engagement_admin_dash.run_query',
+        MagicMock(return_value=[])
+    )
+    @patch(
+        'enterprise_data.admin_analytics.database.tables.fact_enrollment_admin_dash.run_query',
+        MagicMock(return_value=[])
+    )
+    @patch(
+        'enterprise_data.admin_analytics.database.tables.skills_daily_rollup_admin_dash.run_query',
+        MagicMock(return_value=[])
+    )
     @patch('enterprise_data.api.v1.views.analytics_enrollments.FactEnrollmentAdminDashTable.get_top_enterprises')
     @patch('enterprise_data.cache.decorators.cache.set')
     @patch('enterprise_data.cache.decorators.cache.get')
@@ -47,5 +56,5 @@ class Test(TestCase):
 
         call_command('pre_warm_analytics_cache')
 
-        assert mock_get_cache.call_count == 24
-        assert mock_set_cache.call_count == 24
+        assert mock_get_cache.call_count == 23
+        assert mock_set_cache.call_count == 23

--- a/enterprise_data/utils.py
+++ b/enterprise_data/utils.py
@@ -97,3 +97,20 @@ def primary_subject_truncate(x):
         return x
     else:
         return "other"
+
+
+def find_first(iterable, condition):
+    """
+    Find the first item in an iterable that satisfies the condition.
+
+    Arguments:
+        iterable (iterable): The iterable to search.
+        condition (function): The condition to satisfy.
+
+    Returns:
+        The first item that satisfies the condition, or None if no item satisfies the condition.
+    """
+    try:
+        return next(item for item in iterable if condition(item))
+    except StopIteration:
+        return None

--- a/enterprise_data_roles/rules.py
+++ b/enterprise_data_roles/rules.py
@@ -57,5 +57,5 @@ def request_user_has_explicit_access(*args, **kwargs):
 
 rules.add_perm(
     'can_access_enterprise',
-    request_user_has_implicit_access | request_user_has_explicit_access  # pylint: disable=unsupported-binary-operation
+    request_user_has_implicit_access | request_user_has_explicit_access
 )


### PR DESCRIPTION
__Jira Ticket:__ [ENT-9704](https://2u-internal.atlassian.net/browse/ENT-9704)

__Description:__
This PR fixes a bug that was causing 500 error for leaderboard. It also implements a new feature where accumulated data for `NULL` emails is returned by the last page of the leaderboard API endpoint.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
