### PR TITLE
chore: bump version to 10.22.4 to fix failed PyPI publish for 10.22.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[10.22.4] - 2026-04-27
+-----------------------
+  * chore: bump package version to 10.22.4 to fix failed PyPI publish for 10.22.3 (version was not bumped in __init__.py before tagging)
+
+[10.22.3] - 2026-04-24
+-----------------------
+  * fix: add ``snowflake-connector-python`` to base requirements and improve Snowflake logging [ENT-11183]
+
 [10.22.2] - 2026-04-21
 -----------------------
   * feat: add ``course_progress`` field to v1 learner enrollment API and CSV export

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.2"
+__version__ = "10.22.4"


### PR DESCRIPTION
# chore: bump version to 10.22.4 to fix failed PyPI publish

## Problem

The [10.22.3 GitHub release](https://github.com/openedx/edx-enterprise-data/releases/tag/10.22.3)
was created after merging [#662](https://github.com/openedx/edx-enterprise-data/pull/662), but the
PyPI publish workflow **failed** with:

```
400 Bad Request — File already exists
('edx_enterprise_data-10.22.2-py3-none-any.whl')
```

## Root Cause

`enterprise_data/__init__.py` was never bumped from `10.22.2` → `10.22.3` before the tag was
created. So the build artifacts were named `10.22.2`, which already existed on PyPI. PyPI does not
allow overwriting existing files.

## Fix

- Bump `__version__` from `10.22.2` → `10.22.4`
- Update `CHANGELOG.rst` to document both `10.22.3` and `10.22.4`

> **Why 10.22.4 and not 10.22.3?**
> PyPI permanently rejects re-uploads of any file that was ever uploaded under a given version,
> even if the previous upload failed partway. Since `10.22.2` files were already uploaded under
> the `10.22.3` tag attempt, using version `10.22.4` is the safest path forward.

## Changes

| File | Change |
|------|--------|
| `enterprise_data/__init__.py` | `10.22.2` → `10.22.4` |
| `CHANGELOG.rst` | Added entries for `10.22.3` and `10.22.4` |

## Testing

After merging:
1. Tag the release `10.22.4`
2. Confirm the PyPI publish workflow succeeds
3. Verify `pip install edx-enterprise-data==10.22.4` works
