### PR TITLE
feat: api to fetch enrolled courses

### DIFF
--- a/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_enrollment_admin_dash.py
@@ -301,3 +301,28 @@ class FactEnrollmentAdminDashQueries:
             GROUP BY passed_date, enroll_type
             ORDER BY passed_date;
         """
+
+    @staticmethod
+    def get_enrolled_courses(
+        query_filters: QueryFilters
+    ) -> str:
+        """
+        Get the query to fetch the enrolled courses.
+
+        Returns:
+            (str): Query to fetch the enrolled courses.
+        """
+        return f"""
+            WITH filtered_data AS (
+                SELECT
+                    DISTINCT course_key, course_title
+                FROM
+                    fact_enrollment_admin_dash
+                WHERE {query_filters.to_sql()}
+            )
+            SELECT
+                course_key,
+                course_title
+            FROM
+                filtered_data
+        """

--- a/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
@@ -547,3 +547,36 @@ class FactEnrollmentAdminDashTable(BaseTable):
             params=query_filter_params,
             as_dict=True,
         )
+
+    @cache_it()
+    def get_all_enrolled_courses(
+        self,
+        enterprise_customer_uuid: UUID,
+        start_date: date,
+        end_date: date,
+        group_uuid: Optional[UUID] = None,
+        course_type: Optional[str] = None,
+    ):
+        """
+        Get all enrolled courses for the given enterprise customer.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): The UUID of the enterprise customer.
+            group_uuid (UUID): The UUID of the group.
+            start_date (date): The start date.
+            end_date (date): The end date.
+            course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
+
+        Returns:
+            list<dict>: A list of dictionaries where each dict will contain course key and course title.
+
+        """
+        query_filters, query_filter_params = self.__get_common_query_filters(
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type
+        )
+
+        return run_query(
+            query=self.queries.get_enrolled_courses(query_filters),
+            params=query_filter_params,
+            as_dict=True,
+        )

--- a/enterprise_data/api/v1/urls.py
+++ b/enterprise_data/api/v1/urls.py
@@ -106,6 +106,11 @@ urlpatterns = [
         enterprise_admin_views.EnterpriseGroupMembershipView.as_view(),
         name='enterprise-groups'
     ),
+    re_path(
+        fr'^admin/analytics/(?P<enterprise_uuid>{UUID4_REGEX})/enrolled-courses',
+        enterprise_admin_views.EnterpriseEnrolledCoursesView.as_view(),
+        name='enterprise-enrolled-courses'
+    ),
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
**Description:** API to fetch enrolled courses.
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-10726

**API URL:** `<base-url>/enterprise/api/v1/admin/analytics/<enterprise-uuid>/enrolled-courses`
**API Response Format:**
```json
[
    {
        "course_key": "UPValenciaX+BSP101x",
        "course_title": "UPValenciaX: Basic Spanish 1: Getting Started"
    },
    {
        "course_key": "DoaneX+ECON-203x",
        "course_title": "DoaneX: Macroeconomics - The Basics"
    },
    {
        "course_key": "CurtinX+MKT5x",
        "course_title": "CurtinX: Online Marketing Strategies (2021 2T)"
    },
    {
        "course_key": "WBGx+WDR2002x",
        "course_title": "WBGx: Trading for Development in the Age of Global Value Chains - WDR 2020"
    }
]
```
---

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
