### PR TITLE
feat: filter analytics data by course key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[10.20.0] - 2025-08-13
+---------------------
+  * feat: Add course key filtering for enrollments, engagements, completions, skills and leaderboard APIs.
+
 [10.19.1] - 2025-08-13
 ---------------------
   * chore: upgrade python requirements

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.19.1"
+__version__ = "10.20.0"

--- a/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
@@ -30,7 +30,8 @@ class FactEngagementAdminDashTable(BaseTable):
             group_uuid: Optional[UUID],
             start_date: date,
             end_date: date,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None,
     ) -> Tuple[QueryFilters, dict]:
         """
         Utility method to get query filters common in most usages below.
@@ -67,6 +68,13 @@ class FactEngagementAdminDashTable(BaseTable):
                 value_placeholder='course_type',
             ))
             params['course_type'] = course_type
+
+        if course_key:
+            query_filters.append(EqualQueryFilter(
+                column='course_key',
+                value_placeholder='course_key',
+            ))
+            params['course_key'] = course_key
 
         return query_filters, params
 
@@ -172,7 +180,8 @@ class FactEngagementAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None,
     ):
         """
         Get the top courses by user engagement for the given enterprise customer.
@@ -182,12 +191,13 @@ class FactEngagementAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_top_courses_by_engagement_query(query_filters),
@@ -202,7 +212,8 @@ class FactEngagementAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the top subjects by user engagement for the given enterprise customer.
@@ -212,12 +223,13 @@ class FactEngagementAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_top_subjects_by_engagement_query(query_filters),
@@ -232,7 +244,8 @@ class FactEngagementAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the engagement time series data.
@@ -242,12 +255,13 @@ class FactEngagementAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the engagement time series data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_engagement_time_series_data_query(query_filters),
@@ -337,7 +351,8 @@ class FactEngagementAdminDashTable(BaseTable):
             limit: int,
             offset: int,
             include_null_email: bool,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None
     ):
         """
         Get the engagement data for leaderboard.
@@ -353,12 +368,14 @@ class FactEngagementAdminDashTable(BaseTable):
             offset (int): The number of records to skip.
             include_null_email (bool): If True, only fetch data for NULL emails.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list[dict]: The engagement data for leaderboard.
         """
         equality_filters = {
             'course_product_line': course_type,
+            'course_key': course_key,
             'is_engaged': 1
         }
         query_filters, params = self.build_query_filters_for_leaderboard(
@@ -410,7 +427,8 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date: date,
             email_list: list,
             include_null_email: bool,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None
     ):
         """
         Get the completion data for leaderboard.
@@ -425,12 +443,14 @@ class FactEngagementAdminDashTable(BaseTable):
             email_list (list<str>): List of emails of the enterprise learners.
             include_null_email (bool): If True, only fetch data for NULL emails.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list[dict]: The engagement data for leaderboard.
         """
         equality_filters = {
             'course_product_line': course_type,
+            'course_key': course_key,
             'has_passed': 1
         }
         in_filters = {
@@ -477,7 +497,8 @@ class FactEngagementAdminDashTable(BaseTable):
             limit: int,
             offset: int,
             total_count: int,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None,
     ):
         """
         Get the leaderboard data for the given enterprise customer.
@@ -490,6 +511,7 @@ class FactEngagementAdminDashTable(BaseTable):
             offset (int): The number of records to skip.
             total_count (int): The total number of records.
             course_type (Optional[str]): The course type filter.
+            course_key (Optional[str]): The course key filter.
 
         Returns:
             list[dict]: The leaderboard data.
@@ -506,7 +528,8 @@ class FactEngagementAdminDashTable(BaseTable):
             limit=limit,
             offset=offset,
             include_null_email=include_null_email,
-            course_type=course_type
+            course_type=course_type,
+            course_key=course_key
         )
         # If there is no data, no need to proceed.
         if not engagement_data:
@@ -521,7 +544,8 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date=end_date,
             email_list=list(engagement_data_dict.keys()),
             include_null_email=include_null_email,
-            course_type=course_type
+            course_type=course_type,
+            course_key=course_key
         )
         for completion in completion_data:
             email = completion['email']
@@ -542,7 +566,8 @@ class FactEngagementAdminDashTable(BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the total number of leaderboard records for the given enterprise customer.
@@ -552,12 +577,14 @@ class FactEngagementAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type filter.
+            course_key (Optional[str]): The course key filter.
 
         Returns:
             (int): The total number of leaderboard records.
         """
         equality_filters = {
             'course_product_line': course_type,
+            'course_key': course_key,
             'is_engaged': 1
         }
         query_filters, params = self.build_query_filters_for_leaderboard(

--- a/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
@@ -28,7 +28,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid: Optional[UUID],
             start_date: date,
             end_date: date,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None
     ) -> (QueryFilters, dict):
         """
         Utility method to get query filters common in most usages below.
@@ -67,6 +68,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             ))
             params['course_type'] = course_type
 
+        if course_key:
+            query_filters.append(EqualQueryFilter(
+                column='course_key',
+                value_placeholder='course_key',
+            ))
+            params['course_key'] = course_key
+
         return query_filters, params
 
     def __get_common_query_filters_for_completion(
@@ -74,7 +82,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None,
     ) -> Tuple[QueryFilters, dict]:
         """
         Utility method to get query filters common in most usages below.
