### PR TITLE
ENT-10126 Added the ability to filter enrollments by group_uuid in the enterprise enrollments API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[10.11.0] - 2025-03-25
+---------------------
+  * feat: Added the ability to filter enrollments by group_uuid in the enterprise enrollments API.
+
 [10.10.1] - 2025-03-18
 ---------------------
   * fix: Updated FROM email address to a provisioned email address.

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.10.1"
+__version__ = "10.11.0"

--- a/enterprise_data/admin_analytics/database/filters/__init__.py
+++ b/enterprise_data/admin_analytics/database/filters/__init__.py
@@ -1,0 +1,5 @@
+"""
+Query Filters for database tables.
+"""
+
+from .fact_enrollment_admin_dash import FactEnrollmentAdminDashFilters

--- a/enterprise_data/admin_analytics/database/filters/base.py
+++ b/enterprise_data/admin_analytics/database/filters/base.py
@@ -1,0 +1,7 @@
+"""
+Base filters for database tables.
+"""
+
+
+class BaseFilter:
+    pass

--- a/enterprise_data/admin_analytics/database/filters/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/filters/fact_enrollment_admin_dash.py
@@ -1,0 +1,51 @@
+"""
+Query filters for enrollments table.
+"""
+from enterprise_data.admin_analytics.database.filters.base import BaseFilter
+from enterprise_data.admin_analytics.database.query_filters import BetweenQueryFilter, EqualQueryFilter, INQueryFilter
+
+
+class FactEnrollmentAdminDashFilters(BaseFilter):
+    """
+    Query filters for enrollments table.
+    """
+    @staticmethod
+    def enterprise_customer_uuid_filter(enterprise_customer_uuid_params_key: str) -> EqualQueryFilter:
+        """
+        Filter by enterprise customer uuid.
+
+        Arguments:
+            enterprise_customer_uuid_params_key: The key against which value will be passed in the query.
+        """
+        return EqualQueryFilter(
+            column='enterprise_customer_uuid',
+            value_placeholder=enterprise_customer_uuid_params_key,
+        )
+
+    @staticmethod
+    def enterprise_enrollment_date_range_filter(
+            start_date_params_key: str, end_date_params_key: str
+    ) -> BetweenQueryFilter:
+        """
+        Filter by enrollment date to be in the given range.
+
+        Arguments:
+            start_date_params_key (str): The start date key against which value will be passed in the query.
+            end_date_params_key (str): The end date key against which value will be passed in the query.
+        """
+        return BetweenQueryFilter(
+            column='enterprise_enrollment_date',
+            range_placeholders=(start_date_params_key, end_date_params_key),
+        )
+
+    @staticmethod
+    def enterprise_user_id_in_filter(
+            enterprise_user_id_param_keys: list,
+    ) -> INQueryFilter:
+        """
+        Filter by enterprise user id.
+        """
+        return INQueryFilter(
+            column='enterprise_user_id',
+            values_placeholders=enterprise_user_id_param_keys
+        )

--- a/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
@@ -1,6 +1,7 @@
 """
 Module containing queries for the fact_enrollment_admin_dash table.
 """
+from ..query_filters import QueryFilters
 
 
 class FactEnrollmentAdminDashQueries:
@@ -20,27 +21,25 @@ class FactEnrollmentAdminDashQueries:
         """
 
     @staticmethod
-    def get_enrollment_count_query():
+    def get_enrollment_count_query(query_filters: QueryFilters) -> str:
         """
         Get the query to fetch the total number of enrollments for an enterprise customer.
         """
-        return """
+        return f"""
             SELECT count(*)
             FROM fact_enrollment_admin_dash
-            WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
-                enterprise_enrollment_date BETWEEN %(start_date)s AND %(end_date)s;
+            WHERE {query_filters.to_sql()};
         """
 
     @staticmethod
-    def get_all_enrollments_query():
+    def get_all_enrollments_query(query_filters: QueryFilters) -> str:
         """
         Get the query to fetch all enrollments.
         """
-        return """
+        return f"""
             SELECT email, course_title, course_subject, enroll_type, enterprise_enrollment_date
             FROM fact_enrollment_admin_dash
-            WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
-                enterprise_enrollment_date BETWEEN %(start_date)s AND %(end_date)s
+            WHERE {query_filters.to_sql()}
             ORDER BY ENTERPRISE_ENROLLMENT_DATE DESC LIMIT %(limit)s OFFSET %(offset)s
         """
 
@@ -98,21 +97,21 @@ class FactEnrollmentAdminDashQueries:
         """
 
     @staticmethod
