### PR TITLE
feat: filter by budgets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 =========================
 
+[10.21.0] - 2025-08-27
+---------------------
+  * feat: Add course key filtering for enrollments, engagements, completions, skills and leaderboard APIs.
+
 [10.20.1] - 2025-08-19
 ---------------------
   * chore: Update changelog and pkg version

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.20.1"
+__version__ = "10.21.0"

--- a/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_engagement_admin_dash.py
@@ -32,6 +32,7 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date: date,
             course_type: Optional[str] = None,
             course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None,
     ) -> Tuple[QueryFilters, dict]:
         """
         Utility method to get query filters common in most usages below.
@@ -75,6 +76,13 @@ class FactEngagementAdminDashTable(BaseTable):
                 value_placeholder='course_key',
             ))
             params['course_key'] = course_key
+
+        if budget_uuid:
+            query_filters.append(EqualQueryFilter(
+                column='subsidy_access_policy_uuid',
+                value_placeholder='budget_uuid',
+            ))
+            params['budget_uuid'] = budget_uuid
 
         return query_filters, params
 
@@ -182,6 +190,7 @@ class FactEngagementAdminDashTable(BaseTable):
         end_date: date,
         course_type: Optional[str] = None,
         course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the top courses by user engagement for the given enterprise customer.
@@ -192,12 +201,13 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_top_courses_by_engagement_query(query_filters),
@@ -213,7 +223,8 @@ class FactEngagementAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the top subjects by user engagement for the given enterprise customer.
@@ -224,12 +235,13 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_top_subjects_by_engagement_query(query_filters),
@@ -245,7 +257,8 @@ class FactEngagementAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the engagement time series data.
@@ -256,12 +269,13 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the engagement time series data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_engagement(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_engagement_time_series_data_query(query_filters),
@@ -352,7 +366,8 @@ class FactEngagementAdminDashTable(BaseTable):
             offset: int,
             include_null_email: bool,
             course_type: Optional[str] = None,
-            course_key: Optional[str] = None
+            course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None,
     ):
         """
         Get the engagement data for leaderboard.
@@ -369,6 +384,7 @@ class FactEngagementAdminDashTable(BaseTable):
             include_null_email (bool): If True, only fetch data for NULL emails.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list[dict]: The engagement data for leaderboard.
@@ -376,6 +392,7 @@ class FactEngagementAdminDashTable(BaseTable):
         equality_filters = {
             'course_product_line': course_type,
             'course_key': course_key,
+            'subsidy_access_policy_uuid': budget_uuid,
             'is_engaged': 1
         }
         query_filters, params = self.build_query_filters_for_leaderboard(
@@ -428,7 +445,8 @@ class FactEngagementAdminDashTable(BaseTable):
             email_list: list,
             include_null_email: bool,
             course_type: Optional[str] = None,
-            course_key: Optional[str] = None
+            course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ):
         """
         Get the completion data for leaderboard.
@@ -444,6 +462,7 @@ class FactEngagementAdminDashTable(BaseTable):
             include_null_email (bool): If True, only fetch data for NULL emails.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list[dict]: The engagement data for leaderboard.
@@ -451,6 +470,7 @@ class FactEngagementAdminDashTable(BaseTable):
         equality_filters = {
             'course_product_line': course_type,
             'course_key': course_key,
+            'subsidy_access_policy_uuid': budget_uuid,
             'has_passed': 1
         }
         in_filters = {
@@ -499,6 +519,7 @@ class FactEngagementAdminDashTable(BaseTable):
             total_count: int,
             course_type: Optional[str] = None,
             course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ):
         """
         Get the leaderboard data for the given enterprise customer.
@@ -512,6 +533,7 @@ class FactEngagementAdminDashTable(BaseTable):
             total_count (int): The total number of records.
             course_type (Optional[str]): The course type filter.
             course_key (Optional[str]): The course key filter.
+            budget_uuid (Optional[str]): The budget UUID filter.
 
         Returns:
             list[dict]: The leaderboard data.
@@ -529,7 +551,8 @@ class FactEngagementAdminDashTable(BaseTable):
             offset=offset,
             include_null_email=include_null_email,
             course_type=course_type,
-            course_key=course_key
+            course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         # If there is no data, no need to proceed.
         if not engagement_data:
@@ -545,7 +568,8 @@ class FactEngagementAdminDashTable(BaseTable):
             email_list=list(engagement_data_dict.keys()),
             include_null_email=include_null_email,
             course_type=course_type,
-            course_key=course_key
+            course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         for completion in completion_data:
             email = completion['email']
@@ -567,7 +591,8 @@ class FactEngagementAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the total number of leaderboard records for the given enterprise customer.
@@ -578,6 +603,7 @@ class FactEngagementAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type filter.
             course_key (Optional[str]): The course key filter.