@@ -114,6 +123,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
                 value_placeholder='course_type',
             ))
             params['course_type'] = course_type
+
+        if course_key:
+            query_filters.append(EqualQueryFilter(
+                column='course_key',
+                value_placeholder='course_key',
+            ))
+            params['course_key'] = course_key
 
         return query_filters, params
 
@@ -263,7 +279,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the completion count for the given enterprise customer.
@@ -274,12 +291,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             int: The completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         results = run_query(
             query=self.queries.get_completion_count_query(query_filters),
@@ -298,7 +316,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid: Optional[UUID],
             start_date: date,
             end_date: date,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None
     ) -> list:
         """
         Get the top courses enrollments for the given enterprise customer.
@@ -308,12 +327,14 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
+            course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course key, course_title and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
 
         return run_query(
@@ -329,7 +350,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid: Optional[UUID],
             start_date: date,
             end_date: date,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None
     ) -> list:
         """
         Get the top subjects by enrollments for the given enterprise customer.
@@ -339,12 +361,14 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid (UUID): The UUID of the group.
             start_date (date): The start date.
             end_date (date): The end date.
+            course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
 
         return run_query(
@@ -359,7 +383,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             group_uuid: Optional[UUID],
             start_date: date,
             end_date: date,
-            course_type: Optional[str] = None
+            course_type: Optional[str] = None,
+            course_key: Optional[str] = None,
     ) -> list:
         """
         Get the enrollment time series data for the given enterprise customer.
@@ -370,12 +395,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the date and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
 
         return run_query(
@@ -394,6 +420,7 @@ class FactEnrollmentAdminDashTable(BaseTable):
         limit: int,
         offset: int,
         course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get all completions for the given enterprise customer.
@@ -406,12 +433,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             limit (int): The maximum number of records to return.
             offset (int): The number of records to skip.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the completions data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_all_completions_query(query_filters),
@@ -430,7 +458,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the top courses by completion for the given enterprise customer.
@@ -439,12 +468,14 @@ class FactEnrollmentAdminDashTable(BaseTable):
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
             start_date (date): The start date.
             end_date (date): The end date.
+            course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course key, course_title and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_top_courses_by_completions_query(query_filters),
@@ -459,7 +490,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the top subjects by completions for the given enterprise customer.
@@ -468,12 +500,14 @@ class FactEnrollmentAdminDashTable(BaseTable):
             enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
             start_date (date): The start date.
             end_date (date): The end date.
+            course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_top_subjects_by_completions_query(query_filters),
@@ -488,7 +522,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         group_uuid: Optional[UUID],
         start_date: date,
         end_date: date,
-        course_type: Optional[str] = None
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None
     ):
         """
         Get the completions time series data for the given enterprise customer.
