### PR TITLE
fix: csv file name and skill top chart data ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 =========================
 
+[10.5.0] - 2024-11-14
+---------------------
+  * Fix CSV file names
+  * Fix ordering of skills charts data
+
 [10.4.0] - 2024-11-14
 ---------------------
   * Updated text for null emails record of leaderboard.
@@ -35,8 +40,8 @@ Unreleased
 
 [10.0.1] - 2024-10-25
 ---------------------
-  * Same as ``10.0.0`` 
-  * Bumping the version so a new tag can be created in the GitHub 
+  * Same as ``10.0.0``
+  * Bumping the version so a new tag can be created in the GitHub
 
 [10.0.0] - 2024-10-25
 ---------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.4.0"
+__version__ = "10.5.0"

--- a/enterprise_data/admin_analytics/database/queries/skills_daily_rollup_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/skills_daily_rollup_admin_dash.py
@@ -38,7 +38,8 @@ class SkillsDailyRollupAdminDashQueries:
             WITH TopSkills AS (
                 -- Get top 10 skills by total enrollments
                 SELECT
-                    skill_name
+                    skill_name,
+                    SUM(enrolls) AS total_enrollment_count
                 FROM
                     skills_daily_rollup_admin_dash
                 WHERE
@@ -47,7 +48,7 @@ class SkillsDailyRollupAdminDashQueries:
                 GROUP BY
                     skill_name
                 ORDER BY
-                    SUM(enrolls) DESC
+                    total_enrollment_count DESC
                 LIMIT 10
             )
             SELECT
@@ -70,7 +71,7 @@ class SkillsDailyRollupAdminDashQueries:
             GROUP BY
                 sd.skill_name, subject_name
             ORDER BY
-                subject_name;
+                total_enrollment_count DESC;
         """
 
     @staticmethod
@@ -82,7 +83,8 @@ class SkillsDailyRollupAdminDashQueries:
             WITH TopSkills AS (
                 -- Get top 10 skills by total completions
                 SELECT
-                    skill_name
+                    skill_name,
+                    SUM(completions) AS total_completion_count
                 FROM
                     skills_daily_rollup_admin_dash
                 WHERE
@@ -91,7 +93,7 @@ class SkillsDailyRollupAdminDashQueries:
                 GROUP BY
                     skill_name
                 ORDER BY
-                    SUM(completions) DESC
+                    total_completion_count DESC
                 LIMIT 10
             )
             SELECT
@@ -114,5 +116,5 @@ class SkillsDailyRollupAdminDashQueries:
             GROUP BY
                 sd.skill_name, subject_name
             ORDER BY
-                subject_name;
+                total_completion_count DESC;
         """

--- a/enterprise_data/api/v1/views/analytics_completions.py
+++ b/enterprise_data/api/v1/views/analytics_completions.py
@@ -75,7 +75,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         )
 
         if response_type == ResponseType.CSV.value:
-            filename = f"""individual_completions, {start_date} - {end_date}.csv"""
+            filename = f"""Individual Completions, {start_date} - {end_date}.csv"""
 
             return StreamingHttpResponse(
                 IndividualCompletionsCSVRenderer().render(self._stream_serialized_data(

--- a/enterprise_data/api/v1/views/analytics_engagements.py
+++ b/enterprise_data/api/v1/views/analytics_engagements.py
@@ -75,7 +75,7 @@ class AdvanceAnalyticsEngagementView(AnalyticsPaginationMixin, ViewSet):
         )
 
         if response_type == ResponseType.CSV.value:
-            filename = f"""individual_engagements, {start_date} - {end_date}.csv"""
+            filename = f"""Individual Engagements, {start_date} - {end_date}.csv"""
 
             return StreamingHttpResponse(
                 IndividualEngagementsCSVRenderer().render(self._stream_serialized_data(

--- a/enterprise_data/api/v1/views/analytics_enrollments.py
+++ b/enterprise_data/api/v1/views/analytics_enrollments.py
@@ -74,7 +74,7 @@ class AdvanceAnalyticsEnrollmentsView(AnalyticsPaginationMixin, ViewSet):
         )
 
         if response_type == ResponseType.CSV.value:
-            filename = f"""individual_enrollments, {start_date} - {end_date}.csv"""
+            filename = f"""Individual Enrollments, {start_date} - {end_date}.csv"""
 
             return StreamingHttpResponse(
                 IndividualEnrollmentsCSVRenderer().render(self._stream_serialized_data(


### PR DESCRIPTION
**Description:**
  * Fix CSV file names
  * Fix ordering of skills top charts data

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