+            budget_uuid (Optional[str]): The budget UUID filter.
 
         Returns:
             (int): The total number of leaderboard records.
@@ -585,6 +611,7 @@ class FactEngagementAdminDashTable(BaseTable):
         equality_filters = {
             'course_product_line': course_type,
             'course_key': course_key,
+            'subsidy_access_policy_uuid': budget_uuid,
             'is_engaged': 1
         }
         query_filters, params = self.build_query_filters_for_leaderboard(

--- a/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/fact_enrollment_admin_dash.py
@@ -29,7 +29,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date: date,
             end_date: date,
             course_type: Optional[str] = None,
-            course_key: Optional[str] = None
+            course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ) -> (QueryFilters, dict):
         """
         Utility method to get query filters common in most usages below.
@@ -75,6 +76,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             ))
             params['course_key'] = course_key
 
+        if budget_uuid:
+            query_filters.append(EqualQueryFilter(
+                column='subsidy_access_policy_uuid',
+                value_placeholder='budget_uuid',
+            ))
+            params['budget_uuid'] = budget_uuid
+
         return query_filters, params
 
     def __get_common_query_filters_for_completion(
@@ -84,6 +92,7 @@ class FactEnrollmentAdminDashTable(BaseTable):
         end_date: date,
         course_type: Optional[str] = None,
         course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ) -> Tuple[QueryFilters, dict]:
         """
         Utility method to get query filters common in most usages below.
@@ -130,6 +139,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
                 value_placeholder='course_key',
             ))
             params['course_key'] = course_key
+
+        if budget_uuid:
+            query_filters.append(EqualQueryFilter(
+                column='subsidy_access_policy_uuid',
+                value_placeholder='budget_uuid',
+            ))
+            params['budget_uuid'] = budget_uuid
 
         return query_filters, params
 
@@ -280,7 +296,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the completion count for the given enterprise customer.
@@ -292,12 +309,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             int: The completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         results = run_query(
             query=self.queries.get_completion_count_query(query_filters),
@@ -317,7 +335,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date: date,
             end_date: date,
             course_type: Optional[str] = None,
-            course_key: Optional[str] = None
+            course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ) -> list:
         """
         Get the top courses enrollments for the given enterprise customer.
@@ -329,12 +348,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course key, course_title and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
 
         return run_query(
@@ -351,7 +371,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
             start_date: date,
             end_date: date,
             course_type: Optional[str] = None,
-            course_key: Optional[str] = None
+            course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ) -> list:
         """
         Get the top subjects by enrollments for the given enterprise customer.
@@ -363,12 +384,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
 
         return run_query(
@@ -385,6 +407,7 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date: date,
             course_type: Optional[str] = None,
             course_key: Optional[str] = None,
+            budget_uuid: Optional[str] = None
     ) -> list:
         """
         Get the enrollment time series data for the given enterprise customer.
@@ -396,12 +419,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the date and enrollment count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
 
         return run_query(
@@ -420,7 +444,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         limit: int,
         offset: int,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get all completions for the given enterprise customer.
@@ -434,12 +459,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             offset (int): The number of records to skip.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the completions data.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_all_completions_query(query_filters),
@@ -459,7 +485,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the top courses by completion for the given enterprise customer.
@@ -470,12 +497,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the course key, course_title and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_top_courses_by_completions_query(query_filters),
@@ -491,7 +519,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the top subjects by completions for the given enterprise customer.
@@ -502,12 +531,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the subject and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_top_subjects_by_completions_query(query_filters),
@@ -523,7 +553,8 @@ class FactEnrollmentAdminDashTable(BaseTable):
         start_date: date,
         end_date: date,
         course_type: Optional[str] = None,
-        course_key: Optional[str] = None
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None
     ):
         """
         Get the completions time series data for the given enterprise customer.
@@ -535,12 +566,13 @@ class FactEnrollmentAdminDashTable(BaseTable):
             end_date (date): The end date.
             course_type (Optional[str]): The course type (OCM or Executive Education) to filter by (optional).
             course_key (Optional[str]): The course key to filter by (optional).