@@ -499,12 +534,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (Optional[str]): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the date and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
         )
         return run_query(
             query=self.queries.get_completions_time_series_data_query(query_filters),

--- a/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
@@ -2,6 +2,7 @@
 Module for interacting with the skills_daily_rollup_admin_dash table.
 """
 from datetime import date
+from typing import Optional
 from uuid import UUID
 
 from enterprise_data.admin_analytics.database.filters.mixins import CommonFiltersMixin
@@ -85,6 +86,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         start_date: date,
         end_date: date,
         course_type: str = None,
+        course_key: Optional[str] = None,
     ):
         """
         Get the top skills for the given enterprise customer.
@@ -94,6 +96,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (str): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, skill_type, enrolls and completions.
@@ -103,6 +106,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
         )
         return run_query(
             query=self.queries.get_top_skills(query_filters),
@@ -116,7 +120,8 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_type: str = None,
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None,
     ):
         """
         Get the top skills by enrollments for the given enterprise customer.
@@ -126,6 +131,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (str): The course key to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, subject_name, count.
@@ -135,6 +141,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
         )
         return run_query(
             query=self.queries.get_top_skills_by_enrollment(query_filters),
@@ -148,7 +155,8 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_type: str = None,
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None,
     ):
         """
         Get the top skills by completion for the given enterprise customer.
@@ -167,6 +175,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
         )
         return run_query(
             query=self.queries.get_top_skills_by_completion(query_filters),
@@ -179,8 +188,8 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_key: str = None,
-        course_type: str = None,
+        course_key: Optional[str] = None,
+        course_type: Optional[str] = None,
     ):
         """
         Get the skills by learning hours for the given enterprise customer.

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -349,6 +349,7 @@ class AdvanceAnalyticsQueryParamSerializer(serializers.Serializer):  # pylint: d
         allow_blank=False,
         allow_null=False,
     )
+    course_key = serializers.CharField(required=False)
 
     def validate(self, attrs):
         """

--- a/enterprise_data/api/v1/views/analytics_completions.py
+++ b/enterprise_data/api/v1/views/analytics_completions.py
@@ -53,6 +53,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         completions = FactEnrollmentAdminDashTable().get_all_completions(
@@ -61,6 +62,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
             limit=page_size,
             offset=(page - 1) * page_size,
         )
@@ -70,6 +72,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
         )
         response_type = request.query_params.get('response_type', ResponseType.JSON.value)
 
@@ -85,7 +88,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
 
             return StreamingHttpResponse(
                 IndividualCompletionsCSVRenderer().render(self._stream_serialized_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, total_count, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, total_count, course_type, course_key
                 )),
                 content_type="text/csv",
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
@@ -107,6 +110,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         end_date,
         total_count,
         course_type=None,
+        course_key=None,
         page_size=50000
     ):
         """
@@ -122,6 +126,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
                 limit=page_size,
                 offset=offset,
                 course_type=course_type,
+                course_key=course_key,
             )
             yield from completions
             offset += page_size
@@ -151,17 +156,18 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
 
         with timer('construct_completion_all_stats'):
             data = {
                 'completions_over_time': FactEnrollmentAdminDashTable().get_completions_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_courses_by_completions': FactEnrollmentAdminDashTable().get_top_courses_by_completions(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_subjects_by_completions': FactEnrollmentAdminDashTable().get_top_subjects_by_completions(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_engagements.py
+++ b/enterprise_data/api/v1/views/analytics_engagements.py
@@ -139,17 +139,18 @@ class AdvanceAnalyticsEngagementView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
 
         with timer('construct_engagement_all_stats'):
             data = {
                 'engagement_over_time': FactEngagementAdminDashTable().get_engagement_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_courses_by_engagement': FactEngagementAdminDashTable().get_top_courses_by_engagement(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_subjects_by_engagement': FactEngagementAdminDashTable().get_top_subjects_by_engagement(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_enrollments.py
+++ b/enterprise_data/api/v1/views/analytics_enrollments.py
@@ -139,17 +139,18 @@ class AdvanceAnalyticsEnrollmentsView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
 
         with timer('construct_enrollment_all_stats'):
             data = {
                 'enrollments_over_time': FactEnrollmentAdminDashTable().get_enrolment_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_courses_by_enrollments': FactEnrollmentAdminDashTable().get_top_courses_by_enrollments(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
                 'top_subjects_by_enrollments': FactEnrollmentAdminDashTable().get_top_subjects_by_enrollments(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_leaderboard.py
+++ b/enterprise_data/api/v1/views/analytics_leaderboard.py
@@ -48,6 +48,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
         start_date = serializer.data.get('start_date', min_enrollment_date)
         end_date = serializer.data.get('end_date', date.today())
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         total_count = FactEngagementAdminDashTable().get_leaderboard_data_count(
@@ -55,6 +56,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
             start_date=start_date,
             end_date=end_date,
             course_type=course_type,
+            course_key=course_key,
         )
         leaderboard = FactEngagementAdminDashTable().get_all_leaderboard_data(
             enterprise_customer_uuid=enterprise_uuid,
@@ -63,7 +65,8 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
             limit=page_size,
             offset=(page - 1) * page_size,
             total_count=total_count,
-            course_type=course_type
+            course_type=course_type,
+            course_key=course_key,
         )
         response_type = request.query_params.get('response_type', ResponseType.JSON.value)
 
@@ -79,7 +82,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
 
             return StreamingHttpResponse(
                 LeaderboardCSVRenderer().render(self._stream_serialized_data(
-                    enterprise_uuid, start_date, end_date, total_count, course_type
+                    enterprise_uuid, start_date, end_date, total_count, course_type, course_key
                 )),
                 content_type='text/csv',
                 headers={'Content-Disposition': f'attachment; filename="{filename}"'},
@@ -100,6 +103,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
         end_date,
         total_count,
         course_type=None,
+        course_key=None,
         page_size=50000
     ):
         """
