### PR TITLE
fix: add snowflake-connector-python to base requirements [ENT-11183]

### DIFF
--- a/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
@@ -21,14 +21,21 @@ Optional Django settings (with defaults)
   LPR_SNOWFLAKE_ROLE                 = None   (omitted from connection if not set)
 """
 
+from logging import getLogger
 from types import SimpleNamespace
 
 from django.conf import settings
+
+LOGGER = getLogger(__name__)
 
 try:
     import snowflake.connector as snowflake_connector
 except ImportError:  # pragma: no cover - depends on runtime extras
     snowflake_connector = None
+    LOGGER.warning(
+        '[course_progress] snowflake-connector-python is not installed. '
+        'course_progress will be null. Add snowflake-connector-python to requirements/base.in.'
+    )
 
 snowflake = SimpleNamespace(connector=snowflake_connector)
 
@@ -55,15 +62,30 @@ class SnowflakeCourseProgressSource:
         if snowflake.connector is None:
             raise ImportError('snowflake-connector-python is required for Snowflake LPR access')
 
-        connect_kwargs = {
-            'user': settings.SNOWFLAKE_SERVICE_USER,
-            'password': settings.SNOWFLAKE_SERVICE_USER_PASSWORD,
-            'account': getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1'),
-        }
+        user = getattr(settings, 'SNOWFLAKE_SERVICE_USER', None)
+        password = getattr(settings, 'SNOWFLAKE_SERVICE_USER_PASSWORD', None)
+        account = getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
         warehouse = getattr(settings, 'LPR_SNOWFLAKE_WAREHOUSE', None)
+        role = getattr(settings, 'LPR_SNOWFLAKE_ROLE', None)
+
+        if not user or not password:
+            LOGGER.error(
+                '[course_progress] Snowflake credentials missing — '
+                'SNOWFLAKE_SERVICE_USER=%s, SNOWFLAKE_SERVICE_USER_PASSWORD=%s.',
+                'SET' if user else 'NOT SET',
+                'SET' if password else 'NOT SET',
+            )
+            raise ValueError(
+                'SNOWFLAKE_SERVICE_USER and SNOWFLAKE_SERVICE_USER_PASSWORD must both be configured'
+            )
+
+        connect_kwargs = {
+            'user': user,
+            'password': password,
+            'account': account,
+        }
         if warehouse:
             connect_kwargs['warehouse'] = warehouse
-        role = getattr(settings, 'LPR_SNOWFLAKE_ROLE', None)
         if role:
             connect_kwargs['role'] = role
         return snowflake.connector.connect(**connect_kwargs)
@@ -120,9 +142,16 @@ class SnowflakeCourseProgressSource:
         cs = ctx.cursor()
         try:
             cs.execute(sql, [normalized_uuid] + flat_params)
+            rows = cs.fetchall()
+            if not rows:
+                LOGGER.warning(
+                    '[course_progress] Snowflake returned 0 rows for enterprise_uuid=%s. '
+                    'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
+                    enterprise_customer_uuid,
+                )
             return {
                 (row[0], row[1]): row[2]
-                for row in cs.fetchall()
+                for row in rows
             }
         finally:
             cs.close()

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,3 +14,4 @@ edx-rbac
 rules
 factory_boy
 mysql-connector-python
+snowflake-connector-python                       # Required for Snowflake LPR course_progress enrichment

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -232,7 +232,9 @@ six==1.17.0
     #   python-dateutil
     #   vertica-python
 snowflake-connector-python==4.4.0
-    # via -r requirements/reporting.in
+    # via
+    #   -r requirements/base.in
+    #   -r requirements/reporting.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 sqlparse==0.5.5


### PR DESCRIPTION
# fix: add snowflake-connector-python to base requirements and improve Snowflake logging [ENT-11183]
JIRA ticket :# fix: add snowflake-connector-python to base requirements and improve Snowflake logging [ENT-11183]

## Problem

`course_progress` was returning `null` for all enrollments on the Learner Progress Report (LPR) endpoint:

```
GET /enterprise/api/v1/enterprise/9e4ce451-48c4-4c2c-86a9-bb3ddd138d6b/enrollments/?page=1&page_size=50&audit_enrollments=false
```

Production logs showed:

```
WARNING - Could not enrich course_progress from Snowflake
ImportError: snowflake-connector-python is required for Snowflake LPR access
```

## Root Cause

`snowflake-connector-python` was pinned in `requirements/base.txt` but only as a transitive
dependency pulled in via `requirements/reporting.in`. The `analytics-api` production virtualenv
installs only base dependencies — not the `reporting` extras — so the package was not present
in the environment.

## Changes

### 1. Fix missing dependency

| File | Change |
|---|---|
| `requirements/base.in` | Added `snowflake-connector-python` as a direct base dependency |
| `requirements/base.txt` | Updated `# via` comment to include `-r requirements/base.in`. No version change — `4.4.0` was already pinned. |

### 2. Minimal logging improvements

Added only the logs needed to diagnose failures in production without noise:

| File | Level | Condition |
|---|---|---|
| `lpr_data_source_snowflake.py` | `ERROR` | `SNOWFLAKE_SERVICE_USER` or `SNOWFLAKE_SERVICE_USER_PASSWORD` are missing |
| `lpr_data_source_snowflake.py` | `WARNING` | Snowflake returns 0 rows for an enterprise — data missing in the table |


## Testing

- After deploy, hit the LPR endpoint and confirm `course_progress` returns numeric values instead of `null`
- Confirm no `ImportError` in logs