-    def get_top_courses_by_enrollments_query(record_count=10):
+    def get_top_courses_by_enrollments_query(query_filters: QueryFilters, record_count: int = 10) -> str:
         """
         Get the query to fetch the enrollment count by courses.
 
         Query will fetch the top N courses by enrollment count. Where N is the value of record_count.
 
         Arguments:
+            query_filters (QueryFilters): List of query filters.
             record_count (int): Number of records to fetch.
         """
         return f"""
             WITH filtered_data AS (
                 SELECT *
                 FROM fact_enrollment_admin_dash
-                WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
-                enterprise_enrollment_date BETWEEN %(start_date)s AND %(end_date)s
+                WHERE {query_filters.to_sql()}
             ),
             top_10_courses AS (
                 SELECT course_key
@@ -134,7 +133,7 @@ class FactEnrollmentAdminDashQueries:
         """
 
     @staticmethod
-    def get_top_subjects_by_enrollments_query(record_count=10):
+    def get_top_subjects_by_enrollments_query(query_filters: QueryFilters, record_count: int = 10) -> str:
         """
         Get the query to fetch the enrollment count by subjects.
 
@@ -142,13 +141,13 @@ class FactEnrollmentAdminDashQueries:
 
         Arguments:
             record_count (int): Number of records to fetch.
+            query_filters (QueryFilters): List of query filters.
         """
         return f"""
             WITH filtered_data AS (
                 SELECT *
                 FROM fact_enrollment_admin_dash
-                WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
-                enterprise_enrollment_date BETWEEN %(start_date)s AND %(end_date)s
+                WHERE {query_filters.to_sql()}
             ),
             top_10_subjects AS (
                 SELECT course_subject
@@ -168,15 +167,17 @@ class FactEnrollmentAdminDashQueries:
         """
 
     @staticmethod
-    def get_enrolment_time_series_data_query():
+    def get_enrolment_time_series_data_query(query_filters: QueryFilters) -> str:
         """
         Get the query to fetch the enrollment time series data with daily aggregation.
+
+        Arguments:
+            query_filters (QueryFilters): A list of filters for this query.
         """
-        return """
+        return f"""
             SELECT enterprise_enrollment_date, enroll_type, COUNT(*) as enrollment_count
             FROM fact_enrollment_admin_dash
-            WHERE enterprise_customer_uuid=%(enterprise_customer_uuid)s AND
-                enterprise_enrollment_date BETWEEN %(start_date)s AND %(end_date)s
+            WHERE {query_filters.to_sql()}
             GROUP BY enterprise_enrollment_date, enroll_type
             ORDER BY enterprise_enrollment_date;
         """

--- a/enterprise_data/admin_analytics/database/query_filters/__init__.py
+++ b/enterprise_data/admin_analytics/database/query_filters/__init__.py
@@ -1,0 +1,7 @@
+"""
+Query Filters to filter query data.
+"""
+from .base import QueryFilters
+from .between import BetweenQueryFilter
+from .equal import EqualQueryFilter
+from .in_ import INQueryFilter

--- a/enterprise_data/admin_analytics/database/query_filters/base.py
+++ b/enterprise_data/admin_analytics/database/query_filters/base.py
@@ -1,0 +1,68 @@
+"""
+Base Query Filter.
+"""
+from abc import ABC, abstractmethod
+
+
+class QueryFilter(ABC):
+    """
+    Base Query filter class for functionality common to all filters.
+    """
+    @abstractmethod
+    def to_sql(self) -> str:
+        """
+        Convert the filter to a SQL string.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def validate_argument_exclusivity(value, value_placeholder):
+        """
+        Validate that that arguments are mutually exclusive.
+
+        This method will make sure that at-least one of the value or value_placeholder is provided. it will also
+        make sure that both value and value_placeholder are not provided at the same time.
+
+        Arguments:
+            value: The value of the filter.
+            value_placeholder: The placeholder for the value.
+        """
+        if value is not None and value_placeholder is not None:
+            raise ValueError('Both value and value_placeholder cannot be provided at the same time.')
+        if value is None and value_placeholder is None:
+            raise ValueError('Either value or value_placeholder must be provided.')
+        return True
+
+    def value_to_sql(self, value):
+        """
+        Convert the given value to a string in a way that it can be used inside WHERE clause of SQL query.
+
+        Note: This method is meant to evolve according to user needs. currently it handles the following data types.
+        More types can be added as needed.
+
+        1. str: Encloses the string in single quotes.
+        2. list<str>: Encloses the list of strings in a tuple after calling this method recursively on each item.
+
+        Arguments:
+            value (Any): The value to format.
+
+        Returns:
+            (Any): The formatted value.
+        """
+        if isinstance(value, str):
+            return f"'{value}'"
+        if isinstance(value, list):
+            return [self.value_to_sql(item) for item in value]
+
+        return value
+
+
+class QueryFilters(list):
+    """
+    A list of QueryFilter objects.
+    """
+    def to_sql(self) -> str:
+        """
+        Convert the filters to a SQL string.
+        """
+        return ' AND '.join([_filter.to_sql() for _filter in self])

