### PR TITLE
feat: get groups data from membership endpoint using enterprise client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[10.9.0] - 2025-02-24
+---------------------
+  * feat: get groups data from membership endpoint using enterprise client.
+
 [10.8.1] - 2025-02-20
 ---------------------
   * feat: Added 2 new columns in module performance report model and exposed them via associated REST API.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.8.1"
+__version__ = "10.9.0"

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from rest_framework import filters, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from django.conf import settings
@@ -20,6 +21,7 @@ from django.utils import timezone
 
 from enterprise_data.admin_analytics.database.utils import LOGGER
 from enterprise_data.api.v1 import serializers
+from enterprise_data.clients import EnterpriseApiClient
 from enterprise_data.models import EnterpriseGroupMembership, EnterpriseLearner, EnterpriseLearnerEnrollment
 from enterprise_data.paginators import EnterpriseEnrollmentsPagination
 from enterprise_data.renderers import EnrollmentsCSVRenderer
@@ -176,12 +178,51 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
 
         group_uuid = query_filters.get('group_uuid')
         if group_uuid:
-            flex_group_exists = EnterpriseGroupMembership.objects.filter(
-                enterprise_customer_user_id=OuterRef('enterprise_user_id'),
-                enterprise_group_uuid=group_uuid,
-                group_type='flex'
-            )
-            queryset = queryset.filter(Exists(flex_group_exists))
+            queryset = self.filter_by_group_uuid(queryset, group_uuid)
+
+        return queryset
+
+    def filter_by_group_uuid(self, queryset, group_uuid):
+        """
+        Filters the queryset based on the provided group_uuid. If no records are found,
+        it attempts to fetch group learners from the API and filter the queryset again.
+
+        Args:
+            queryset (QuerySet): The initial queryset to filter.
+            group_uuid (str): The UUID of the group to filter by.
+
+        Returns:
+            QuerySet: The filtered queryset.
+        """
+        flex_group_exists = EnterpriseGroupMembership.objects.filter(
+            enterprise_customer_user_id=OuterRef('enterprise_user_id'),
+            enterprise_group_uuid=group_uuid,
+            group_type='flex'
+        )
+
+        # First, filter the queryset using flex_group_exists
+        filtered_queryset = queryset.filter(Exists(flex_group_exists))
+
+        # If no records are found, attempt to fetch group_learners from the API
+        if not filtered_queryset.exists():
+            try:
+                enterprise_api_client = EnterpriseApiClient(
+                    settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
+                    settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+                    settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+                )
+                group_learners = enterprise_api_client.get_enterprise_group_learners(group_uuid)
+                if group_learners:
+                    group_learners_ids = [learner['enterprise_customer_user_id'] for learner in group_learners]
+                    queryset = queryset.filter(enterprise_user_id__in=group_learners_ids)
+                else:
+                    LOGGER.warning(f"No group learners found for group: {group_uuid}")
+                    raise NotFound(f"No learners found for group: {group_uuid}")
+            except (Exception) as e:  # pylint: disable=broad-exception-caught
+                LOGGER.error("Failed to fetch group learners from API: %s", e)
+                queryset = queryset.none()  # API call failed or unexpected error, return an empty queryset
+        else:
+            queryset = filtered_queryset
 
         return queryset
 

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -101,3 +101,30 @@ class EnterpriseApiClient(OAuthAPIClient):
         TieredCache.set_all_tiers(cache_key, data, DEFAULT_REPORTING_CACHE_TIMEOUT)
 
         return data
+
+    def get_enterprise_group_learners(self, group_uuid):
+        """
+        Get the learners associated with a given enterprise group.
+
+        Returns: list of learners or None if unable to retrieve or no learners exist
+        """
+        LOGGER.info(f'[EnterpriseApiClient] getting learners for enterprise group:{group_uuid}')
+        url = urljoin(self.API_BASE_URL, f'enterprise-group/{group_uuid}/learners/')
+        all_learners = []
+
+        try:
+            while url:
+                response = self.get(url)
+                response.raise_for_status()
+                data = response.json()
+                all_learners.extend(data.get('results', []))
+                url = data.get('next')  # Get the URL for the next page, if any
+
+        except (HTTPError, RequestException) as exc:
+            LOGGER.warning(
+                "[Data Overview Failure] Unable to retrieve Enterprise Group Learners details. "
+                f"Group: {group_uuid}, Exception: {exc}"
+            )
+            return None
+
+        return all_learners


### PR DESCRIPTION
**Description**

JIRA -> [ENT-10020](https://2u-internal.atlassian.net/browse/ENT-10020)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
