### PR TITLE
fix: update pip-tools to 7.5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[10.21.17] - 2025-11-21
+-----------------------
+  * fix: update pip-tools to 7.5.2
+
 [10.21.16] - 2025-11-21
 -----------------------
   * feat: filter out unenrollment and update filter order in Learner Progress Report 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -251,7 +251,7 @@ pgpy==0.6.0
     # via -r requirements/reporting.in
 pillow==12.0.0
     # via pansi
-pip-tools==7.5.1
+pip-tools==7.5.2
     # via -r requirements/dev-enterprise_data.in
 platformdirs==4.5.0
     # via

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,7 +10,7 @@ click==8.3.0
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.5.1
+pip-tools==7.5.2
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -267,7 +267,7 @@ pgpy==0.6.0
     # via -r requirements/reporting.in
 pillow==12.0.0
     # via pansi
-pip-tools==7.5.1
+pip-tools==7.5.2
     # via -r requirements/dev-enterprise_data.in
 platformdirs==4.5.0
     # via


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the edx-analytics-data-api requirements installed or if you checked out edx-enterprise-data into the src directory used by edx-analytics-data-api, you can run this command through an edx-analytics-data-api shell.
        - It would be `./manage.py makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