--- a/enterprise_data/admin_analytics/database/query_filters/between.py
+++ b/enterprise_data/admin_analytics/database/query_filters/between.py
@@ -1,0 +1,30 @@
+"""
+Query filter for between operation.
+"""
+from .base import QueryFilter
+
+
+class BetweenQueryFilter(QueryFilter):
+    """
+    Query filter for between operation.
+    """
+
+    def __init__(self, column: str, _range: tuple = None, range_placeholders: tuple = None):
+        """
+        Initialize the filter.
+
+        This will also validate arguments.
+        """
+        self.validate_argument_exclusivity(_range, range_placeholders)
+
+        self.column = column
+        self.range = _range
+        self.range_placeholders = range_placeholders
+
+    def to_sql(self) -> str:
+        if self.range:
+            lower, upper = self.range
+            return f'{self.column} BETWEEN {self.value_to_sql(lower)} AND {self.value_to_sql(upper)}'
+        else:
+            lower_placeholder, upper_placeholder = self.range_placeholders
+            return f'{self.column} BETWEEN %({lower_placeholder})s AND %({upper_placeholder})s'

--- a/enterprise_data/admin_analytics/database/query_filters/equal.py
+++ b/enterprise_data/admin_analytics/database/query_filters/equal.py
@@ -1,0 +1,27 @@
+"""
+Query filter for equal operation.
+"""
+from .base import QueryFilter
+
+
+class EqualQueryFilter(QueryFilter):
+    """
+    Query filter for equal operation.
+    """
+    def __init__(self, column: str, value: str = None, value_placeholder: str = None):
+        """
+        Initialize the filter.
+
+        This will also validate arguments.
+        """
+        self.validate_argument_exclusivity(value, value_placeholder)
+
+        self.column = column
+        self.value = value
+        self.value_placeholder = value_placeholder
+
+    def to_sql(self) -> str:
+        if self.value is not None:
+            return f'{self.column} = {self.value_to_sql(self.value)}'
+        else:
+            return f'{self.column} = %({self.value_placeholder})s'

--- a/enterprise_data/admin_analytics/database/query_filters/in_.py
+++ b/enterprise_data/admin_analytics/database/query_filters/in_.py
@@ -1,0 +1,28 @@
+"""
+Query filter for between operation.
+"""
+from .base import QueryFilter
+
+
+class INQueryFilter(QueryFilter):
+    """
+    Query filter for IN operation.
+    """
+
+    def __init__(self, column: str, values: list = None, values_placeholders: list = None):
+        """
+        Initialize the filter.
+
+        This will also validate arguments.
+        """
+        self.validate_argument_exclusivity(values, values_placeholders)
+
+        self.column = column
+        self.values = values
+        self.values_placeholders = values_placeholders
+
+    def to_sql(self) -> str:
+        if self.values is not None:
+            return f'{self.column} IN {str(tuple(self.value_to_sql(self.values)))}'
+        else:
+            return f'{self.column} IN {tuple(f"%({item})s" for item in self.values_placeholders)}'

--- a/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
@@ -2,13 +2,21 @@
 Module for interacting with the fact_enrollment_admin_dash table.
 """
 from datetime import date, datetime
+from logging import getLogger
+from typing import Optional, Tuple
 from uuid import UUID
 
 from enterprise_data.cache.decorators import cache_it
+from enterprise_data.clients import EnterpriseApiClient
+from enterprise_data.exceptions import EnterpriseApiClientException
 
+from ..filters import FactEnrollmentAdminDashFilters
 from ..queries import FactEnrollmentAdminDashQueries
+from ..query_filters import INQueryFilter, QueryFilters
 from ..utils import run_query
 from .base import BaseTable
+
+LOGGER = getLogger(__name__)
 
 
 class FactEnrollmentAdminDashTable(BaseTable):
@@ -16,6 +24,73 @@ class FactEnrollmentAdminDashTable(BaseTable):
     Class for communicating with the fact_enrollment_admin_dash table.
     """
     queries = FactEnrollmentAdminDashQueries()