+            budget_uuid (Optional[str]): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the date and completion count.
         """
         query_filters, query_filter_params = self.__get_common_query_filters_for_completion(
-            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key
+            enterprise_customer_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
         )
         return run_query(
             query=self.queries.get_completions_time_series_data_query(query_filters),

--- a/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/tables/skills_daily_rollup_admin_dash.py
@@ -28,8 +28,9 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_type: str = None,
-        course_key: str = None,
+        course_type: Optional[str] = None,
+        course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Build query filters and parameters for enterprise analytics queries.
@@ -40,6 +41,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date (date): The end date for the query.
             course_type (str, optional): The course type to filter by (e.g., 'OCM', 'Executive Education').
             course_key (str, optional): The course key to filter by.
+            budget_uuid (str, optional): The budget UUID to filter by.
 
         Returns:
             tuple: A tuple containing:
@@ -76,6 +78,13 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             ))
             optional_params['course_type'] = course_type
 
+        if budget_uuid:
+            query_filters.append(EqualQueryFilter(
+                column='subsidy_access_policy_uuid',
+                value_placeholder='budget_uuid',
+            ))
+            optional_params['budget_uuid'] = budget_uuid
+
         params = {**default_params, **optional_params}
         return query_filters, params
 
@@ -85,8 +94,9 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         enterprise_customer_uuid: UUID,
         start_date: date,
         end_date: date,
-        course_type: str = None,
+        course_type: Optional[str] = None,
         course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the top skills for the given enterprise customer.
@@ -97,6 +107,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date (date): The end date.
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
             course_key (str): The course key to filter by (optional).
+            budget_uuid (str): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, skill_type, enrolls and completions.
@@ -107,6 +118,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         return run_query(
             query=self.queries.get_top_skills(query_filters),
@@ -122,6 +134,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         end_date: date,
         course_type: Optional[str] = None,
         course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the top skills by enrollments for the given enterprise customer.
@@ -132,6 +145,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date (date): The end date.
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
             course_key (str): The course key to filter by (optional).
+            budget_uuid (str): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, subject_name, count.
@@ -142,6 +156,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         return run_query(
             query=self.queries.get_top_skills_by_enrollment(query_filters),
@@ -157,6 +172,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         end_date: date,
         course_type: Optional[str] = None,
         course_key: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the top skills by completion for the given enterprise customer.
@@ -166,6 +182,8 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             start_date (date): The start date.
             end_date (date): The end date.
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
+            course_key (str): The course key to filter by (optional).
+            budget_uuid (str): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, subject_name, count.
@@ -176,6 +194,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         return run_query(
             query=self.queries.get_top_skills_by_completion(query_filters),
@@ -190,6 +209,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
         end_date: date,
         course_key: Optional[str] = None,
         course_type: Optional[str] = None,
+        budget_uuid: Optional[str] = None,
     ):
         """
         Get the skills by learning hours for the given enterprise customer.
@@ -200,6 +220,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date (date): The end date.
             course_key (str): The course key to filter by (optional).
             course_type (str): The course type (OCM or Executive Education) to filter by (optional).
+            budget_uuid (str): The budget UUID to filter by (optional).
 
         Returns:
             list<dict>: A list of dictionaries containing the skill_name, subject_name, count.
@@ -210,6 +231,7 @@ class SkillsDailyRollupAdminDashTable(CommonFiltersMixin, BaseTable):
             end_date=end_date,
             course_key=course_key,
             course_type=course_type,
+            budget_uuid=budget_uuid,
         )
         return run_query(
             query=self.queries.get_skills_by_learning_hours(query_filters),

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -350,6 +350,7 @@ class AdvanceAnalyticsQueryParamSerializer(serializers.Serializer):  # pylint: d
         allow_null=False,
     )
     course_key = serializers.CharField(required=False)
+    budget_uuid = serializers.UUIDField(required=False, format='hex')
 
     def validate(self, attrs):
         """

--- a/enterprise_data/api/v1/views/analytics_completions.py
+++ b/enterprise_data/api/v1/views/analytics_completions.py
@@ -54,6 +54,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         completions = FactEnrollmentAdminDashTable().get_all_completions(
@@ -63,6 +64,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
             limit=page_size,
             offset=(page - 1) * page_size,
         )
@@ -73,6 +75,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         response_type = request.query_params.get('response_type', ResponseType.JSON.value)
 
@@ -88,7 +91,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
 
             return StreamingHttpResponse(
                 IndividualCompletionsCSVRenderer().render(self._stream_serialized_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, total_count, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, total_count, course_type, course_key, budget_uuid
                 )),
                 content_type="text/csv",
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
@@ -111,6 +114,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         total_count,
         course_type=None,
         course_key=None,
+        budget_uuid=None,
         page_size=50000
     ):
         """
@@ -127,6 +131,7 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
                 offset=offset,
                 course_type=course_type,
                 course_key=course_key,
+                budget_uuid=budget_uuid,
             )
             yield from completions
             offset += page_size