@@ -114,7 +118,8 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
                 limit=page_size,
                 offset=offset,
                 total_count=total_count,
-                course_type=course_type
+                course_type=course_type,
+                course_key=course_key,
             )
             yield from leaderboard
             offset += page_size

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -164,13 +164,15 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
 
         end_date = serializer.data.get('end_date', date.today())
         course_type = serializer.data.get('course_type')
+        course_key = serializer.data.get('course_key')
 
         with timer('top_skills'):
             skills = SkillsDailyRollupAdminDashTable().get_top_skills(
                 enterprise_id,
                 start_date,
                 end_date,
-                course_type
+                course_type,
+                course_key,
             )
 
         with timer('top_skills_by_enrollments'):
@@ -178,20 +180,18 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 enterprise_id,
                 start_date,
                 end_date,
-                course_type
+                course_type,
+                course_key,
             )
         with timer('top_skills_by_completions'):
             top_skills_by_completions = SkillsDailyRollupAdminDashTable().get_top_skills_by_completion(
                 enterprise_id,
                 start_date,
                 end_date,
-                course_type
+                course_type,
+                course_key,
             )
 
-        # TODO: Handle course_key and course_type when they are provided in the request.
-        #       We have separate tickets to handle this implementation.
-        course_key = None
-        course_type = None
         with timer('skills_by_learning_hours'):
             skills_by_learning_hours = SkillsDailyRollupAdminDashTable().get_skills_by_learning_hours(
                 enterprise_id,


### PR DESCRIPTION
**Description:** Add support to filter analytics data by course key.
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-10517

**Testing**

Did local testing of all the api endpoints listed below.  


http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard?course_type=OCM&course_key=HarvardX%2BGSE2x

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard?course_key=HarvardX%2BGSE2x

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard?course_type=Executive%20Education&course_key=HarvardX%2BGSE2x

—

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats?course_type=Executive%20Education&course_key=HarvardX%2BGSE2x

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats?course_type=OCM&course_key=HarvardX%2BGSE2x

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats?course_key=HarvardX%2BGSE2x

— 

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/completions/stats?course_key=HarvardX%2BGSE2x

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/completions/stats?course_key=HarvardX%2BGSE2x&course_type=OCM

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/completions/stats?course_key=HarvardX%2BGSE2x&start_date=2023-05-15&end_date=2025-08-13

—

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/engagements/stats?start_date=2023-05-15&end_date=2025-08-12&course_key=HarvardX%2BGSE2x&course_type=OCM

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/engagements/stats?start_date=2023-05-15&end_date=2025-08-12&course_key=HarvardX%2BGSE2x&course_type=Executive%20Education

—

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/enrollments/stats?start_date=2023-05-15&end_date=2025-08-13

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/enrollments/stats?start_date=2023-05-15&end_date=2025-08-13&course_type=OCM

http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/enrollments/stats?start_date=2023-05-15&end_date=2025-08-13&course_key=HarvardX%2BGSE2x

---

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