+    filters = FactEnrollmentAdminDashFilters()
+
+    def __get_enterprise_user_query_filter(  # pylint: disable=inconsistent-return-statements
+            self, group_uuid: Optional[UUID],
+            enterprise_customer_uuid: UUID
+    ) -> Optional[Tuple[INQueryFilter, dict]]:
+        """
+        Get the query filter to filter enrollments for enterprise users in the given group.
+
+        Arguments:
+            group_uuid (UUID): The UUID of the group.
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+
+        Returns:
+            (INQueryFilter | None): The query filter to filter enrollments for enterprise users in the given group.
+        """
+        if not group_uuid:
+            return None
+
+        try:
+            learners_in_group = EnterpriseApiClient.get_enterprise_user_ids_in_group(group_uuid)
+        except EnterpriseApiClientException:
+            LOGGER.exception(
+                "Failed to get learners in group [%s] for enterprise [%s]",
+                group_uuid,
+                enterprise_customer_uuid,
+            )
+        else:
+            params = {f'eu_{i}': i for i in range(len(learners_in_group))}
+            return self.filters.enterprise_user_id_in_filter(list(params.keys())), params
+
+    def __get_common_query_filters(
+            self, enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date,
+    ) -> (QueryFilters, dict):
+        """
+        Utility method to get query filters common in most usages below.
+
+        This will return a tuple containing the query filters list and the dictionary of query parameters that
+        will be used in the query.
+
+        It will contain the following query filters.
+            1. enterprise_customer_uuid filter to filter records for an enterprise customer.
+            2. enrollment_date range filter to filter records by enrollment date.
+            3. group_uuid filter to filter records for learners who belong to the given group.
+        """
+        query_filters = QueryFilters([
+            self.filters.enterprise_customer_uuid_filter('enterprise_customer_uuid'),
+            self.filters.enterprise_enrollment_date_range_filter('start_date', 'end_date'),
+        ])
+        params = {
+            'enterprise_customer_uuid': enterprise_customer_uuid,
+            'start_date': start_date,
+            'end_date': end_date,
+        }
+
+        response = self.__get_enterprise_user_query_filter(
+            group_uuid, enterprise_customer_uuid
+        )
+        if response is not None:
+            enterprise_user_id_in_filter, enterprise_user_id_params = response
+            query_filters.append(enterprise_user_id_in_filter)
+            params.update(enterprise_user_id_params)
+
+        return query_filters, params
 
     def get_top_enterprises(self, count=10):
         """
@@ -34,25 +109,32 @@ class FactEnrollmentAdminDashTable(BaseTable):
         return [row[0] for row in result]
 
     @cache_it()
-    def get_enrollment_count(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
+    def get_enrollment_count(
+            self,
+            enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date,
+    ) -> int:
         """
         Get the total number of enrollments for the given enterprise customer.
 
         Arguments:
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
 
         Returns:
             (int): The total number of enrollments.
         """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date
+        )
+
         results = run_query(
-            query=self.queries.get_enrollment_count_query(),
-            params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
-            }
+            query=self.queries.get_enrollment_count_query(query_filters),
+            params=query_filter_params
         )
         if not results:
             return 0
@@ -60,13 +142,20 @@ class FactEnrollmentAdminDashTable(BaseTable):
 
     @cache_it()
     def get_all_enrollments(
-            self, enterprise_customer_uuid: UUID, start_date: date, end_date: date, limit: int, offset: int
-    ):
+            self,
+            enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date,
+            limit: int,
+            offset: int,
+    ) -> list:
         """
         Get all enrollments for the given enterprise customer.
 
         Arguments:
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
             limit (int): The maximum number of records to return.