@@ -157,17 +162,18 @@ class AdvanceAnalyticsCompletionsView(AnalyticsPaginationMixin, ViewSet):
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
 
         with timer('construct_completion_all_stats'):
             data = {
                 'completions_over_time': FactEnrollmentAdminDashTable().get_completions_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_courses_by_completions': FactEnrollmentAdminDashTable().get_top_courses_by_completions(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_subjects_by_completions': FactEnrollmentAdminDashTable().get_top_subjects_by_completions(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_engagements.py
+++ b/enterprise_data/api/v1/views/analytics_engagements.py
@@ -140,17 +140,18 @@ class AdvanceAnalyticsEngagementView(AnalyticsPaginationMixin, ViewSet):
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
 
         with timer('construct_engagement_all_stats'):
             data = {
                 'engagement_over_time': FactEngagementAdminDashTable().get_engagement_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_courses_by_engagement': FactEngagementAdminDashTable().get_top_courses_by_engagement(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_subjects_by_engagement': FactEngagementAdminDashTable().get_top_subjects_by_engagement(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_enrollments.py
+++ b/enterprise_data/api/v1/views/analytics_enrollments.py
@@ -140,17 +140,18 @@ class AdvanceAnalyticsEnrollmentsView(AnalyticsPaginationMixin, ViewSet):
         group_uuid = serializer.data.get('group_uuid')
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
 
         with timer('construct_enrollment_all_stats'):
             data = {
                 'enrollments_over_time': FactEnrollmentAdminDashTable().get_enrolment_time_series_data(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_courses_by_enrollments': FactEnrollmentAdminDashTable().get_top_courses_by_enrollments(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
                 'top_subjects_by_enrollments': FactEnrollmentAdminDashTable().get_top_subjects_by_enrollments(
-                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key
+                    enterprise_uuid, group_uuid, start_date, end_date, course_type, course_key, budget_uuid
                 ),
             }
         return Response(data)

--- a/enterprise_data/api/v1/views/analytics_leaderboard.py
+++ b/enterprise_data/api/v1/views/analytics_leaderboard.py
@@ -49,6 +49,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
         end_date = serializer.data.get('end_date', date.today())
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
         page = serializer.data.get('page', 1)
         page_size = serializer.data.get('page_size', 100)
         total_count = FactEngagementAdminDashTable().get_leaderboard_data_count(
@@ -57,6 +58,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
             end_date=end_date,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         leaderboard = FactEngagementAdminDashTable().get_all_leaderboard_data(
             enterprise_customer_uuid=enterprise_uuid,
@@ -67,6 +69,7 @@ class AdvanceAnalyticsLeaderboardView(AnalyticsPaginationMixin, ViewSet):
             total_count=total_count,
             course_type=course_type,
             course_key=course_key,
+            budget_uuid=budget_uuid,
         )
         response_type = request.query_params.get('response_type', ResponseType.JSON.value)
 

--- a/enterprise_data/api/v1/views/enterprise_admin.py
+++ b/enterprise_data/api/v1/views/enterprise_admin.py
@@ -165,6 +165,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
         end_date = serializer.data.get('end_date', date.today())
         course_type = serializer.data.get('course_type')
         course_key = serializer.data.get('course_key')
+        budget_uuid = serializer.data.get('budget_uuid')
 
         with timer('top_skills'):
             skills = SkillsDailyRollupAdminDashTable().get_top_skills(
@@ -173,6 +174,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 end_date,
                 course_type,
                 course_key,
+                budget_uuid,
             )
 
         with timer('top_skills_by_enrollments'):
@@ -182,6 +184,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 end_date,
                 course_type,
                 course_key,
+                budget_uuid,
             )
         with timer('top_skills_by_completions'):
             top_skills_by_completions = SkillsDailyRollupAdminDashTable().get_top_skills_by_completion(
@@ -190,6 +193,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 end_date,
                 course_type,
                 course_key,
+                budget_uuid,
             )
 
         with timer('skills_by_learning_hours'):
@@ -199,6 +203,7 @@ class EnterpriseAdminAnalyticsSkillsView(APIView):
                 end_date,
                 course_key,
                 course_type,
+                budget_uuid,
             )
 
         response_data = {


### PR DESCRIPTION
**Description:** Add filter by budgets support for enrollments, completions, engagements, skills and leaderboard APIs.
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-10834

**Testing:**
Did local testing of all the api endpoints listed below.

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/enrollments/stats?start_date=2023-05-15&end_date=2025-08-13&budget_uuid=76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/enrollments/stats?start_date=2023-05-15&end_date=2025-08-13

--

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/engagements/stats?budget_uuid=76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae
* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/engagements/stats
* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/engagements/stats?start_date=2023-05-15&end_date=2025-08-12&budget_uuid=76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae

--

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/completions/stats?start_date=2023-05-15&end_date=2025-08-13&budget_uuid=76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae
* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/completions/stats?start_date=2023-05-15&end_date=2025-08-13

--

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard
* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/leaderboard?budget_uuid=76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae

--

* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats
* http://localhost:19001/enterprise/api/v1/admin/analytics/76b933cb-bf2a-4c1e-bf44-4e8a58cc37ae/skills/stats?end_date=2025-08-13

---


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
