### PR TITLE
feat: add skills by learning hours metric

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[10.16.8] - 2025-06-16
+---------------------
+  * feat: add skills by learning hours metric
+
 [10.16.7] - 2025-06-11
 ---------------------
   * chore: pin numpy to versions less then 2.3.0

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.16.7"
+__version__ = "10.16.8"

--- a/enterprise_data/admin_analytics/database/queries/skills_daily_rollup_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/skills_daily_rollup_admin_dash.py
@@ -1,6 +1,7 @@
 """
 Module containing queries for the skills_daily_rollup_admin_dash table.
 """
+from ..query_filters import QueryFilters
 
 
 class SkillsDailyRollupAdminDashQueries:
@@ -117,4 +118,32 @@ class SkillsDailyRollupAdminDashQueries:
                 sd.skill_name, subject_name
             ORDER BY
                 total_completion_count DESC;
+        """
+
+    @staticmethod
+    def get_skills_by_learning_hours(query_filters: QueryFilters, record_count: int = 25):
+        """
+        Get the query to fetch skills by learning hours for an enterprise customer.
+        """
+        return f"""
+            WITH filtered_data AS (
+                SELECT
+                    skill_name,
+                    total_learning_time_hours
+                FROM
+                    skills_daily_rollup_admin_dash
+                WHERE
+                    {query_filters.to_sql()}
+            )
+
+            SELECT
+                skill_name,
+                SUM(total_learning_time_hours) AS learning_hours
+            FROM
+                filtered_data
+            GROUP BY
+                skill_name
+            ORDER BY
+                learning_hours DESC
+            LIMIT {record_count};
         """

--- a/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
@@ -4,15 +4,19 @@ Module for interacting with the skills_daily_rollup_admin_dash table.
 from datetime import date
 from uuid import UUID
 
+from enterprise_data.admin_analytics.database.filters.mixins import CommonFiltersMixin
 from enterprise_data.admin_analytics.database.queries.skills_daily_rollup_admin_dash import (
     SkillsDailyRollupAdminDashQueries,
 )
+from enterprise_data.admin_analytics.database.query_filters import EqualQueryFilter
 from enterprise_data.admin_analytics.database.tables.base import BaseTable
 from enterprise_data.admin_analytics.database.utils import run_query
 from enterprise_data.cache.decorators import cache_it
 
+from ..query_filters import QueryFilters
 
-class SkillsDailyRollupAdminDashTable(BaseTable):
+
+class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
     """
     Class for communicating with the skills_daily_rollup_admin_dash table.
     """
@@ -94,5 +98,70 @@ class SkillsDailyRollupAdminDashTable(BaseTable):
                 'start_date': start_date,
                 'end_date': end_date,
             },
+            as_dict=True,
+        )
+
+    def get_skills_by_learning_hours(
+        self,
+        enterprise_customer_uuid: UUID,
+        start_date: date,
+        end_date: date,
+        course_key: str = None,
+        course_type: str = None,
+    ):
+        """
+        Get the skills by learning hours for the given enterprise customer.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            start_date (date): The start date.
+            end_date (date): The end date.
+            course_key (str): The course key to filter by (optional).
+            course_type (str): The course type (OCM or Executive Education) to filter by (optional).
+
+        Returns:
+            list<dict>: A list of dictionaries containing the skill_name, subject_name, count.
+        """
+        optional_params = {}
+        course_key_filter = None
+        course_type_filter = None
+
+        default_params = {
+            'enterprise_customer_uuid': enterprise_customer_uuid,
+            'start_date': start_date,
+            'end_date': end_date,
+        }
+        query_filters = QueryFilters([
+            self.enterprise_customer_uuid_filter('enterprise_customer_uuid'),
+            self.date_range_filter(
+                column='date',
+                start_date_params_key='start_date',
+                end_date_params_key='end_date',
+            ),
+        ])
+
+        if course_key:
+            course_key_filter = EqualQueryFilter(
+                column='course_key',
+                value_placeholder='course_key',
+            )
+
+            optional_params['course_key'] = course_key
+            query_filters.append(course_key_filter)
+
+        if course_type:
+            course_type_filter = EqualQueryFilter(
+                column='course_product_line',
+                value_placeholder='course_type',
+            )
+
+            optional_params['course_type'] = course_type
+            query_filters.append(course_type_filter)
+
+        params = {**default_params, **optional_params}
+
+        return run_query(
+            query=self.queries.get_skills_by_learning_hours(query_filters),
+            params=params,
             as_dict=True,
         )

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -180,10 +180,24 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 end_date
             )
 
+        # TODO: Handle course_key and course_type when they are provided in the request.
+        #       We have separate tickets to handle this implementation.
+        course_key = None
+        course_type = None
+        with timer('skills_by_learning_hours'):
+            skills_by_learning_hours = SkillsDailyRollupAdminDashTable().get_skills_by_learning_hours(
+                enterprise_id,
+                start_date,
+                end_date,
+                course_key,
+                course_type,
+            )
+
         response_data = {
             "top_skills": skills,
             "top_skills_by_enrollments": top_skills_by_enrollments,
             "top_skills_by_completions": top_skills_by_completions,
+            "skills_by_learning_hours": skills_by_learning_hours,
         }
 
         return Response(data=response_data, status=HTTP_200_OK)

--- a/enterprise_data/tests/admin_analytics/mock_analytics_data.py
+++ b/enterprise_data/tests/admin_analytics/mock_analytics_data.py
@@ -470,3 +470,17 @@ TOP_SKILLS_BY_COMPLETIONS = [
         "count": 15.0
     },
 ]
+SKILLS_BY_LEARNING_HOURS = [
+    {
+        "skill_name": "Python (Programming Language)",
+        "learning_hours": 100.0
+    },
+    {
+        "skill_name": "Data Science",
+        "learning_hours": 80.0
+    },
+    {
+        "skill_name": "Algorithms",
+        "learning_hours": 60.0
+    },
+]

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -16,6 +16,7 @@ from enterprise_data.admin_analytics.database.queries import (
     FactEnrollmentAdminDashQueries,
 )
 from enterprise_data.tests.admin_analytics.mock_analytics_data import (
+    SKILLS_BY_LEARNING_HOURS,
     TOP_SKILLS,
     TOP_SKILLS_BY_COMPLETIONS,
     TOP_SKILLS_BY_ENROLLMENTS,
@@ -137,8 +138,10 @@ class TestSkillsStatsAPI(JWTTestMixin, APITransactionTestCase):
     @patch('enterprise_data.api.v1.views.enterprise_admin.SkillsDailyRollupAdminDashTable.get_top_skills')
     @patch('enterprise_data.api.v1.views.enterprise_admin.SkillsDailyRollupAdminDashTable.get_top_skills_by_enrollment')
     @patch('enterprise_data.api.v1.views.enterprise_admin.SkillsDailyRollupAdminDashTable.get_top_skills_by_completion')
+    @patch('enterprise_data.api.v1.views.enterprise_admin.SkillsDailyRollupAdminDashTable.get_skills_by_learning_hours')
     def test_get(
         self,
+        mock_get_skills_by_learning_hours,
         mock_get_top_skills_by_completion,
         mock_get_top_skills_by_enrollment,
         mock_get_top_skills,
@@ -151,6 +154,7 @@ class TestSkillsStatsAPI(JWTTestMixin, APITransactionTestCase):
         mock_get_top_skills.return_value = TOP_SKILLS
         mock_get_top_skills_by_enrollment.return_value = TOP_SKILLS_BY_ENROLLMENTS
         mock_get_top_skills_by_completion.return_value = TOP_SKILLS_BY_COMPLETIONS
+        mock_get_skills_by_learning_hours.return_value = SKILLS_BY_LEARNING_HOURS
 
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
@@ -210,6 +214,20 @@ class TestSkillsStatsAPI(JWTTestMixin, APITransactionTestCase):
                     "count": 15.0,
                 },
             ],
+            "skills_by_learning_hours": [
+                {
+                    "skill_name": "Python (Programming Language)",
+                    "learning_hours": 100.0
+                },
+                {
+                    "skill_name": "Data Science",
+                    "learning_hours": 80.0
+                },
+                {
+                    "skill_name": "Algorithms",
+                    "learning_hours": 60.0
+                },
+            ]
         }
 
     @ddt.data(


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