@@ -75,12 +164,14 @@ class FactEnrollmentAdminDashTable(BaseTable):
         Returns:
             list<dict>: A list of dictionaries containing the enrollment data.
         """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date
+        )
+
         return run_query(
-            query=self.queries.get_all_enrollments_query(),
+            query=self.queries.get_all_enrollments_query(query_filters),
             params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
+                **query_filter_params,
                 'limit': limit,
                 'offset': offset,
             },
@@ -167,71 +258,90 @@ class FactEnrollmentAdminDashTable(BaseTable):
         return int(results[0][0] or 0)
 
     @cache_it()
-    def get_top_courses_by_enrollments(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
+    def get_top_courses_by_enrollments(
+            self, enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date
+    ) -> list:
         """
         Get the top courses enrollments for the given enterprise customer.
 
         Arguments:
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
 
         Returns:
             list<dict>: A list of dictionaries containing the course key, course_title and enrollment count.
         """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date
+        )
+
         return run_query(
-            query=self.queries.get_top_courses_by_enrollments_query(),
-            params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
-            },
+            query=self.queries.get_top_courses_by_enrollments_query(query_filters),
+            params=query_filter_params,
             as_dict=True,
         )
 
     @cache_it()
-    def get_top_subjects_by_enrollments(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
+    def get_top_subjects_by_enrollments(
+            self,
+            enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date,
+    ) -> list:
         """
         Get the top subjects by enrollments for the given enterprise customer.
 
         Arguments:
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
 
         Returns:
             list<dict>: A list of dictionaries containing the subject and enrollment count.
         """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date
+        )
+
         return run_query(
-            query=self.queries.get_top_subjects_by_enrollments_query(),
-            params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
-            },
+            query=self.queries.get_top_subjects_by_enrollments_query(query_filters),
+            params=query_filter_params,
             as_dict=True,
         )
 
     @cache_it()
-    def get_enrolment_time_series_data(self, enterprise_customer_uuid: UUID, start_date: date, end_date: date):
+    def get_enrolment_time_series_data(
+            self, enterprise_customer_uuid: UUID,
+            group_uuid: Optional[UUID],
+            start_date: date,
+            end_date: date
+    ) -> list:
         """
         Get the enrollment time series data for the given enterprise customer.
 
         Arguments:
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
 
         Returns:
             list<dict>: A list of dictionaries containing the date and enrollment count.
         """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date
+        )
+
         return run_query(
-            query=self.queries.get_enrolment_time_series_data_query(),
-            params={
-                'enterprise_customer_uuid': enterprise_customer_uuid,
-                'start_date': start_date,
-                'end_date': end_date,
-            },
+            query=self.queries.get_enrolment_time_series_data_query(query_filters),
+            params=query_filter_params,
             as_dict=True,
         )
 

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -341,6 +341,7 @@ class AdvanceAnalyticsQueryParamSerializer(serializers.Serializer):  # pylint: d
     response_type = serializers.CharField(required=False)
     page = serializers.IntegerField(required=False, min_value=1)
     page_size = serializers.IntegerField(required=False, min_value=2)
+    group_uuid = serializers.UUIDField(required=False)
 
     def validate(self, attrs):
         """

--- a/enterprise_data/exceptions.py
+++ b/enterprise_data/exceptions.py
@@ -1,0 +1,21 @@
+"""
+Custom Exceptions related to enterprise data.
+"""
+
+
+class EnterpriseDataException(Exception):
+    """
+    Base exception for enterprise data.
+    """
+
+    def __init__(self, message: str):
+        """
+        Initialize the exception with a message.
+        """
+        super().__init__(message)
+
+
+class EnterpriseApiClientException(EnterpriseDataException):
+    """
+    Exception for enterprise API client.
+    """

--- a/enterprise_data/management/commands/pre_warm_analytics_cache.py
+++ b/enterprise_data/management/commands/pre_warm_analytics_cache.py
@@ -2,6 +2,7 @@
 Management command for pre-warming the analytics cache for large enterprises.
 """
 from datetime import date
+from uuid import UUID
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -21,12 +22,12 @@ class Command(BaseCommand):
     help = 'Pre-warm the analytics cache for a large enterprises.'
 
     @staticmethod
-    def __cache_enrollment_data(enterprise_customer_uuid):
+    def __cache_enrollment_data(enterprise_customer_uuid: UUID):
         """
         Helper method to cache all the enrollment related data for the given enterprise.
 
         Arguments:
