### PR TITLE
chore: Upgrade Python requirements (#667)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,17 +10,17 @@ asgiref==3.11.1
     # via django
 asn1crypto==1.5.1
     # via snowflake-connector-python
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -56,7 +56,7 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via awscli
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   django-fernet-fields-v2
@@ -132,7 +132,7 @@ faker==40.15.0
     # via factory-boy
 filelock==3.29.0
     # via snowflake-connector-python
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -159,7 +159,7 @@ packaging==26.2
     #   snowflake-connector-python
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 pgpy==0.6.0
     # via -r requirements/reporting.in
@@ -195,7 +195,7 @@ pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 python-dateutil==2.9.0.post0
     # via
@@ -243,7 +243,7 @@ stevedore==5.7.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via snowflake-connector-python
 typing-extensions==4.15.0
     # via
@@ -256,7 +256,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   py2neo

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,7 +8,7 @@ cachetools==7.1.1
     # via tox
 colorama==0.4.6
     # via tox
-coverage==7.13.5
+coverage==7.14.0
     # via -r requirements/ci.in
 distlib==0.4.0
     # via virtualenv
@@ -30,7 +30,7 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via
     #   tox
     #   virtualenv
@@ -38,5 +38,5 @@ tomli-w==1.2.0
     # via tox
 tox==4.53.1
     # via -r requirements/ci.in
-virtualenv==21.3.0
+virtualenv==21.3.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,17 +14,17 @@ astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -76,7 +76,7 @@ colorama==0.4.6
     # via
     #   awscli
     #   tox
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   django-fernet-fields-v2
@@ -174,7 +174,7 @@ filelock==3.29.0
     #   virtualenv
 id==1.6.1
     # via twine
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -214,7 +214,7 @@ lxml[html-clean]==6.1.0
     #   lxml-html-clean
 lxml-html-clean==0.4.4
     # via lxml
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
@@ -246,7 +246,7 @@ packaging==26.2
     #   wheel
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 path==16.16.0
     # via edx-i18n-tools
@@ -319,7 +319,7 @@ pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 pyproject-api==1.10.0
     # via tox
@@ -332,7 +332,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   vertica-python
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via
     #   tox
     #   virtualenv
@@ -404,7 +404,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli-w==1.2.0
     # via tox
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via
     #   edx-lint
     #   pylint
@@ -424,7 +424,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   id
@@ -438,7 +438,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.3.0
+virtualenv==21.3.1
     # via tox
 wcwidth==0.7.0
     # via prompt-toolkit

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1
+pip==26.1.1
     # via -r requirements/pip.in
 setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,17 +14,17 @@ astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -76,9 +76,9 @@ colorama==0.4.6
     # via
     #   awscli
     #   tox
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   django-fernet-fields-v2
@@ -185,7 +185,7 @@ freezegun==1.5.5
     # via -r requirements/test.in
 id==1.6.1
     # via twine
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -227,7 +227,7 @@ lxml[html-clean]==6.1.0
     #   lxml-html-clean
 lxml-html-clean==0.4.4
     # via lxml
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
@@ -262,7 +262,7 @@ packaging==26.2
     #   wheel
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 path==16.16.0
     # via edx-i18n-tools
@@ -338,7 +338,7 @@ pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 pyproject-api==1.10.0
     # via tox
@@ -360,7 +360,7 @@ python-dateutil==2.9.0.post0
     #   celery
     #   freezegun
     #   vertica-python
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via
     #   tox
     #   virtualenv
@@ -438,7 +438,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli-w==1.2.0
     # via tox
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via
     #   edx-lint
     #   pylint
@@ -458,7 +458,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   id
@@ -473,7 +473,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.3.0
+virtualenv==21.3.1
     # via tox
 wcwidth==0.7.0
     # via prompt-toolkit

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -10,17 +10,17 @@ asgiref==3.11.1
     # via django
 asn1crypto==1.5.1
     # via snowflake-connector-python
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -56,9 +56,9 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via awscli
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   django-fernet-fields-v2
@@ -145,7 +145,7 @@ flaky==3.8.1
     # via -r requirements/test.in
 freezegun==1.5.5
     # via -r requirements/test.in
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -177,7 +177,7 @@ packaging==26.2
     #   snowflake-connector-python
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 pgpy==0.6.0
     # via -r requirements/reporting.in
@@ -219,7 +219,7 @@ pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 pytest==9.0.3
     # via
@@ -283,7 +283,7 @@ stevedore==5.7.0
     #   edx-opaque-keys
 testfixtures==11.0.0
     # via -r requirements/test.in
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via snowflake-connector-python
 typing-extensions==4.15.0
     # via
@@ -296,7 +296,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   py2neo

--- a/requirements/test-reporting.txt
+++ b/requirements/test-reporting.txt
@@ -8,17 +8,17 @@ amqp==5.3.1
     # via kombu
 asn1crypto==1.5.1
     # via snowflake-connector-python
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -57,9 +57,9 @@ colorama==0.4.6
     # via
     #   awscli
     #   tox
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   paramiko
@@ -78,7 +78,7 @@ filelock==3.29.0
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -108,7 +108,7 @@ packaging==26.2
     #   tox
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 pbr==7.0.3
     # via mock
@@ -144,7 +144,7 @@ pyminizip==0.2.6
     # via -r requirements/reporting.in
 pynacl==1.6.2
     # via paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 pyproject-api==1.10.0
     # via tox
@@ -159,7 +159,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   vertica-python
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via
     #   tox
     #   virtualenv
@@ -196,7 +196,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tomli-w==1.2.0
     # via tox
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via snowflake-connector-python
 tox==4.53.1
     # via -r requirements/test-reporting.in
@@ -210,7 +210,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   py2neo
@@ -223,7 +223,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.3.0
+virtualenv==21.3.1
     # via tox
 wcwidth==0.7.0
     # via prompt-toolkit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,17 +10,17 @@ asgiref==3.11.1
     # via django
 asn1crypto==1.5.1
     # via snowflake-connector-python
-awscli==1.45.2
+awscli==1.45.6
     # via -r requirements/reporting.in
 bcrypt==5.0.0
     # via paramiko
 billiard==4.2.4
     # via celery
-boto3==1.43.2
+boto3==1.43.6
     # via
     #   -r requirements/reporting.in
     #   snowflake-connector-python
-botocore==1.43.2
+botocore==1.43.6
     # via
     #   awscli
     #   boto3
@@ -56,9 +56,9 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via awscli
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
-cryptography==47.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/reporting.in
     #   django-fernet-fields-v2
@@ -143,7 +143,7 @@ flaky==3.8.1
     # via -r requirements/test.in
 freezegun==1.5.5
     # via -r requirements/test.in
-idna==3.13
+idna==3.14
     # via
     #   requests
     #   snowflake-connector-python
@@ -175,7 +175,7 @@ packaging==26.2
     #   snowflake-connector-python
 pansi==2024.11.0
     # via py2neo
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements/reporting.in
 pgpy==0.6.0
     # via -r requirements/reporting.in
@@ -217,7 +217,7 @@ pynacl==1.6.2
     # via
     #   edx-django-utils
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.2.0
     # via snowflake-connector-python
 pytest==9.0.3
     # via
@@ -281,7 +281,7 @@ stevedore==5.7.0
     #   edx-opaque-keys
 testfixtures==11.0.0
     # via -r requirements/test.in
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via snowflake-connector-python
 typing-extensions==4.15.0
     # via
@@ -294,7 +294,7 @@ tzdata==2026.2
     #   kombu
 unicodecsv==0.14.1
     # via -r requirements/reporting.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   py2neo


### PR DESCRIPTION
# [ENT-11788] Add Course Passing Grade Enrichment & Course Progress Caching to LPR

## Summary

This PR implements the backend enrichment layer in `edx-enterprise-data` to support a new **Course Passing Grade** column in the Learner Progress Report (LPR) in the Admin Portal. It also introduces an enterprise-scoped **caching strategy** for Course Progress data to eliminate frequent Snowflake queries.

> **Note:** The UI column placement and CSV download integration will be addressed in [ENT-11722](https://2u-internal.atlassian.net/browse/ENT-11722).

---

## Problem

Admins reviewing the Learner Progress Report currently lack visibility into the **required passing grade** for each course. Without this information, it is difficult to assess whether a learner's current progress is on track to meet the course's standard. This creates friction when Admins try to make informed decisions about learner outreach.

Additionally, Course Progress data was being fetched from Snowflake on every API request, causing unnecessary repeated queries for data that changes infrequently (roughly once per day).

---

## Solution

### 1. Course Passing Grade — New Snowflake Source (`SnowflakeCoursePassingGradeSource`)

- Fetches `LOWEST_PASSING_GRADE` from Snowflake's LMS course-overviews table:
  `PROD.LMS.COURSE_OVERVIEWS_COURSEOVERVIEW`
- Batched query per page of enrollments to minimize Snowflake round-trips
- Per-courserun-key caching with:
  - **Positive cache TTL**: `86400` seconds (24 hours) — configurable via `LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT`
  - **Negative cache TTL**: `3600` seconds (1 hour) — configurable via `LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT`
- Graceful degradation: if Snowflake is unavailable, the field is omitted without breaking the LPR response

### 2. Course Progress Caching — Enterprise-Scoped Cache (`SnowflakeCourseProgressSource`)

- Full enterprise-scoped result set is fetched once from Snowflake and cached
- Subsequent requests for the same enterprise are served from cache
- Cache TTL: `300` seconds (5 minutes) — configurable via `LPR_COURSE_PROGRESS_CACHE_TIMEOUT`
- Only the rows needed for the current page are extracted from the cached map

---

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | A new `course_passing_grade` field is exposed in the LPR API response | ✅ This PR |
| 2 | The column is positioned to the left of "Course Progress" in Admin Portal | 🔜 ENT-11722 |
| 3 | The column displays the required passing grade sourced from Snowflake course overviews | ✅ This PR |
| 4 | The field is included in the LPR CSV download | 🔜 ENT-11722 |
| 5 | Course Progress data is cached at the enterprise level to reduce Snowflake query frequency | ✅ This PR |

---

## Configuration Reference

### Required Settings
| Setting | Description |
|--------|-------------|
| `SNOWFLAKE_SERVICE_USER` | Snowflake service account username |
| `SNOWFLAKE_SERVICE_USER_PASSWORD` | Snowflake service account password |

### Optional Settings (with defaults)
| Setting | Default | Description |
|--------|---------|-------------|
| `SNOWFLAKE_ACCOUNT` | `'edx.us-east-1'` | Snowflake account identifier |
| `LPR_SNOWFLAKE_DATABASE` | `'PROD'` | Snowflake database for LPR internal table |
| `LPR_SNOWFLAKE_SCHEMA` | `'ENTERPRISE'` | Snowflake schema for LPR internal table |
| `LPR_SNOWFLAKE_INTERNAL_TABLE` | `'LEARNER_PROGRESS_REPORT_INTERNAL'` | Internal LPR table name |
| `LPR_SNOWFLAKE_WAREHOUSE` | `None` | Optional Snowflake warehouse |
| `LPR_SNOWFLAKE_ROLE` | `None` | Optional Snowflake role |
| `LPR_COURSE_PROGRESS_CACHE_TIMEOUT` | `300` | Cache TTL for course progress (seconds) |
| `LPR_SNOWFLAKE_LMS_DATABASE` | `'PROD'` | Snowflake database for course overviews |
| `LPR_SNOWFLAKE_LMS_SCHEMA` | `'LMS'` | Snowflake schema for course overviews |
| `LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE` | `'COURSE_OVERVIEWS_COURSEOVERVIEW'` | Course overviews table name |
| `LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT` | `86400` | Positive cache TTL for passing grades (seconds) |
| `LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT` | `3600` | Negative cache TTL for missing passing grades (seconds) |

## Files Changed

- `enterprise_data/api/v1/views/lpr_data_source_snowflake.py`
  - Added `SnowflakeCoursePassingGradeSource` class
  - Updated `SnowflakeCourseProgressSource` with enterprise-scoped caching

---

## Related Tickets

- **[ENT-11788](https://2u-internal.atlassian.net/browse/ENT-11788)** — Add cache to course-progress and add course passing grade enrichment *(this PR)*
- **[ENT-11722](https://2u-internal.atlassian.net/browse/ENT-11722)** — Add Course Passing Grade column to LPR UI and CSV in Admin Portal *(follow-up)*

Test screen shots using postgresql as datasource:
API Result:
<img width="1655" height="879" alt="image" src="https://github.com/user-attachments/assets/0c4c0cd4-40c0-47cc-ad00-2109e9e706f6" />
UI Screen:
<img width="1900" height="879" alt="image" src="https://github.com/user-attachments/assets/8cd51936-7824-4220-a7da-862c5e0a7854" />
