### PR TITLE
ENT-10099: Added separate handling for of SFTP transmission failures.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Unreleased
 ----------
 
 =========================
+[10.10.0] - 2025-02-24
+---------------------
+  * feat: Added separate handling for of SFTP transmission failures.
 
 [10.9.2] - 2025-03-11
 ---------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.9.2"
+__version__ = "10.10.0"

--- a/enterprise_reporting/constants.py
+++ b/enterprise_reporting/constants.py
@@ -1,0 +1,7 @@
+"""
+Constants for enterprise_reporting.
+"""
+
+
+SFTP_OPS_GENIE_EMAIL_ALERT_FROM_EMAIL = "enterprise-analytics@edx.org"
+SFTP_OPS_GENIE_EMAIL_ALERT_EMAILS = ['enterprise-reporting-sftp@2u-internal.opsgenie.net']

--- a/enterprise_reporting/tests/test_delivery_method.py
+++ b/enterprise_reporting/tests/test_delivery_method.py
@@ -2,13 +2,12 @@
 Test delivery methods.
 """
 
-import sys
 import unittest
 
 import ddt
-import pytest
 
-from enterprise_reporting.delivery_method import DeliveryMethod, SFTPDeliveryMethod, SMTPDeliveryMethod
+from mock import patch, MagicMock
+from enterprise_reporting.delivery_method import SFTPDeliveryMethod, SMTPDeliveryMethod
 from enterprise_reporting.utils import encrypt_string
 
 from .utils import create_files, verify_compressed
@@ -73,3 +72,47 @@ class TestDeliveryMethod(unittest.TestCase):
         else:
             assert len(delivery_files) == len(delivery_files)
             assert delivery_files == [file['file'].name for file in files]
+
+    @patch('enterprise_reporting.delivery_method.send_email_with_attachment')
+    def test_verify_sftp_exception_handling(self, mock_send_email_with_attachment):
+        """
+        Verify that SFTP transmission related exceptions are being handled correctly.
+        """
+        file_data = [
+            {
+                'name': 'A History of Magic.txt',
+                'size': 1000
+            },
+            {
+                'name': 'Quidditch Through the Ages.txt',
+                'size': 500
+            },
+            {
+                'name': 'Quidditch Through the Ages.txt',
+                'size': 500
+            },
+        ]
+        files, total_original_size = create_files(file_data)
+        sftp_delivery_method = SFTPDeliveryMethod(self.reporting_config, self.password)
+
+        # Verify failed SFTP transmission.
+        with patch('paramiko.SSHClient.connect', side_effect=Exception('SFTP transmission failed')):
+            sftp_delivery_method.send([file['file'] for file in files])
+            mock_send_email_with_attachment.assert_called_with(
+                subject='SFTP transmission failed for bleh-bleh',
+                body='Failed to send progress report for bleh-bleh',
+                from_email='enterprise-analytics@edx.org',
+                to_email=['enterprise-reporting-sftp@2u-internal.opsgenie.net'],
+                attachment_data={},
+            )
+
+        # Verify successful SFTP transmission.
+        with patch('paramiko.SSHClient', MagicMock()):
+            sftp_delivery_method.send([file['file'] for file in files])
+            mock_send_email_with_attachment.assert_called_with(
+                subject='SFTP transmission successful for bleh-bleh',
+                body='SFTP transmission successful for bleh-bleh',
+                from_email='enterprise-analytics@edx.org',
+                to_email=['enterprise-reporting-sftp@2u-internal.opsgenie.net'],
+                attachment_data={},
+            )


### PR DESCRIPTION
__Jira Ticket:__ [ENT-10099](https://2u-internal.atlassian.net/browse/ENT-10099)

__Description:__
This PR adds separate handling for SFTP transmission failures, instead of propagating all failures to Jenkins where Jenkins send those as alerts to OpsGenie via an Email integration, we will capture SFTP failures in python code and send those to OpsGenie via a different Email integration. This will help declutter analytics alerts and segment them into 2 distinct categories.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