-            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
         """
         enterprise_enrollment_table = FactEnrollmentAdminDashTable()
         start_date, _ = enterprise_enrollment_table.get_enrollment_date_range(
@@ -35,12 +36,14 @@ class Command(BaseCommand):
         end_date = date.today()
         enterprise_enrollment_table.get_enrollment_count(
             enterprise_customer_uuid=enterprise_customer_uuid,
+            group_uuid=None,
             start_date=start_date,
             end_date=end_date,
         )
         page_size = 100
         enterprise_enrollment_table.get_all_enrollments(
             enterprise_customer_uuid=enterprise_customer_uuid,
+            group_uuid=None,
             start_date=start_date,
             end_date=end_date,
             limit=page_size,
@@ -58,27 +61,30 @@ class Command(BaseCommand):
         )
         enterprise_enrollment_table.get_top_courses_by_enrollments(
             enterprise_customer_uuid=enterprise_customer_uuid,
+            group_uuid=None,
             start_date=start_date,
             end_date=end_date,
         )
         enterprise_enrollment_table.get_top_subjects_by_enrollments(
             enterprise_customer_uuid=enterprise_customer_uuid,
+            group_uuid=None,
             start_date=start_date,
             end_date=end_date,
         )
         enterprise_enrollment_table.get_enrolment_time_series_data(
             enterprise_customer_uuid=enterprise_customer_uuid,
+            group_uuid=None,
             start_date=start_date,
             end_date=end_date,
         )
 
     @staticmethod
-    def __cache_completions_data(enterprise_customer_uuid):
+    def __cache_completions_data(enterprise_customer_uuid: UUID):
         """
         Helper method to cache all the completions related data for the given enterprise.
 
         Arguments:
-            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
         """
         enterprise_enrollment_table = FactEnrollmentAdminDashTable()
         start_date, _ = enterprise_enrollment_table.get_enrollment_date_range(
@@ -116,12 +122,12 @@ class Command(BaseCommand):
         )
 
     @staticmethod
-    def __cache_engagement_data(enterprise_customer_uuid):
+    def __cache_engagement_data(enterprise_customer_uuid: UUID):
         """
         Helper method to cache all the engagement related data for the given enterprise.
 
         Arguments:
-            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
         """
         start_date, _ = FactEnrollmentAdminDashTable().get_enrollment_date_range(
             enterprise_customer_uuid,
@@ -176,12 +182,12 @@ class Command(BaseCommand):
         )
 
     @staticmethod
-    def __cache_skills_data(enterprise_customer_uuid):
+    def __cache_skills_data(enterprise_customer_uuid: UUID):
         """
         Helper method to cache all the skills related data for the given enterprise.
 
         Arguments:
-            enterprise_customer_uuid (str): The UUID of the enterprise customer.
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
         """
         start_date, _ = FactEnrollmentAdminDashTable().get_enrollment_date_range(
             enterprise_customer_uuid,

--- a/enterprise_data/tests/admin_analytics/mock_enrollments.py
+++ b/enterprise_data/tests/admin_analytics/mock_enrollments.py
@@ -23,6 +23,7 @@ ENROLLMENTS = [
         "passed_date_raw": "2021-08-25",
         "passed_date": "2021-08-25",
         "has_passed": 1,
+        "enterprise_user_id": 1,
     },
     {
         "enterprise_customer_name": "Hill Ltd",
@@ -46,6 +47,7 @@ ENROLLMENTS = [
         "passed_date_raw": "2021-09-01",
         "passed_date": "2021-09-01",
         "has_passed": 1,
+        "enterprise_user_id": 1,
     },
     {
         "enterprise_customer_name": "Hill Ltd",
@@ -69,6 +71,7 @@ ENROLLMENTS = [
         "passed_date_raw": None,
         "passed_date": '2022-08-24',
         "has_passed": 0,
+        "enterprise_user_id": 1,
     },
     {
         "enterprise_customer_name": "Hill Ltd",
@@ -92,6 +95,7 @@ ENROLLMENTS = [
         "passed_date_raw": None,
         "passed_date": "2022-08-24",
         "has_passed": 0,
+        "enterprise_user_id": 1,
     },
     {
         "enterprise_customer_name": "Hill Ltd",
@@ -115,5 +119,6 @@ ENROLLMENTS = [
         "passed_date_raw": None,
         "passed_date": "2022-08-20",
         "has_passed": 0,
+        "enterprise_user_id": 1,
     },
 ]

--- a/enterprise_data_roles/tests/test_models.py
+++ b/enterprise_data_roles/tests/test_models.py
@@ -2,7 +2,6 @@
 Tests for the `enterprise-data` models module.
 """
 
-
 import unittest
 
 import ddt


### PR DESCRIPTION
__Jira Ticket:__ [ENT-10126](https://2u-internal.atlassian.net/browse/ENT-10126)

Added the ability for users to filter enrollments by group_uuid in the enterprise enrollments API.

Note: This PR can not be merged until the `enterprise_user_id` is added to the `fact_enrollment_admin_dash` table.


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
