### PR TITLE
fix: Convert UUIDField columns to uuid type for MariaDB

### DIFF
--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.21.8"
+__version__ = "10.21.9"

--- a/enterprise_data/migrations/0049_mariadb_uuid_conversion.py
+++ b/enterprise_data/migrations/0049_mariadb_uuid_conversion.py
@@ -1,0 +1,83 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'mysql':
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    with connection.cursor() as cursor:
+        # EnterpriseEnrollment
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY enterprise_customer_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY budget_id uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY subscription_license_uuid uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY enterprise_group_uuid uuid NULL")
+        # EnterpriseUser
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseuser MODIFY enterprise_customer_uuid uuid NOT NULL")
+        # EnterpriseOffer
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseoffer MODIFY enterprise_customer_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseoffer MODIFY enterprise_id uuid NOT NULL")
+        # EnterpriseBudget
+        cursor.execute("ALTER TABLE enterprise_data_enterprisebudget MODIFY enterprise_customer_uuid uuid NOT NULL")
+        # EnterpriseSubsidyBudget
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY subsidy_access_policy_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY subsidy_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY enterprise_customer_uuid uuid NOT NULL")
+        # EnterpriseLearner
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_customer_id uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_group_uuid uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_group_membership_uuid uuid NULL")
+        # EnterpriseSubsidyTransaction
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY enterprise_id uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY subsidy_transaction_id uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY enterprise_customer_uuid uuid NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'mysql':
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY enterprise_customer_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY budget_id char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY subscription_license_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseenrollment MODIFY enterprise_group_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseuser MODIFY enterprise_customer_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseoffer MODIFY enterprise_customer_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriseoffer MODIFY enterprise_id char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisebudget MODIFY enterprise_customer_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY subsidy_access_policy_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY subsidy_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidybudget MODIFY enterprise_customer_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_customer_id char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_group_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterpriselearner MODIFY enterprise_group_membership_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY enterprise_id char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY subsidy_transaction_id char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_data_enterprisesubsidytransaction MODIFY enterprise_customer_uuid char(32) NULL")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('enterprise_data', '0048_alter_enterpriseexecedlcmoduleperformance_avg_after_lo_score_and_more'),
+    ]
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/enterprise_data_roles/migrations/0008_mariadb_uuid_conversion.py
+++ b/enterprise_data_roles/migrations/0008_mariadb_uuid_conversion.py
@@ -1,0 +1,44 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'mysql':
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE enterprise_data_roles_enterprisedataroleassignment MODIFY enterprise_id uuid NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'mysql':
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE enterprise_data_roles_enterprisedataroleassignment MODIFY enterprise_id char(32) NULL")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('enterprise_data_roles', '0007_enterprisedataroleassignment_applies_to_all_contexts'),
+    ]
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]


### PR DESCRIPTION
## Description
The behavior of the MariaDB backend has changed for UUIDField from a `CharField(32)` to an actual `uuid` type in Django 5. This migration converts affected columns to prevent data insertion errors.

This migration converts **19 UUIDFields** across 2 Django apps:
- enterprise_data (18 fields)
- enterprise_data_roles (1 field)

## Supporting information
https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

## Related PRs
- https://github.com/openedx/edx-platform/pull/37494
- https://github.com/openedx/enterprise-catalog/pull/1108
- https://github.com/openedx/edx-enterprise/pull/2472
- https://github.com/openedx/enterprise-access/pull/887
- https://github.com/openedx/enterprise-subsidy/pull/405