### PR TITLE
feat: Add lowest passing grade to LPR and also add caching to course_progress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+
+[10.22.5] - 2026-04-27
+-----------------------
+  * feat: add passing grade column plus per-enrollment progress caching in learner progress report v1 API and CSV export
+
 [10.22.4] - 2026-04-27
 -----------------------
   * chore: bump package version to 10.22.4 to fix failed PyPI publish for 10.22.3 (version was not bumped in __init__.py before tagging)

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.4"
+__version__ = "10.22.5"

--- a/enterprise_data/api/v1/serializers.py
+++ b/enterprise_data/api/v1/serializers.py
@@ -30,6 +30,7 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
     enterprise_flex_group_name = serializers.SerializerMethodField()
     enterprise_flex_group_uuid = serializers.SerializerMethodField()
     course_progress = serializers.SerializerMethodField()
+    course_passing_grade = serializers.SerializerMethodField()
 
     class Meta:
         model = EnterpriseLearnerEnrollment
@@ -52,6 +53,7 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
             'total_learning_time_hours', 'is_subsidy', 'course_product_line', 'budget_id',
             'enterprise_flex_group_name', 'enterprise_flex_group_uuid',
             'course_progress',
+            'course_passing_grade',
         )
 
     def get_course_api_url(self, obj):
@@ -71,6 +73,10 @@ class EnterpriseLearnerEnrollmentSerializer(serializers.ModelSerializer):
     def get_course_progress(self, obj):
         """Returns learner course progress from selected report data."""
         return getattr(obj, 'course_progress', None)
+
+    def get_course_passing_grade(self, obj):
+        """Returns learner course lowest passing grade from selected report data."""
+        return getattr(obj, 'course_passing_grade', None)
 
     @cache_it()
     def _get_flex_groups(self, obj):

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -181,15 +181,15 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
             # Deduplicate here so we pass a clean list to the source (which also
             # deduplicates internally, but being explicit avoids unnecessary work).
             courseruns = list(dict.fromkeys(
-                row.get('courserun_key', '').strip()
+                (row.get('courserun_key') or '').strip()
                 for row in rows
-                if row.get('courserun_key', '').strip()
+                if (row.get('courserun_key') or '').strip()
             ))
             if not courseruns:
                 return rows
             grades = SnowflakeCoursePassingGradeSource().get_passing_grade_map(courseruns)
             for row in rows:
-                courserun = row.get('courserun_key', '').strip()
+                courserun = (row.get('courserun_key') or '').strip()
                 if courserun and courserun in grades:
                     row['course_passing_grade'] = grades[courserun]
             return rows

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -29,7 +29,7 @@ from enterprise_data.renderers import EnrollmentsCSVRenderer
 from enterprise_data.utils import subtract_one_month
 
 from .base import EnterpriseViewSetMixin
-from .lpr_data_source_snowflake import SnowflakeCourseProgressSource
+from .lpr_data_source_snowflake import SnowflakeCoursePassingGradeSource, SnowflakeCourseProgressSource
 
 LOGGER = getLogger(__name__)
 
@@ -71,6 +71,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         'is_subsidy', 'course_product_line', 'budget_id',
         'enterprise_flex_group_name', 'enterprise_flex_group_uuid',
         'course_progress',
+        'course_passing_grade',
     ]
 
     # TODO: Remove after we release the streaming csv changes
@@ -83,9 +84,9 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         """
         Returns all learner enrollment records for a given enterprise.
 
-        ``course_progress`` is not a column on ``EnterpriseLearnerEnrollment``,
-        so we add a synthetic placeholder column here and enrich it later from
-        Snowflake in the response path.
+        ``course_progress`` and ``course_passing_grade`` are not columns on
+        ``EnterpriseLearnerEnrollment``, so we add synthetic placeholder columns
+        here and enrich both later from Snowflake in the response path.
         """
         if getattr(self, 'swagger_fake_view', False):
             # queryset just for schema generation metadata
@@ -96,11 +97,15 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
 
         # TODO: Created a ticket ENT0-9531 to add the cache on this viewset
 
-        # Add a synthetic placeholder column so the serialized response shape
-        # always includes `course_progress`; real values are merged in later.
+        # Add synthetic placeholder columns so the serialized response shape
+        # always includes `course_progress` and `course_passing_grade`; real
+        # values are merged in later from Snowflake during enrichment.
         enrollments = EnterpriseLearnerEnrollment.objects.filter(
             enterprise_customer_uuid=enterprise_customer_uuid
-        ).extra(select={'course_progress': 'NULL'})
+        ).extra(select={
+            'course_progress': 'NULL',
+            'course_passing_grade': 'NULL',
+        })
         enrollments = self.apply_filters(enrollments)
 
         return enrollments
@@ -108,7 +113,8 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
     def list(self, request, *args, **kwargs):
         """
         Override the list method to handle streaming CSV download and enrich
-        the ``course_progress`` field from Snowflake's internal LPR table.
+        the ``course_progress`` and ``course_passing_grade`` fields from
+        Snowflake's internal LPR table and course-overviews table respectively.
         """
         if request.accepted_renderer.format == 'csv':
             return StreamingHttpResponse(
@@ -118,7 +124,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
             )
 
         response = super().list(request, *args, **kwargs)
-        self._enrich_course_progress(response)
+        self._enrich_lpr_fields(response)
         return response
 
     def _enrich_course_progress_rows(self, rows):
@@ -147,21 +153,54 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
             LOGGER.warning('Could not enrich course_progress from Snowflake', exc_info=True)
             return rows
 
-    def _enrich_course_progress(self, response):
+    def _enrich_lpr_fields(self, response):
         """
-        Enrich each row in the paginated response with ``course_progress`` fetched
-        from Snowflake's ``learner_progress_report_internal`` table.
+        Enrich each row in the paginated response with ``course_progress`` and
+        ``course_passing_grade`` fetched from Snowflake.
 
+        Both fields start as ``NULL`` placeholders added by ``get_queryset``.
         Silently skips enrichment on any error so the ORM response is always
         returned intact.
         """
         results = response.data.get('results', [])
         self._enrich_course_progress_rows(results)
+        self._enrich_course_passing_grade_rows(results)
+
+    def _enrich_course_passing_grade_rows(self, rows):
+        """
+        Enrich serialized enrollment rows with ``course_passing_grade`` fetched
+        from Snowflake's course overviews table.
+
+        Accepts a list-like collection of serialized row dicts and mutates each
+        matching row in place. Silently skips enrichment on any error so the
+        ORM-backed response is always returned intact.
+        """
+        try:
+            if not rows:
+                return rows
+            # Deduplicate here so we pass a clean list to the source (which also
+            # deduplicates internally, but being explicit avoids unnecessary work).
+            courseruns = list(dict.fromkeys(
+                row.get('courserun_key', '').strip()
+                for row in rows
+                if row.get('courserun_key', '').strip()
+            ))
+            if not courseruns:
+                return rows
+            grades = SnowflakeCoursePassingGradeSource().get_passing_grade_map(courseruns)
+            for row in rows:
+                courserun = row.get('courserun_key', '').strip()
+                if courserun and courserun in grades:
+                    row['course_passing_grade'] = grades[courserun]
+            return rows
+        except Exception:  # pylint: disable=broad-exception-caught
+            LOGGER.warning('Could not enrich course_passing_grade from Snowflake', exc_info=True)
+            return rows
 
     def _stream_serialized_data(self):
         """
         Stream the serialized data, including Snowflake-backed
-        ``course_progress`` enrichment.
+        ``course_progress`` and ``course_passing_grade`` enrichment.
         """
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer_class()
@@ -169,6 +208,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         for page_number in paginator.page_range:
             page_results = list(serializer(paginator.page(page_number).object_list, many=True).data)
             self._enrich_course_progress_rows(page_results)
+            self._enrich_course_passing_grade_rows(page_results)
             yield from page_results
 
     # pylint: disable=too-many-statements

--- a/enterprise_data/api/v1/views/lpr_data_source_base.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_base.py
@@ -32,6 +32,7 @@ class LPRSerializerShapeMixin:
         'total_learning_time_hours', 'is_subsidy', 'course_product_line', 'budget_id',
         'enterprise_flex_group_name', 'enterprise_flex_group_uuid',
         'course_progress',
+        'course_passing_grade',
     )
 
     @staticmethod

--- a/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
@@ -1,10 +1,18 @@
-"""
-Snowflake helper for fetching the ``course_progress`` field.
 
-Reads a single column — COURSE_PROGRESS — from
-``PROD.ENTERPRISE.LEARNER_PROGRESS_REPORT_INTERNAL`` and merges it into the
-existing ORM-backed LPR response.  All other LPR data continues to come from
-the Django ORM (EnterpriseLearnerEnrollment) as before.
+"""
+Snowflake LPR sources for course progress and passing grade.
+
+Classes
+-------
+SnowflakeCourseProgressSource
+    Fetches COURSE_PROGRESS per ``(enterprise_customer_uuid, user_email, courserun_key)``
+    from ``LEARNER_PROGRESS_REPORT_INTERNAL``.  Results are cached per (enterprise, pair).
+
+SnowflakeCoursePassingGradeSource
+    Fetches LOWEST_PASSING_GRADE per ``courserun_key`` from
+    ``COURSE_OVERVIEWS_COURSEOVERVIEW``.  Results are cached per courserun key
+    (not enterprise-scoped, since the passing threshold is course-level, not
+    enterprise-level).
 
 Required Django settings
 ------------------------
@@ -13,20 +21,33 @@ Required Django settings
 
 Optional Django settings (with defaults)
 -----------------------------------------
-  SNOWFLAKE_ACCOUNT                  = 'edx.us-east-1'
-  LPR_SNOWFLAKE_DATABASE             = 'PROD'
-  LPR_SNOWFLAKE_SCHEMA               = 'ENTERPRISE'
-  LPR_SNOWFLAKE_INTERNAL_TABLE       = 'LEARNER_PROGRESS_REPORT_INTERNAL'
-  LPR_SNOWFLAKE_WAREHOUSE            = None   (omitted from connection if not set)
-  LPR_SNOWFLAKE_ROLE                 = None   (omitted from connection if not set)
+  SNOWFLAKE_ACCOUNT                          = 'edx.us-east-1'
+  LPR_SNOWFLAKE_WAREHOUSE                    = None
+  LPR_SNOWFLAKE_ROLE                         = None
+  LPR_SNOWFLAKE_DATABASE                     = 'PROD'
+  LPR_SNOWFLAKE_SCHEMA                       = 'ENTERPRISE'
+  LPR_SNOWFLAKE_INTERNAL_TABLE               = 'LEARNER_PROGRESS_REPORT_INTERNAL'
+  LPR_COURSE_PROGRESS_CACHE_TIMEOUT          = 300    (5 min)
+  LPR_SNOWFLAKE_LMS_DATABASE                 = 'PROD'
+  LPR_SNOWFLAKE_LMS_SCHEMA                   = 'LMS'
+  LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE       = 'COURSE_OVERVIEWS_COURSEOVERVIEW'
+  LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT     = 86400  (24 h)
+  LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT = 3600  (1 h)
 """
 
-from logging import getLogger
+import logging
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 from django.conf import settings
 
-LOGGER = getLogger(__name__)
+from enterprise_data import cache
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT = 60 * 5           # 5 minutes
+DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT = 60 * 60 * 24  # 24 hours
+DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT = 60 * 60  # 1 hour
 
 try:
     import snowflake.connector as snowflake_connector
@@ -40,63 +61,164 @@ except ImportError:  # pragma: no cover - depends on runtime extras
 snowflake = SimpleNamespace(connector=snowflake_connector)
 
 
-class SnowflakeCourseProgressSource:
-    """
-    Fetches **only** the ``course_progress`` column from Snowflake's internal
-    LPR table (``learner_progress_report_internal``).
+# ---------------------------------------------------------------------------
+# Shared connection factory
+# ---------------------------------------------------------------------------
 
-    Rows are matched by ``enterprise_customer_uuid`` + ``user_email`` +
-    ``courserun_key``, mirroring the composite key used by the ORM queryset.
+def _get_snowflake_connection():
+    """
+    Open and return a Snowflake connection from Django settings.
+
+    The returned ``SnowflakeConnection`` object supports the context-manager
+    protocol (``__enter__`` returns ``self``), so callers should use it inside
+    a ``with`` block::
+
+        with _get_snowflake_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(...)
+
+    Required settings: SNOWFLAKE_SERVICE_USER, SNOWFLAKE_SERVICE_USER_PASSWORD.
+    Optional settings: SNOWFLAKE_ACCOUNT (default ``'edx.us-east-1'``),
+    LPR_SNOWFLAKE_WAREHOUSE, LPR_SNOWFLAKE_ROLE.
+
+    Raises:
+        ImportError: When snowflake-connector-python is not installed.
+        ValueError: When required credentials are absent from settings.
+    """
+    if snowflake.connector is None:
+        raise ImportError(
+            'snowflake-connector-python is required for Snowflake LPR access'
+        )
+
+    user = getattr(settings, 'SNOWFLAKE_SERVICE_USER', None)
+    password = getattr(settings, 'SNOWFLAKE_SERVICE_USER_PASSWORD', None)
+    account = getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
+    warehouse = getattr(settings, 'LPR_SNOWFLAKE_WAREHOUSE', None)
+    role = getattr(settings, 'LPR_SNOWFLAKE_ROLE', None)
+
+    if not user or not password:
+        LOGGER.error(
+            '[lpr] Snowflake credentials missing — '
+            'SNOWFLAKE_SERVICE_USER=%s SNOWFLAKE_SERVICE_USER_PASSWORD=%s.',
+            'SET' if user else 'NOT SET',
+            'SET' if password else 'NOT SET',
+        )
+        raise ValueError(
+            'SNOWFLAKE_SERVICE_USER and SNOWFLAKE_SERVICE_USER_PASSWORD must both be configured'
+        )
+
+    connect_kwargs = {'user': user, 'password': password, 'account': account}
+    if warehouse:
+        connect_kwargs['warehouse'] = warehouse
+    if role:
+        connect_kwargs['role'] = role
+    return snowflake.connector.connect(**connect_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class SnowflakeLPRBaseSource:
+    """Shared base for Snowflake LPR data sources.
+
+    Provides a ``_get_setting`` helper and a ``_snowflake_cursor`` context
+    manager that wraps the module-level connection factory.  Subclasses only
+    need to implement their own SQL and cache-key logic.
+    """
+
+    @staticmethod
+    def _get_setting(name, default=None):
+        """Return the Django setting *name*, or *default* when absent."""
+        return getattr(settings, name, default)
+
+    @contextmanager
+    def _snowflake_cursor(self):
+        """Yield a Snowflake cursor, managing the connection lifecycle.
+
+        Uses ``_get_snowflake_connection()`` (module-level) so that the
+        connection factory can be independently mocked in tests.
+        """
+        with _get_snowflake_connection() as connection:
+            with connection.cursor() as cursor:
+                yield cursor
+
+
+# ---------------------------------------------------------------------------
+# SnowflakeCourseProgressSource
+# ---------------------------------------------------------------------------
+
+class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
+    """
+    Course progress data source backed by Snowflake.
+
+    Fetches COURSE_PROGRESS from ``LEARNER_PROGRESS_REPORT_INTERNAL`` filtered
+    by both ``enterprise_customer_uuid`` and the exact ``(user_email,
+    courserun_key)`` pairs requested.  Results are cached per pair so that
+    repeated page requests never re-query Snowflake for already-seen rows.
     """
 
     # ------------------------------------------------------------------
-    # Connection helpers
+    # Settings / table helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _get_connection():
-        """
-        Open a Snowflake connection using the same credential settings as
-        ``monthly_impact_report.py``.
-        """
-        if snowflake.connector is None:
-            raise ImportError('snowflake-connector-python is required for Snowflake LPR access')
-
-        user = getattr(settings, 'SNOWFLAKE_SERVICE_USER', None)
-        password = getattr(settings, 'SNOWFLAKE_SERVICE_USER_PASSWORD', None)
-        account = getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
-        warehouse = getattr(settings, 'LPR_SNOWFLAKE_WAREHOUSE', None)
-        role = getattr(settings, 'LPR_SNOWFLAKE_ROLE', None)
-
-        if not user or not password:
-            LOGGER.error(
-                '[course_progress] Snowflake credentials missing — '
-                'SNOWFLAKE_SERVICE_USER=%s, SNOWFLAKE_SERVICE_USER_PASSWORD=%s.',
-                'SET' if user else 'NOT SET',
-                'SET' if password else 'NOT SET',
-            )
-            raise ValueError(
-                'SNOWFLAKE_SERVICE_USER and SNOWFLAKE_SERVICE_USER_PASSWORD must both be configured'
-            )
-
-        connect_kwargs = {
-            'user': user,
-            'password': password,
-            'account': account,
-        }
-        if warehouse:
-            connect_kwargs['warehouse'] = warehouse
-        if role:
-            connect_kwargs['role'] = role
-        return snowflake.connector.connect(**connect_kwargs)
-
-    @staticmethod
-    def _internal_table():
-        """Return fully qualified Snowflake table name for internal LPR data."""
-        database = getattr(settings, 'LPR_SNOWFLAKE_DATABASE', 'PROD')
-        schema = getattr(settings, 'LPR_SNOWFLAKE_SCHEMA', 'ENTERPRISE')
-        table = getattr(settings, 'LPR_SNOWFLAKE_INTERNAL_TABLE', 'LEARNER_PROGRESS_REPORT_INTERNAL')
+    @classmethod
+    def _internal_table(cls):
+        """Return the fully-qualified Snowflake table name for internal LPR data."""
+        database = cls._get_setting('LPR_SNOWFLAKE_DATABASE', 'PROD')
+        schema = cls._get_setting('LPR_SNOWFLAKE_SCHEMA', 'ENTERPRISE')
+        table = cls._get_setting('LPR_SNOWFLAKE_INTERNAL_TABLE', 'LEARNER_PROGRESS_REPORT_INTERNAL')
         return f'{database}.{schema}.{table}'
+
+    @classmethod
+    def _cache_timeout(cls):
+        """Return the configurable TTL (seconds) for enterprise cache entries."""
+        return cls._get_setting('LPR_COURSE_PROGRESS_CACHE_TIMEOUT', DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT)
+
+    # ------------------------------------------------------------------
+    # Key normalisation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalized_enterprise_uuid(enterprise_customer_uuid):
+        """Normalise an enterprise UUID to the Snowflake comparison format (no hyphens, lowercase)."""
+        return str(enterprise_customer_uuid).replace('-', '').lower()
+
+    @staticmethod
+    def _normalized_row_key(user_email, courserun_key):
+        """Return a stable in-memory key for matching ORM rows to Snowflake rows."""
+        return (str(user_email).strip(), str(courserun_key).strip())
+
+    # ------------------------------------------------------------------
+    # Cache key helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _pair_cache_key(cls, enterprise_customer_uuid, user_email, courserun_key):
+        """Return a per-enterprise, per-``(email, courserun_key)`` cache key for course progress."""
+        return cache.get_key(
+            'lpr_course_progress',
+            cls._internal_table(),
+            cls._normalized_enterprise_uuid(enterprise_customer_uuid),
+            str(user_email).strip(),
+            str(courserun_key).strip(),
+        )
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _log_cache_stats(requested, cache_hits, missing, snowflake_rows, enterprise_customer_uuid):
+        """Emit a structured log line summarising cache efficiency for one request."""
+        LOGGER.info(
+            '[course_progress] enterprise=%s requested=%d cache_hits=%d missing=%d snowflake_rows=%d',
+            enterprise_customer_uuid,
+            requested,
+            cache_hits,
+            missing,
+            snowflake_rows,
+        )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -104,33 +226,84 @@ class SnowflakeCourseProgressSource:
 
     def get_course_progress_map(self, enterprise_customer_uuid, enrollments):
         """
-        Return a ``{(user_email, courserun_key): course_progress}`` mapping for
-        all rows on the current page.
+        Return a ``{(user_email, courserun_key): course_progress}`` mapping.
 
-        Args:
-            enterprise_customer_uuid (str): The enterprise UUID to scope the query.
-            enrollments (list[dict]): Serialized enrollment rows from the ORM page.
-                Each dict must contain ``user_email`` and ``courserun_key``.
-
-        Returns:
-            dict: Possibly empty mapping; never raises — callers should guard via
-            try/except so Snowflake unavailability never breaks the LPR response.
+        Per-pair cache is checked first; only the cache-missing pairs are sent
+        to Snowflake in a single batched query filtered by both enterprise UUID
+        and the exact ``(USER_EMAIL, COURSERUN_KEY)`` pairs.
         """
-        pairs = [
-            (row.get('user_email', ''), row.get('courserun_key', ''))
+        # Deduplicate while preserving order.
+        requested_pairs = list(dict.fromkeys(
+            self._normalized_row_key(row.get('user_email', ''), row.get('courserun_key', ''))
             for row in enrollments
             if row.get('user_email') and row.get('courserun_key')
-        ]
-        if not pairs:
+        ))
+        if not requested_pairs:
             return {}
 
+        progress_map = {}
+        missing_pairs = []
+
+        for pair in requested_pairs:
+            cached_response = cache.get(self._pair_cache_key(enterprise_customer_uuid, *pair))
+            if cached_response.is_found:
+                if cached_response.value is not None:
+                    progress_map[pair] = cached_response.value
+            else:
+                missing_pairs.append(pair)
+
+        snowflake_rows = {}
+        if missing_pairs:
+            snowflake_rows = self._fetch_progress_for_pairs(enterprise_customer_uuid, missing_pairs)
+            for pair in missing_pairs:
+                grade = snowflake_rows.get(pair)
+                if grade is not None:
+                    progress_map[pair] = grade
+                # Cache positive hits and misses (None) alike to prevent
+                # repeated Snowflake round-trips for pairs not in the table.
+                cache.set(
+                    self._pair_cache_key(enterprise_customer_uuid, *pair),
+                    grade,
+                    timeout=self._cache_timeout(),
+                )
+
+        self._log_cache_stats(
+            requested=len(requested_pairs),
+            cache_hits=len(requested_pairs) - len(missing_pairs),
+            missing=len(missing_pairs),
+            snowflake_rows=len(snowflake_rows),
+            enterprise_customer_uuid=enterprise_customer_uuid,
+        )
+        return progress_map
+
+    # ------------------------------------------------------------------
+    # Snowflake queries
+    # ------------------------------------------------------------------
+
+    def _fetch_progress_for_pairs(self, enterprise_customer_uuid, pairs):
+        """
+        Fetch COURSE_PROGRESS from Snowflake for specific ``(user_email, courserun_key)`` pairs.
+
+        Filters by both enterprise UUID and the exact set of pairs so only the
+        rows needed are transferred from Snowflake — never the full enterprise
+        table.
+
+        Args:
+            enterprise_customer_uuid: The enterprise UUID.
+            pairs (list[tuple[str, str]]): Deduplicated (user_email, courserun_key) tuples.
+
+        Returns:
+            dict: ``{(user_email, courserun_key): course_progress}`` for found rows.
+        """
         table = self._internal_table()
-        normalized_uuid = str(enterprise_customer_uuid).replace('-', '').lower()
+        normalized_uuid = self._normalized_enterprise_uuid(enterprise_customer_uuid)
 
-        # Build parameterised IN list for (user_email, courserun_key) pairs.
+        # Row-value constructor: ``(USER_EMAIL, COURSERUN_KEY) IN ((%s,%s), ...)
+        # Requires snowflake-connector-python >= 2.7.0.
         placeholders = ', '.join(['(%s, %s)'] * len(pairs))
-        flat_params = [param for pair in pairs for param in pair]
+        flat_params = [val for pair in pairs for val in pair]
 
+        # Table name from Django settings — safe to interpolate.
         sql = (
             f"SELECT USER_EMAIL, COURSERUN_KEY, COURSE_PROGRESS "
             f"FROM {table} "
@@ -138,21 +311,196 @@ class SnowflakeCourseProgressSource:
             f"  AND (USER_EMAIL, COURSERUN_KEY) IN ({placeholders})"
         )
 
-        ctx = self._get_connection()
-        cs = ctx.cursor()
-        try:
-            cs.execute(sql, [normalized_uuid] + flat_params)
-            rows = cs.fetchall()
-            if not rows:
-                LOGGER.warning(
-                    '[course_progress] Snowflake returned 0 rows for enterprise_uuid=%s. '
-                    'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
-                    enterprise_customer_uuid,
-                )
-            return {
-                (row[0], row[1]): row[2]
-                for row in rows
-            }
-        finally:
-            cs.close()
-            ctx.close()
+        LOGGER.info(
+            '[course_progress] querying Snowflake table=%s enterprise=%s pairs=%d',
+            table, enterprise_customer_uuid, len(pairs),
+        )
+
+        result = {}
+        with self._snowflake_cursor() as cursor:
+            cursor.execute(sql, [normalized_uuid] + flat_params)
+            rows = cursor.fetchall()
+
+        if not rows:
+            LOGGER.warning(
+                '[course_progress] Snowflake returned 0 rows for enterprise=%s pairs=%d. '
+                'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
+                enterprise_customer_uuid, len(pairs),
+            )
+        else:
+            LOGGER.info(
+                '[course_progress] Snowflake returned rows=%d for pairs=%d',
+                len(rows), len(pairs),
+            )
+
+        for row in rows:
+            result[self._normalized_row_key(row[0], row[1])] = row[2]
+        return result
+
+
+# ---------------------------------------------------------------------------
+# SnowflakeCoursePassingGradeSource
+# ---------------------------------------------------------------------------
+
+
+class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
+    """
+    Fetches ``lowest_passing_grade`` from Snowflake's LMS course-overviews table.
+
+    Results are cached per courserun key to avoid repeated Snowflake round-trips.
+    Absent keys (not present in the table) are stored as ``None`` under a shorter
+    negative-cache TTL so that they are re-checked sooner.
+    """
+    # No __init__ needed; base class handles connection.
+
+    # ------------------------------------------------------------------
+    # Settings / table helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _course_overviews_table(cls):
+        """Return the fully-qualified Snowflake table name for course overviews."""
+        database = cls._get_setting('LPR_SNOWFLAKE_LMS_DATABASE', 'PROD')
+        schema = cls._get_setting('LPR_SNOWFLAKE_LMS_SCHEMA', 'LMS')
+        table = cls._get_setting('LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE', 'COURSE_OVERVIEWS_COURSEOVERVIEW')
+        return f'{database}.{schema}.{table}'
+
+    @classmethod
+    def _cache_timeout(cls):
+        """Return the configurable TTL (seconds) for positive passing-grade cache entries."""
+        return cls._get_setting(
+            'LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT',
+            DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT,
+        )
+
+    @classmethod
+    def _negative_cache_timeout(cls):
+        """Return the TTL (seconds) for negative (not-found) passing-grade cache entries."""
+        return cls._get_setting(
+            'LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT',
+            DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Cache key helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_key(cls, courserun_key):
+        """
+        Return the per-courserun-key cache key for the lowest passing grade.
+
+        The key is intentionally **not** enterprise-scoped: ``LOWEST_PASSING_GRADE``
+        is a course-level attribute stored in the LMS course-overviews table and
+        is the same threshold for all enterprises enrolling in that course.
+        """
+        return cache.get_key(
+            'lpr_course_passing_grade',
+            cls._course_overviews_table(),
+            courserun_key,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def get_passing_grade_map(self, courserun_keys):
+        """Return a ``{courserun_key: lowest_passing_grade}`` mapping.
+
+        Serves cached values where available and fetches the remainder from
+        Snowflake in a single batched query.  Exceptions from cache or
+        Snowflake operations propagate; callers are responsible for error
+        handling and graceful degradation.
+
+        Args:
+            courserun_keys (list[str]): Courserun keys to look up.
+
+        Returns:
+            dict: Maps each requested courserun key to its lowest passing
+            grade (float) when found, or ``None`` when the key is absent
+            from the table.
+        """
+        if not courserun_keys:
+            return {}
+
+        # Deduplicate while preserving order.
+        courserun_keys = list(dict.fromkeys(courserun_keys))
+
+        cache_key_map = {key: self._cache_key(key) for key in courserun_keys}
+
+        passing_grade_map = {}
+        missing_keys = []
+
+        for courserun_key, ck in cache_key_map.items():
+            cached_response = cache.get(ck)
+            if cached_response.is_found:
+                passing_grade_map[courserun_key] = cached_response.value
+            else:
+                missing_keys.append(courserun_key)
+
+        LOGGER.info(
+            '[course_passing_grade] requested=%d cache_hits=%d missing=%d',
+            len(courserun_keys), len(passing_grade_map), len(missing_keys),
+        )
+
+        if missing_keys:
+            fetched = self._fetch_passing_grades(missing_keys)
+            positive_count = 0
+            negative_count = 0
+
+            for courserun_key in missing_keys:
+                grade = fetched.get(courserun_key)  # None when absent from the table
+                passing_grade_map[courserun_key] = grade
+                ck = cache_key_map[courserun_key]
+                if grade is None:
+                    cache.set(ck, None, timeout=self._negative_cache_timeout())
+                    negative_count += 1
+                else:
+                    cache.set(ck, grade, timeout=self._cache_timeout())
+                    positive_count += 1
+
+            LOGGER.info(
+                '[course_passing_grade] snowflake_rows=%d positive_cached=%d negative_cached=%d',
+                len(fetched), positive_count, negative_count,
+            )
+
+        return passing_grade_map
+
+    # ------------------------------------------------------------------
+    # Snowflake queries
+    # ------------------------------------------------------------------
+
+    def _fetch_passing_grades(self, courserun_keys):
+        """Fetch LOWEST_PASSING_GRADE for *courserun_keys* from Snowflake.
+
+        Args:
+            courserun_keys (list[str]): Courserun keys to query.
+
+        Returns:
+            dict: ``{courserun_key: lowest_passing_grade}`` for rows found.
+        """
+        table = self._course_overviews_table()
+        placeholders = ', '.join(['%s'] * len(courserun_keys))
+
+        # Table name from Django settings — safe to interpolate.
+        # ID is the courserun key string (e.g. ``course-v1:org+X+1``).
+        sql = (
+            f"SELECT ID AS COURSERUN_KEY, LOWEST_PASSING_GRADE "
+            f"FROM {table} "
+            f"WHERE ID IN ({placeholders})"
+        )
+
+        LOGGER.info(
+            '[course_passing_grade] querying Snowflake table=%s keys=%d',
+            table, len(courserun_keys),
+        )
+
+        with self._snowflake_cursor() as cursor:
+            cursor.execute(sql, courserun_keys)
+            rows = cursor.fetchall()
+
+        LOGGER.info(
+            '[course_passing_grade] Snowflake returned %d row(s) for %d requested key(s).',
+            len(rows), len(courserun_keys),
+        )
+        return {row[0]: row[1] for row in rows}

--- a/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
@@ -1,4 +1,3 @@
-
 """
 Snowflake LPR sources for course progress and passing grade.
 
@@ -48,6 +47,9 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT = 60 * 5           # 5 minutes
 DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT = 60 * 60 * 24  # 24 hours
 DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT = 60 * 60  # 1 hour
+
+# Batch size for Snowflake queries to avoid unbounded SQL and parameter limits.
+SNOWFLAKE_QUERY_BATCH_SIZE = 500
 
 try:
     import snowflake.connector as snowflake_connector
@@ -209,13 +211,34 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _log_cache_stats(requested, cache_hits, missing, snowflake_rows, enterprise_customer_uuid):
-        """Emit a structured log line summarising cache efficiency for one request."""
+    def _log_cache_stats(
+        requested,
+        cache_hits,
+        missing,
+        snowflake_rows,
+        enterprise_customer_uuid,
+        negative_cache_hits=0,
+    ):
+        """
+        Emit a structured log line summarising cache efficiency for one request.
+
+        Args:
+            requested: Total pairs requested.
+            cache_hits: Positive cache hits (pairs with non-None values served from cache).
+            missing: Pairs not found in cache, required Snowflake fetch.
+            snowflake_rows: Number of rows returned from Snowflake.
+            enterprise_customer_uuid: The enterprise UUID being logged.
+            negative_cache_hits: Negative cache hits (pairs cached as None, re-verified as absent).
+        """
         LOGGER.info(
-            '[course_progress] enterprise=%s requested=%d cache_hits=%d missing=%d snowflake_rows=%d',
+            (
+                '[course_progress] enterprise=%s requested=%d cache_hits=%d '
+                'negative_cache_hits=%d missing=%d snowflake_rows=%d'
+            ),
             enterprise_customer_uuid,
             requested,
             cache_hits,
+            negative_cache_hits,
             missing,
             snowflake_rows,
         )
@@ -231,6 +254,20 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
         Per-pair cache is checked first; only the cache-missing pairs are sent
         to Snowflake in a single batched query filtered by both enterprise UUID
         and the exact ``(USER_EMAIL, COURSERUN_KEY)`` pairs.
+
+        Return-value contract: only pairs that have a non-``None`` progress
+        value are included in the returned mapping.  Pairs absent from
+        Snowflake (cached as ``None`` to prevent repeated round-trips) are
+        **not** present as keys in the result.  This differs from
+        ``SnowflakeCoursePassingGradeSource.get_passing_grade_map``, which
+        **does** include absent keys mapped to ``None``.
+
+        Error contract: exceptions from Snowflake or cache operations propagate
+        to the caller.  The viewset wraps this method in ``try/except Exception``
+        and gracefully degrades (returns ``None`` for the field) on failure.
+        This contract is intentionally the same as
+        ``SnowflakeCoursePassingGradeSource.get_passing_grade_map`` — both
+        sources raise on error rather than silently swallowing exceptions.
         """
         # Deduplicate while preserving order.
         requested_pairs = list(dict.fromkeys(
@@ -243,33 +280,44 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
 
         progress_map = {}
         missing_pairs = []
+        positive_cache_hits = 0
+        negative_cache_hits = 0
 
-        for pair in requested_pairs:
-            cached_response = cache.get(self._pair_cache_key(enterprise_customer_uuid, *pair))
-            if cached_response.is_found:
-                if cached_response.value is not None:
-                    progress_map[pair] = cached_response.value
+        # Batch cache lookup: one round-trip for all pairs instead of N.
+        pair_to_cache_key = {
+            pair: self._pair_cache_key(enterprise_customer_uuid, *pair)
+            for pair in requested_pairs
+        }
+        cached_values = cache.get_many(list(pair_to_cache_key.values()))
+        for pair, ck in pair_to_cache_key.items():
+            if ck in cached_values:
+                if cached_values[ck] is not None:
+                    progress_map[pair] = cached_values[ck]
+                    positive_cache_hits += 1
+                else:
+                    # Negative cache hit: pair was queried before, not in Snowflake.
+                    negative_cache_hits += 1
             else:
                 missing_pairs.append(pair)
 
         snowflake_rows = {}
         if missing_pairs:
             snowflake_rows = self._fetch_progress_for_pairs(enterprise_customer_uuid, missing_pairs)
+            writes = {}
             for pair in missing_pairs:
                 grade = snowflake_rows.get(pair)
                 if grade is not None:
                     progress_map[pair] = grade
                 # Cache positive hits and misses (None) alike to prevent
                 # repeated Snowflake round-trips for pairs not in the table.
-                cache.set(
-                    self._pair_cache_key(enterprise_customer_uuid, *pair),
-                    grade,
-                    timeout=self._cache_timeout(),
-                )
+                writes[pair_to_cache_key[pair]] = grade
+            # Batch cache write: one round-trip for all missing pairs.
+            cache.set_many(writes, timeout=self._cache_timeout())
 
         self._log_cache_stats(
             requested=len(requested_pairs),
-            cache_hits=len(requested_pairs) - len(missing_pairs),
+            cache_hits=positive_cache_hits,
+            negative_cache_hits=negative_cache_hits,
             missing=len(missing_pairs),
             snowflake_rows=len(snowflake_rows),
             enterprise_customer_uuid=enterprise_customer_uuid,
@@ -295,46 +343,55 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
         Returns:
             dict: ``{(user_email, courserun_key): course_progress}`` for found rows.
         """
+        if not pairs:
+            return {}
+
         table = self._internal_table()
         normalized_uuid = self._normalized_enterprise_uuid(enterprise_customer_uuid)
 
-        # Row-value constructor: ``(USER_EMAIL, COURSERUN_KEY) IN ((%s,%s), ...)
-        # Requires snowflake-connector-python >= 2.7.0.
-        placeholders = ', '.join(['(%s, %s)'] * len(pairs))
-        flat_params = [val for pair in pairs for val in pair]
-
-        # Table name from Django settings — safe to interpolate.
-        sql = (
-            f"SELECT USER_EMAIL, COURSERUN_KEY, COURSE_PROGRESS "
-            f"FROM {table} "
-            f"WHERE LOWER(REPLACE(TO_VARCHAR(ENTERPRISE_CUSTOMER_UUID), '-', '')) = %s "
-            f"  AND (USER_EMAIL, COURSERUN_KEY) IN ({placeholders})"
-        )
-
-        LOGGER.info(
-            '[course_progress] querying Snowflake table=%s enterprise=%s pairs=%d',
-            table, enterprise_customer_uuid, len(pairs),
-        )
-
+        # Chunk the pairs into fixed-size batches so that large pages do not
+        # produce unbounded SQL statements or hit Snowflake's parameter limits.
         result = {}
-        with self._snowflake_cursor() as cursor:
-            cursor.execute(sql, [normalized_uuid] + flat_params)
-            rows = cursor.fetchall()
+        for batch_start in range(0, len(pairs), SNOWFLAKE_QUERY_BATCH_SIZE):
+            batch = pairs[batch_start: batch_start + SNOWFLAKE_QUERY_BATCH_SIZE]
 
-        if not rows:
-            LOGGER.warning(
-                '[course_progress] Snowflake returned 0 rows for enterprise=%s pairs=%d. '
-                'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
-                enterprise_customer_uuid, len(pairs),
+            # Row-value constructor: ``(USER_EMAIL, COURSERUN_KEY) IN ((%s,%s), ...)``
+            # Requires snowflake-connector-python >= 2.7.0.
+            placeholders = ', '.join(['(%s, %s)'] * len(batch))
+            flat_params = [val for pair in batch for val in pair]
+
+            # Table name from Django settings — safe to interpolate.
+            sql = (
+                f"SELECT USER_EMAIL, COURSERUN_KEY, COURSE_PROGRESS "
+                f"FROM {table} "
+                f"WHERE LOWER(REPLACE(TO_VARCHAR(ENTERPRISE_CUSTOMER_UUID), '-', '')) = %s "
+                f"  AND (USER_EMAIL, COURSERUN_KEY) IN ({placeholders})"
             )
-        else:
+
             LOGGER.info(
-                '[course_progress] Snowflake returned rows=%d for pairs=%d',
-                len(rows), len(pairs),
+                '[course_progress] querying Snowflake table=%s enterprise=%s pairs=%d (batch %d-%d)',
+                table, enterprise_customer_uuid, len(pairs), batch_start, batch_start + len(batch) - 1,
             )
 
-        for row in rows:
-            result[self._normalized_row_key(row[0], row[1])] = row[2]
+            with self._snowflake_cursor() as cursor:
+                cursor.execute(sql, [normalized_uuid] + flat_params)
+                rows = cursor.fetchall()
+
+            if not rows:
+                LOGGER.warning(
+                    '[course_progress] Snowflake returned 0 rows for enterprise=%s pairs=%d (batch %d). '
+                    'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
+                    enterprise_customer_uuid, len(batch), batch_start,
+                )
+            else:
+                LOGGER.info(
+                    '[course_progress] Snowflake returned rows=%d for pairs=%d (batch %d)',
+                    len(rows), len(batch), batch_start,
+                )
+
+            for row in rows:
+                result[self._normalized_row_key(row[0], row[1])] = row[2]
+
         return result
 
 
@@ -351,7 +408,6 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
     Absent keys (not present in the table) are stored as ``None`` under a shorter
     negative-cache TTL so that they are re-checked sooner.
     """
-    # No __init__ needed; base class handles connection.
 
     # ------------------------------------------------------------------
     # Settings / table helpers
@@ -408,9 +464,24 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
         """Return a ``{courserun_key: lowest_passing_grade}`` mapping.
 
         Serves cached values where available and fetches the remainder from
-        Snowflake in a single batched query.  Exceptions from cache or
-        Snowflake operations propagate; callers are responsible for error
-        handling and graceful degradation.
+        Snowflake in a single batched query.  Exceptions from cache or Snowflake
+        operations propagate; callers are responsible for error handling and
+        graceful degradation (same contract as
+        ``SnowflakeCourseProgressSource.get_course_progress_map``).
+
+        Return-value contract: every requested key is present in the returned
+        mapping.  Keys absent from Snowflake are mapped to ``None`` (and cached
+        under a shorter negative TTL to prevent repeated round-trips).  This
+        differs from ``SnowflakeCourseProgressSource.get_course_progress_map``,
+        which **omits** absent keys from the result entirely.
+
+        Security note: the cache key for passing grades is **not** enterprise-
+        scoped because ``LOWEST_PASSING_GRADE`` is a course-level attribute
+        identical across all enterprises.  Callers **must** only supply
+        courserun keys that were obtained from the requesting enterprise's
+        filtered enrollment queryset; passing attacker-influenced keys that
+        do not belong to the enterprise is not supported and would return
+        that course's threshold from cache or Snowflake.
 
         Args:
             courserun_keys (list[str]): Courserun keys to look up.
@@ -431,10 +502,11 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
         passing_grade_map = {}
         missing_keys = []
 
+        # Batch cache lookup: one round-trip for all keys instead of N.
+        cached_values = cache.get_many(list(cache_key_map.values()))
         for courserun_key, ck in cache_key_map.items():
-            cached_response = cache.get(ck)
-            if cached_response.is_found:
-                passing_grade_map[courserun_key] = cached_response.value
+            if ck in cached_values:
+                passing_grade_map[courserun_key] = cached_values[ck]
             else:
                 missing_keys.append(courserun_key)
 
@@ -447,17 +519,25 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
             fetched = self._fetch_passing_grades(missing_keys)
             positive_count = 0
             negative_count = 0
+            positive_writes = {}
+            negative_writes = {}
 
             for courserun_key in missing_keys:
                 grade = fetched.get(courserun_key)  # None when absent from the table
                 passing_grade_map[courserun_key] = grade
                 ck = cache_key_map[courserun_key]
                 if grade is None:
-                    cache.set(ck, None, timeout=self._negative_cache_timeout())
+                    negative_writes[ck] = None
                     negative_count += 1
                 else:
-                    cache.set(ck, grade, timeout=self._cache_timeout())
+                    positive_writes[ck] = grade
                     positive_count += 1
+
+            # Batch cache writes: one round-trip each for positive and negative sets.
+            if positive_writes:
+                cache.set_many(positive_writes, timeout=self._cache_timeout())
+            if negative_writes:
+                cache.set_many(negative_writes, timeout=self._negative_cache_timeout())
 
             LOGGER.info(
                 '[course_passing_grade] snowflake_rows=%d positive_cached=%d negative_cached=%d',
@@ -474,33 +554,46 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
         """Fetch LOWEST_PASSING_GRADE for *courserun_keys* from Snowflake.
 
         Args:
-            courserun_keys (list[str]): Courserun keys to query.
+            courserun_keys (list[str]): Courserun keys to query.  Must be
+                non-empty (the caller ``get_passing_grade_map`` guarantees
+                this, and the method also guards itself).
 
         Returns:
             dict: ``{courserun_key: lowest_passing_grade}`` for rows found.
         """
+        if not courserun_keys:
+            return {}
+
         table = self._course_overviews_table()
-        placeholders = ', '.join(['%s'] * len(courserun_keys))
 
-        # Table name from Django settings — safe to interpolate.
-        # ID is the courserun key string (e.g. ``course-v1:org+X+1``).
-        sql = (
-            f"SELECT ID AS COURSERUN_KEY, LOWEST_PASSING_GRADE "
-            f"FROM {table} "
-            f"WHERE ID IN ({placeholders})"
-        )
+        # Chunk the keys into fixed-size batches so that large pages do not
+        # produce unbounded SQL statements or hit Snowflake's parameter limits.
+        result = {}
+        for batch_start in range(0, len(courserun_keys), SNOWFLAKE_QUERY_BATCH_SIZE):
+            batch = courserun_keys[batch_start: batch_start + SNOWFLAKE_QUERY_BATCH_SIZE]
+            placeholders = ', '.join(['%s'] * len(batch))
 
-        LOGGER.info(
-            '[course_passing_grade] querying Snowflake table=%s keys=%d',
-            table, len(courserun_keys),
-        )
+            # Table name from Django settings — safe to interpolate.
+            # ID is the courserun key string (e.g. ``course-v1:org+X+1``).
+            sql = (
+                f"SELECT ID AS COURSERUN_KEY, LOWEST_PASSING_GRADE "
+                f"FROM {table} "
+                f"WHERE ID IN ({placeholders})"
+            )
 
-        with self._snowflake_cursor() as cursor:
-            cursor.execute(sql, courserun_keys)
-            rows = cursor.fetchall()
+            LOGGER.info(
+                '[course_passing_grade] querying Snowflake table=%s keys=%d (batch %d-%d)',
+                table, len(courserun_keys), batch_start, batch_start + len(batch) - 1,
+            )
 
-        LOGGER.info(
-            '[course_passing_grade] Snowflake returned %d row(s) for %d requested key(s).',
-            len(rows), len(courserun_keys),
-        )
-        return {row[0]: row[1] for row in rows}
+            with self._snowflake_cursor() as cursor:
+                cursor.execute(sql, batch)
+                rows = cursor.fetchall()
+
+            LOGGER.info(
+                '[course_passing_grade] Snowflake returned %d row(s) for %d requested key(s) (batch %d).',
+                len(rows), len(batch), batch_start,
+            )
+            result.update({row[0]: row[1] for row in rows})
+
+        return result

--- a/enterprise_data/cache/__init__.py
+++ b/enterprise_data/cache/__init__.py
@@ -5,6 +5,8 @@ import hashlib
 
 from edx_django_utils.cache import TieredCache
 
+from django.core.cache import cache
+
 DEFAULT_TIMEOUT = 60 * 60  # 1 hour
 
 
@@ -51,9 +53,49 @@ def set(key, value, timeout=DEFAULT_TIMEOUT):  # pylint: disable=redefined-built
     """
     Set value in cache for given key.
 
+    Supports negative-cache entries: passing ``value=None`` will cache a negative
+    result that is later retrieved by get() with ``is_found=True``.
+
     Arguments:
         key (str): Cache key.
-        value (object): Value to be stored in cache.
+        value (object): Value to be stored in cache (can be ``None`` for negative-cache).
         timeout (int): Cache timeout in seconds.
     """
     TieredCache.set_all_tiers(key, value, django_cache_timeout=timeout)
+
+
+def get_many(keys):
+    """
+    Retrieve multiple keys from the cache in a single batched operation.
+
+    Uses Django's ``cache.get_many`` which hits the cache only once and returns
+    a dict containing only the keys that were found.  Keys whose cached value is
+    ``None`` (a deliberate negative-cache sentinel) are included in the returned
+    mapping; keys that were never stored are omitted.
+
+    Arguments:
+        keys (list[str]): Cache keys to retrieve.
+
+    Returns:
+        dict: Maps each key that is present in the cache to its cached value
+        (which may be ``None`` for a negative-cache hit).  Keys absent from
+        the cache are not present in the returned dict.
+    """
+    return cache.get_many(keys)
+
+
+def set_many(mapping, timeout=DEFAULT_TIMEOUT):
+    """
+    Store multiple key-value pairs in the cache in a single logical operation.
+
+    Uses Django's ``cache.set_many`` which writes all entries in a single call,
+    making it more efficient than individual per-key writes.  Supports
+    negative-cache entries: passing ``value=None`` caches an absence sentinel
+    that is later returned by get_many().
+
+    Arguments:
+        mapping (dict): ``{cache_key: value}`` pairs to store.  Values can be any
+            object, including ``None`` for negative-cache entries.
+        timeout (int): Cache timeout in seconds applied to every entry.
+    """
+    cache.set_many(mapping, timeout)

--- a/enterprise_data/renderers.py
+++ b/enterprise_data/renderers.py
@@ -29,6 +29,7 @@ class EnrollmentsCSVRenderer(CSVStreamingRenderer):
         'enterprise_customer_uuid', 'enterprise_sso_uid', 'created', 'course_api_url', 'total_learning_time_hours',
         'is_subsidy', 'course_product_line', 'budget_id', 'enterprise_flex_group_name', 'enterprise_flex_group_uuid',
         'course_progress',
+        'course_passing_grade',
     ]
 
 

--- a/enterprise_data/tests/api/v1/test_serializers.py
+++ b/enterprise_data/tests/api/v1/test_serializers.py
@@ -48,6 +48,11 @@ class TestEnterpriseLearnerEnrollmentSerializer(APITransactionTestCase):
         serializer = EnterpriseLearnerEnrollmentSerializer(self.enrollment)
         assert serializer.data['course_progress'] == 0.42
 
+    def test_course_passing_grade_field_present(self):
+        self.enrollment.course_passing_grade = 0.6
+        serializer = EnterpriseLearnerEnrollmentSerializer(self.enrollment)
+        assert serializer.data['course_passing_grade'] == 0.6
+
     def test_csv_renderer_header_matches_serializer_field_order(self):
         """CSV header must exactly match serializer field order."""
         serializer_fields = list(EnterpriseLearnerEnrollmentSerializer.Meta.fields)

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -16,6 +16,7 @@ from rest_framework.test import APITransactionTestCase
 from django.utils import timezone
 
 from enterprise_data.api.v1.serializers import EnterpriseOfferSerializer
+from enterprise_data.api.v1.views.enterprise_learner import EnterpriseLearnerEnrollmentViewSet
 from enterprise_data.models import EnterpriseLearnerEnrollment, EnterpriseOffer
 from enterprise_data.tests.factories import (
     EnterpriseAdminLearnerProgressFactory,
@@ -291,6 +292,91 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
         # course_progress column should appear in the CSV header and data rows
         self.assertIn('course_progress', content)
         self.assertIn('0.87', content)
+
+    def test_course_passing_grade_field_in_response(self):
+        """Test that course_passing_grade field is included in the API response"""
+        enterprise_learner = EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            user_email='student@example.com',
+        )
+        EnterpriseLearnerEnrollmentFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_consent_granted=True,
+            enterprise_user_id=enterprise_learner.enterprise_user_id,
+            user_email='student@example.com',
+            courserun_key='course-v1:edX+Demo+2024',
+        )
+
+        url = reverse('v1:enterprise-learner-enrollment-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()['results']
+        self.assertEqual(len(results), 1)
+        # Verify course_passing_grade field is present in the response
+        self.assertIn('course_passing_grade', results[0])
+        # The field remains null unless passing-grade enrichment supplies a value.
+        self.assertIsNone(results[0]['course_passing_grade'])
+
+    @mock.patch('enterprise_data.api.v1.views.enterprise_learner.EnterpriseLearnerEnrollment.objects.filter')
+    @mock.patch.object(EnterpriseLearnerEnrollmentViewSet, 'apply_filters')
+    def test_get_queryset_adds_placeholder_metadata_columns(self, mock_apply_filters, mock_filter):
+        viewset = EnterpriseLearnerEnrollmentViewSet()
+        enrollments = mock.Mock()
+        with_placeholders = mock.Mock()
+        filtered_enrollments = mock.Mock()
+
+        viewset.kwargs = {'enterprise_id': self.enterprise_id}
+        viewset.request = mock.Mock()
+        mock_filter.return_value = enrollments
+        enrollments.extra.return_value = with_placeholders
+        mock_apply_filters.return_value = filtered_enrollments
+
+        result = viewset.get_queryset()
+
+        mock_filter.assert_called_once_with(enterprise_customer_uuid=self.enterprise_id)
+        enrollments.extra.assert_called_once_with(select={
+            'course_progress': 'NULL',
+            'course_passing_grade': 'NULL',
+        })
+        mock_apply_filters.assert_called_once_with(with_placeholders)
+        self.assertEqual(result, filtered_enrollments)
+
+    @mock.patch('enterprise_data.api.v1.views.enterprise_learner.SnowflakeCoursePassingGradeSource')
+    def test_enrich_course_passing_grade_uses_source_results(
+        self,
+        mock_grade_source_cls,
+    ):
+        viewset = EnterpriseLearnerEnrollmentViewSet()
+        viewset.kwargs = {'enterprise_id': self.enterprise_id}
+        mock_grade_source_cls.return_value.get_passing_grade_map.return_value = {
+            'course-v1:edX+Demo+2024': 0.7,
+        }
+        rows = [{'courserun_key': 'course-v1:edX+Demo+2024', 'course_passing_grade': None}]
+
+        result = viewset._enrich_course_passing_grade_rows(rows)  # pylint: disable=protected-access
+
+        self.assertEqual(result[0]['course_passing_grade'], 0.7)
+        mock_grade_source_cls.return_value.get_passing_grade_map.assert_called_once_with([
+            'course-v1:edX+Demo+2024',
+        ])
+
+    @mock.patch('enterprise_data.api.v1.views.enterprise_learner.SnowflakeCoursePassingGradeSource')
+    def test_enrich_course_passing_grade_returns_rows_when_source_fails(
+        self,
+        mock_grade_source_cls,
+    ):
+        viewset = EnterpriseLearnerEnrollmentViewSet()
+        viewset.kwargs = {'enterprise_id': self.enterprise_id}
+        mock_grade_source_cls.return_value.get_passing_grade_map.side_effect = RuntimeError('Snowflake unavailable')
+        rows = [{'courserun_key': 'course-v1:edX+Demo+2024', 'course_passing_grade': None}]
+
+        result = viewset._enrich_course_passing_grade_rows(rows)  # pylint: disable=protected-access
+
+        self.assertIsNone(result[0]['course_passing_grade'])
+        mock_grade_source_cls.return_value.get_passing_grade_map.assert_called_once_with([
+            'course-v1:edX+Demo+2024',
+        ])
 
 
 @ddt.ddt

--- a/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
+++ b/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
@@ -111,9 +111,9 @@ class TestGetSnowflakeConnection:
         assert 'warehouse' not in kwargs
         assert 'role' not in kwargs
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
-    def test_raises_when_credentials_missing(self, mock_settings, mock_connector):
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
+    def test_raises_when_credentials_missing(self, mock_connector, mock_settings):
         mock_settings.SNOWFLAKE_SERVICE_USER = None
         mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = None
         with pytest.raises(ValueError, match='SNOWFLAKE_SERVICE_USER'):
@@ -205,16 +205,18 @@ class TestGetCourseProgressMap:
             [{'user_email': '', 'courserun_key': ''}],
         )
 
-    # Removed duplicate and broken test_cache_stats_are_logged (E0102, E0602)
-
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     def test_full_cache_hit_skips_snowflake(self, mock_cache):
         """All pairs in cache → Snowflake must not be called."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.side_effect = [
-            MagicMock(is_found=True, value=0.8),
-            MagicMock(is_found=True, value=0.7),
-        ]
+
+        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
+        bob_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'course2')
+
+        mock_cache.get_many.return_value = {
+            alice_key: 0.8,
+            bob_key: 0.7,
+        }
 
         enrollments = [
             {'user_email': 'alice@example.com', 'courserun_key': 'course1'},
@@ -226,14 +228,14 @@ class TestGetCourseProgressMap:
             ('alice@example.com', 'course1'): 0.8,
             ('bob@example.com', 'course2'): 0.7,
         }
-        mock_cache.set.assert_not_called()
+        mock_cache.set_many.assert_not_called()
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch.object(SnowflakeCourseProgressSource, '_fetch_progress_for_pairs')
     def test_cache_miss_fetches_pairs_from_snowflake(self, mock_fetch, mock_cache):
         """Cache miss fetches and caches only the missing pairs."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        mock_cache.get_many.return_value = {}  # No cache hits
         mock_fetch.return_value = {
             ('alice@example.com', 'run1'): 0.9,
             ('bob@example.com', 'run2'): 0.7,
@@ -253,42 +255,41 @@ class TestGetCourseProgressMap:
             ENTERPRISE_UUID,
             [('alice@example.com', 'run1'), ('bob@example.com', 'run2')],
         )
-        assert mock_cache.set.call_count == 2
-        mock_cache.set.assert_any_call(
-            _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1'),
-            0.9,
-            timeout=DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT,
-        )
-        mock_cache.set.assert_any_call(
-            _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2'),
-            0.7,
-            timeout=DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT,
-        )
+        mock_cache.set_many.assert_called_once()
+        call_args = mock_cache.set_many.call_args
+        cache_writes = call_args[0][0]  # First positional argument
+        assert len(cache_writes) == 2
+        assert cache_writes[_progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1')] == 0.9
+        assert cache_writes[_progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2')] == 0.7
+        assert call_args[1]['timeout'] == DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     def test_cache_lookup_uses_enterprise_scoped_keys(self, mock_cache):
         """Cache reads must include the enterprise UUID to avoid cross-enterprise leakage."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=True, value=0.8)
+        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
+        mock_cache.get_many.return_value = {alice_key: 0.8}
 
         _source().get_course_progress_map(
             ENTERPRISE_UUID,
             [{'user_email': 'alice@example.com', 'courserun_key': 'course1'}],
         )
 
-        mock_cache.get.assert_called_once_with(
-            _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
-        )
+        mock_cache.get_many.assert_called_once()
+        call_args = mock_cache.get_many.call_args[0][0]  # First positional argument - list of keys
+        assert alice_key in call_args
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     def test_response_filters_to_requested_pairs_only(self, mock_cache):
         """Only the requested pairs are returned; extra cached pairs are excluded."""
         mock_cache.get_key.side_effect = get_key
         # alice is cached, bob is cached, carol is NOT requested
-        mock_cache.get.side_effect = [
-            MagicMock(is_found=True, value=0.9),
-            MagicMock(is_found=True, value=0.7),
-        ]
+        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1')
+        bob_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2')
+        mock_cache.get_many.return_value = {
+            alice_key: 0.9,
+            bob_key: 0.7,
+        }
 
         enrollments = [
             {'user_email': 'alice@example.com', 'courserun_key': 'run1'},
@@ -403,12 +404,13 @@ class TestGetPassingGradeMap:
     def test_full_cache_hit_skips_snowflake(self, mock_cache):
         """All courseruns cached → Snowflake must not be called."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=True, value=0.6)
+        gr_key = _passing_grade_cache_key('course-v1:Org+Course+Run')
+        mock_cache.get_many.return_value = {gr_key: 0.6}
 
         result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
 
         assert result == {'course-v1:Org+Course+Run': 0.6}
-        mock_cache.set.assert_not_called()
+        mock_cache.set_many.assert_not_called()
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
@@ -416,7 +418,7 @@ class TestGetPassingGradeMap:
     def test_absent_keys_stored_as_none_under_negative_ttl(self, _table, mock_connection_factory, mock_cache):
         """Keys not returned by Snowflake are stored as None with the negative TTL."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        mock_cache.get_many.return_value = {}  # Cache miss
 
         ctx, _ = _mock_ctx_and_cursor(fetchall=[])
         mock_connection_factory.return_value = ctx
@@ -424,12 +426,12 @@ class TestGetPassingGradeMap:
         result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
 
         assert result == {'course-v1:Org+Course+Run': None}
+        mock_cache.set_many.assert_called_once()
+        call_args = mock_cache.set_many.call_args
+        cache_writes = call_args[0][0]  # First positional argument
         run_key = _passing_grade_cache_key('course-v1:Org+Course+Run')
-        mock_cache.set.assert_called_once_with(
-            run_key,
-            None,
-            timeout=DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT,
-        )
+        assert cache_writes[run_key] is None
+        assert call_args[1]['timeout'] == DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
@@ -441,11 +443,10 @@ class TestGetPassingGradeMap:
         cached_key = 'course-v1:Org+Cached+Run'
         uncached_key = 'course-v1:Org+Uncached+Run'
 
-        def cache_side_effect(cache_key):
-            if cache_key == _passing_grade_cache_key(cached_key):
-                return MagicMock(is_found=True, value=0.8)
-            return MagicMock(is_found=False, value=None)
-        mock_cache.get.side_effect = cache_side_effect
+        cached_cache_key = _passing_grade_cache_key(cached_key)
+        uncached_cache_key = _passing_grade_cache_key(uncached_key)
+
+        mock_cache.get_many.return_value = {cached_cache_key: 0.8}
 
         ctx, _ = _mock_ctx_and_cursor(fetchall=[(uncached_key, 0.55)])
         mock_connection_factory.return_value = ctx
@@ -453,11 +454,11 @@ class TestGetPassingGradeMap:
         result = _grade_source().get_passing_grade_map([cached_key, uncached_key])
 
         assert result == {cached_key: 0.8, uncached_key: 0.55}
-        mock_cache.set.assert_called_once_with(
-            _passing_grade_cache_key(uncached_key),
-            0.55,
-            timeout=DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT,
-        )
+        mock_cache.set_many.assert_called_once()
+        call_args = mock_cache.set_many.call_args
+        cache_writes = call_args[0][0]  # First positional argument
+        assert cache_writes[uncached_cache_key] == 0.55
+        assert call_args[1]['timeout'] == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
@@ -465,31 +466,32 @@ class TestGetPassingGradeMap:
     def test_positive_values_use_24h_timeout(self, _table, mock_connection_factory, mock_cache):
         """Positive cache writes must use the 24-hour TTL."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        mock_cache.get_many.return_value = {}  # Cache miss
 
         ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
         mock_connection_factory.return_value = ctx
 
         _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
 
-        timeout_arg = mock_cache.set.call_args[1].get('timeout')
+        mock_cache.set_many.assert_called_once()
+        timeout_arg = mock_cache.set_many.call_args[1].get('timeout')
         assert timeout_arg == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
     @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
     def test_single_key_cache_operations_used(self, _table, mock_connection_factory, mock_cache):
-        """Each missing key should be cached through the single-key cache API."""
+        """Each missing key should be cached through the batch cache API."""
         mock_cache.get_key.side_effect = get_key
-        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        mock_cache.get_many.return_value = {}  # Cache miss
 
         ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
         mock_connection_factory.return_value = ctx
 
         _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
 
-        mock_cache.get.assert_called_once()
-        mock_cache.set.assert_called_once()
+        mock_cache.get_many.assert_called_once()
+        mock_cache.set_many.assert_called_once()
 
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
     @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')

--- a/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
+++ b/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
@@ -1,33 +1,138 @@
-"""Tests for ``SnowflakeCourseProgressSource``."""
+"""Tests for ``SnowflakeCourseProgressSource`` and ``SnowflakeCoursePassingGradeSource``."""
 # pylint: disable=protected-access
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from enterprise_data.api.v1.views.lpr_data_source_snowflake import SnowflakeCourseProgressSource
+from django.test import override_settings
+
+from enterprise_data.api.v1.views.lpr_data_source_snowflake import (
+    DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT,
+    DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT,
+    DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT,
+    SnowflakeCoursePassingGradeSource,
+    SnowflakeCourseProgressSource,
+    _get_snowflake_connection,
+)
+from enterprise_data.cache import get_key
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
 
 ENTERPRISE_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 NORMALIZED_UUID = 'a1b2c3d4e5f67890abcdef1234567890'
-DEFAULT_TABLE = 'PROD.ENTERPRISE.LEARNER_PROGRESS_REPORT_INTERNAL'
 
+DEFAULT_TABLE = 'PROD.ENTERPRISE.LEARNER_PROGRESS_REPORT_INTERNAL'
+DEFAULT_OVERVIEWS_TABLE = 'PROD.LMS.COURSE_OVERVIEWS_COURSEOVERVIEW'
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
 def _source():
-    """Return a source instance under test."""
+    """Return a fresh SnowflakeCourseProgressSource instance."""
     return SnowflakeCourseProgressSource()
+
+
+def _grade_source():
+    """Return a fresh SnowflakeCoursePassingGradeSource instance."""
+    return SnowflakeCoursePassingGradeSource()
 
 
 def _mock_ctx_and_cursor(fetchall=None):
     """Return mocked Snowflake connection and cursor objects."""
     cursor = MagicMock()
     cursor.fetchall.return_value = fetchall or []
+
+    def cursor_enter():
+        return cursor
+
+    def cursor_exit(*_):
+        cursor.close()
+    cursor.__enter__.side_effect = cursor_enter
+    cursor.__exit__.side_effect = cursor_exit
+
+    def execute(sql, params=None):
+        cursor._last_sql = sql
+        cursor._last_params = params
+    cursor.execute.side_effect = execute
     ctx = MagicMock()
     ctx.cursor.return_value = cursor
+
+    def ctx_enter():
+        return ctx
+
+    def ctx_exit(*_):
+        ctx.close()
+    ctx.__enter__.side_effect = ctx_enter
+    ctx.__exit__.side_effect = ctx_exit
     return ctx, cursor
 
 
+def _progress_pair_cache_key(enterprise_customer_uuid, user_email, courserun_key):
+    """Build the expected per-pair progress cache key."""
+    return get_key(
+        'lpr_course_progress',
+        SnowflakeCourseProgressSource._internal_table(),
+        SnowflakeCourseProgressSource._normalized_enterprise_uuid(enterprise_customer_uuid),
+        str(user_email).strip(),
+        str(courserun_key).strip(),
+    )
+
+
+def _passing_grade_cache_key(courserun_key):
+    """Build the expected passing-grade cache key, including the course overview table name for parity."""
+    return get_key('lpr_course_passing_grade', DEFAULT_OVERVIEWS_TABLE, courserun_key)
+
+
+# ===========================================================================
+# Module-level connection factory
+# ===========================================================================
+
+class TestGetSnowflakeConnection:
+    """Tests for the shared ``_get_snowflake_connection`` factory."""
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
+    def test_uses_required_credentials(self, mock_settings, mock_connector):
+        mock_settings.SNOWFLAKE_SERVICE_USER = 'user'
+        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = 'pass'
+        mock_settings.SNOWFLAKE_ACCOUNT = 'edx.us-east-1'
+        mock_settings.LPR_SNOWFLAKE_WAREHOUSE = None
+        mock_settings.LPR_SNOWFLAKE_ROLE = None
+        _get_snowflake_connection()
+        kwargs = mock_connector.connect.call_args[1]
+        assert kwargs['user'] == 'user'
+        assert kwargs['password'] == 'pass'
+        assert kwargs['account'] == 'edx.us-east-1'
+        assert 'warehouse' not in kwargs
+        assert 'role' not in kwargs
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
+    def test_raises_when_credentials_missing(self, mock_settings, mock_connector):
+        mock_settings.SNOWFLAKE_SERVICE_USER = None
+        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = None
+        with pytest.raises(ValueError, match='SNOWFLAKE_SERVICE_USER'):
+            _get_snowflake_connection()
+        mock_connector.connect.assert_not_called()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake')
+    def test_raises_import_error_when_connector_missing(self, mock_snowflake):
+        mock_snowflake.connector = None
+        with pytest.raises(ImportError, match='snowflake-connector-python'):
+            _get_snowflake_connection()
+
+
+# ===========================================================================
+# SnowflakeCourseProgressSource — table / settings helpers
+# ===========================================================================
+
 class TestInternalTable:
-    """Tests for fully-qualified internal table resolution."""
+    """Fully-qualified internal table resolution."""
 
     def test_default_internal_table(self):
         assert SnowflakeCourseProgressSource._internal_table() == DEFAULT_TABLE
@@ -40,88 +145,428 @@ class TestInternalTable:
         assert SnowflakeCourseProgressSource._internal_table() == 'STAGING.REPORTING.COURSE_PROGRESS'
 
 
-class TestGetConnection:
-    """Tests for Snowflake connection kwargs construction."""
+# ===========================================================================
+# SnowflakeCourseProgressSource — cache configuration
+# ===========================================================================
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
-    def test_connection_uses_required_credentials(self, mock_settings, mock_connector):
-        mock_settings.SNOWFLAKE_SERVICE_USER = 'user'
-        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = 'pass'
-        mock_settings.SNOWFLAKE_ACCOUNT = 'edx.us-east-1'
-        SnowflakeCourseProgressSource._get_connection()
-        kwargs = mock_connector.connect.call_args[1]
-        assert kwargs['user'] == 'user'
-        assert kwargs['password'] == 'pass'
-        assert kwargs['account'] == 'edx.us-east-1'
+class TestCourseProgressCacheConfiguration:
+    """Cache timeout and key construction for course progress."""
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
-    def test_connection_includes_optional_role_and_warehouse(self, mock_settings, mock_connector):
-        mock_settings.SNOWFLAKE_SERVICE_USER = 'user'
-        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = 'pass'
-        mock_settings.SNOWFLAKE_ACCOUNT = 'myacct'
-        mock_settings.LPR_SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
-        mock_settings.LPR_SNOWFLAKE_ROLE = 'ANALYST'
-        SnowflakeCourseProgressSource._get_connection()
-        kwargs = mock_connector.connect.call_args[1]
-        assert kwargs['account'] == 'myacct'
-        assert kwargs['warehouse'] == 'COMPUTE_WH'
-        assert kwargs['role'] == 'ANALYST'
+    def test_default_cache_timeout_is_five_minutes(self):
+        assert DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT == 300
+        assert _source()._cache_timeout() == 300
+
+    @override_settings(LPR_COURSE_PROGRESS_CACHE_TIMEOUT=120)
+    def test_cache_timeout_is_configurable(self):
+        assert _source()._cache_timeout() == 120
+
+    def test_pair_cache_key_includes_enterprise_table_email_and_courserun(self):
+        key = SnowflakeCourseProgressSource._pair_cache_key(
+            ENTERPRISE_UUID,
+            'alice@example.com',
+            'course-v1:org+X+1',
+        )
+        expected = get_key(
+            'lpr_course_progress',
+            SnowflakeCourseProgressSource._internal_table(),
+            NORMALIZED_UUID,
+            'alice@example.com',
+            'course-v1:org+X+1',
+        )
+        assert key == expected
+
+    def test_pair_cache_key_differs_across_enterprises(self):
+        first = SnowflakeCourseProgressSource._pair_cache_key(
+            ENTERPRISE_UUID,
+            'alice@example.com',
+            'course-v1:org+X+1',
+        )
+        second = SnowflakeCourseProgressSource._pair_cache_key(
+            '11111111-2222-3333-4444-555555555555',
+            'alice@example.com',
+            'course-v1:org+X+1',
+        )
+        assert first != second
+
+# ===========================================================================
+# SnowflakeCourseProgressSource — get_course_progress_map
+# ===========================================================================
 
 
 class TestGetCourseProgressMap:
-    """Tests for SQL execution, mapping, and cleanup behavior."""
+    """Behaviour of the main public method."""
 
-    def test_returns_empty_dict_when_no_pairs(self):
-        assert _source().get_course_progress_map(ENTERPRISE_UUID, []) == {}
-        assert _source().get_course_progress_map(ENTERPRISE_UUID, [{'user_email': '', 'courserun_key': ''}]) == {}
+    def test_returns_empty_dict_when_enrollments_empty(self):
+        assert not _source().get_course_progress_map(ENTERPRISE_UUID, [])
 
-    @patch.object(SnowflakeCourseProgressSource, '_get_connection')
-    @patch.object(SnowflakeCourseProgressSource, '_internal_table', return_value=DEFAULT_TABLE)
-    def test_executes_expected_sql_and_params(self, _table, mock_conn_factory):
-        ctx, cursor = _mock_ctx_and_cursor(fetchall=[('alice@example.com', 'course-v1:Org+Course+Run', 0.8)])
-        mock_conn_factory.return_value = ctx
+    def test_returns_empty_dict_when_all_rows_lack_required_fields(self):
+        assert not _source().get_course_progress_map(
+            ENTERPRISE_UUID,
+            [{'user_email': '', 'courserun_key': ''}],
+        )
+
+    # Removed duplicate and broken test_cache_stats_are_logged (E0102, E0602)
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    def test_full_cache_hit_skips_snowflake(self, mock_cache):
+        """All pairs in cache → Snowflake must not be called."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.side_effect = [
+            MagicMock(is_found=True, value=0.8),
+            MagicMock(is_found=True, value=0.7),
+        ]
 
         enrollments = [
-            {'user_email': 'alice@example.com', 'courserun_key': 'course-v1:Org+Course+Run'},
-            {'user_email': 'bob@example.com', 'courserun_key': 'course-v1:Org+Other+Run'},
+            {'user_email': 'alice@example.com', 'courserun_key': 'course1'},
+            {'user_email': 'bob@example.com', 'courserun_key': 'course2'},
         ]
         result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
 
-        sql, params = cursor.execute.call_args[0]
-        assert DEFAULT_TABLE in sql
-        assert 'COURSE_PROGRESS' in sql
-        assert 'USER_EMAIL, COURSERUN_KEY' in sql
-        assert NORMALIZED_UUID == params[0]
-        assert params[1:] == [
-            'alice@example.com', 'course-v1:Org+Course+Run',
-            'bob@example.com', 'course-v1:Org+Other+Run',
-        ]
-        assert result == {('alice@example.com', 'course-v1:Org+Course+Run'): 0.8}
+        assert result == {
+            ('alice@example.com', 'course1'): 0.8,
+            ('bob@example.com', 'course2'): 0.7,
+        }
+        mock_cache.set.assert_not_called()
 
-    @patch.object(SnowflakeCourseProgressSource, '_get_connection')
-    @patch.object(SnowflakeCourseProgressSource, '_internal_table', return_value=DEFAULT_TABLE)
-    def test_cursor_and_connection_closed_on_success(self, _table, mock_conn_factory):
-        ctx, cursor = _mock_ctx_and_cursor()
-        mock_conn_factory.return_value = ctx
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch.object(SnowflakeCourseProgressSource, '_fetch_progress_for_pairs')
+    def test_cache_miss_fetches_pairs_from_snowflake(self, mock_fetch, mock_cache):
+        """Cache miss fetches and caches only the missing pairs."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        mock_fetch.return_value = {
+            ('alice@example.com', 'run1'): 0.9,
+            ('bob@example.com', 'run2'): 0.7,
+        }
+
+        enrollments = [
+            {'user_email': 'alice@example.com', 'courserun_key': 'run1'},
+            {'user_email': 'bob@example.com', 'courserun_key': 'run2'},
+        ]
+        result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
+
+        assert result == {
+            ('alice@example.com', 'run1'): 0.9,
+            ('bob@example.com', 'run2'): 0.7,
+        }
+        mock_fetch.assert_called_once_with(
+            ENTERPRISE_UUID,
+            [('alice@example.com', 'run1'), ('bob@example.com', 'run2')],
+        )
+        assert mock_cache.set.call_count == 2
+        mock_cache.set.assert_any_call(
+            _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1'),
+            0.9,
+            timeout=DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT,
+        )
+        mock_cache.set.assert_any_call(
+            _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2'),
+            0.7,
+            timeout=DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT,
+        )
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    def test_cache_lookup_uses_enterprise_scoped_keys(self, mock_cache):
+        """Cache reads must include the enterprise UUID to avoid cross-enterprise leakage."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=True, value=0.8)
+
         _source().get_course_progress_map(
             ENTERPRISE_UUID,
-            [{'user_email': 'alice@example.com', 'courserun_key': 'course-v1:Org+Course+Run'}],
+            [{'user_email': 'alice@example.com', 'courserun_key': 'course1'}],
         )
+
+        mock_cache.get.assert_called_once_with(
+            _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
+        )
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    def test_response_filters_to_requested_pairs_only(self, mock_cache):
+        """Only the requested pairs are returned; extra cached pairs are excluded."""
+        mock_cache.get_key.side_effect = get_key
+        # alice is cached, bob is cached, carol is NOT requested
+        mock_cache.get.side_effect = [
+            MagicMock(is_found=True, value=0.9),
+            MagicMock(is_found=True, value=0.7),
+        ]
+
+        enrollments = [
+            {'user_email': 'alice@example.com', 'courserun_key': 'run1'},
+            {'user_email': 'bob@example.com', 'courserun_key': 'run2'},
+        ]
+        result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
+
+        assert result == {
+            ('alice@example.com', 'run1'): 0.9,
+            ('bob@example.com', 'run2'): 0.7,
+        }
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    def test_cursor_and_connection_closed_on_success(self, mock_connection_factory):
+        """Both cursor and connection must be closed after a successful fetch."""
+        ctx, cursor = _mock_ctx_and_cursor()
+        mock_connection_factory.return_value = ctx
+
+        _source()._fetch_progress_for_pairs(ENTERPRISE_UUID, [('alice@example.com', 'run1')])
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
 
-    @patch.object(SnowflakeCourseProgressSource, '_get_connection')
-    @patch.object(SnowflakeCourseProgressSource, '_internal_table', return_value=DEFAULT_TABLE)
-    def test_cursor_and_connection_closed_on_execute_error(self, _table, mock_conn_factory):
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    def test_cursor_and_connection_closed_on_execute_error(self, mock_connection_factory):
+        """Both cursor and connection must be closed even when execute raises."""
         ctx, cursor = _mock_ctx_and_cursor()
-        cursor.execute.side_effect = RuntimeError('Snowflake error')
-        mock_conn_factory.return_value = ctx
+
+        def raise_execute(sql, params=None):
+            raise RuntimeError('Snowflake error')
+        cursor.execute.side_effect = raise_execute
+        mock_connection_factory.return_value = ctx
+
         with pytest.raises(RuntimeError, match='Snowflake error'):
-            _source().get_course_progress_map(
-                ENTERPRISE_UUID,
-                [{'user_email': 'alice@example.com', 'courserun_key': 'course-v1:Org+Course+Run'}],
-            )
+            _source()._fetch_progress_for_pairs(ENTERPRISE_UUID, [('alice@example.com', 'run1')])
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    def test_cache_stats_are_logged(self, mock_cache, mock_logger):
+        """_log_cache_stats must be invoked after every call."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[('alice@example.com', 'run1', 0.9)])
+        path = 'enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection'
+        with patch(path, return_value=ctx):
+            _source().get_course_progress_map(
+                ENTERPRISE_UUID,
+                [{'user_email': 'alice@example.com', 'courserun_key': 'run1'}],
+            )
+        assert mock_logger.info.call_count >= 1
+
+
+# ===========================================================================
+# SnowflakeCoursePassingGradeSource — table / settings helpers
+# ===========================================================================
+
+class TestCourseOverviewsTable:
+    """Fully-qualified course-overviews table resolution."""
+
+    def test_default_course_overviews_table(self):
+        assert _grade_source()._course_overviews_table() == DEFAULT_OVERVIEWS_TABLE
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
+    def test_custom_course_overviews_table(self, mock_settings):
+        mock_settings.LPR_SNOWFLAKE_LMS_DATABASE = 'STAGING'
+        mock_settings.LPR_SNOWFLAKE_LMS_SCHEMA = 'PUBLIC'
+        mock_settings.LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE = 'OVERVIEWS'
+        assert _grade_source()._course_overviews_table() == 'STAGING.PUBLIC.OVERVIEWS'
+
+
+# ===========================================================================
+# SnowflakeCoursePassingGradeSource — cache configuration
+# ===========================================================================
+
+class TestCoursePassingGradeCacheConfiguration:
+    """Cache timeout values and key construction for passing grades."""
+
+    def test_default_positive_cache_timeout_is_24_hours(self):
+        assert DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT == 86400
+        assert _grade_source()._cache_timeout() == 86400
+
+    @override_settings(LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT=3600)
+    def test_positive_cache_timeout_is_configurable(self):
+        assert _grade_source()._cache_timeout() == 3600
+
+    def test_default_negative_cache_timeout_is_1_hour(self):
+        assert DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT == 3600
+        assert _grade_source()._negative_cache_timeout() == 3600
+
+    @override_settings(LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT=300)
+    def test_negative_cache_timeout_is_configurable(self):
+        assert _grade_source()._negative_cache_timeout() == 300
+
+    def test_cache_key_includes_prefix_and_courserun(self):
+        key = SnowflakeCoursePassingGradeSource._cache_key('course-v1:Org+Run')
+        expected = get_key('lpr_course_passing_grade', DEFAULT_OVERVIEWS_TABLE, 'course-v1:Org+Run')
+        assert key == expected
+
+
+# ===========================================================================
+# SnowflakeCoursePassingGradeSource — get_passing_grade_map
+# ===========================================================================
+
+class TestGetPassingGradeMap:
+    """Behaviour of the main public method."""
+
+    def test_returns_empty_dict_for_empty_input(self):
+        assert not _grade_source().get_passing_grade_map([])
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    def test_full_cache_hit_skips_snowflake(self, mock_cache):
+        """All courseruns cached → Snowflake must not be called."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=True, value=0.6)
+
+        result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+
+        assert result == {'course-v1:Org+Course+Run': 0.6}
+        mock_cache.set.assert_not_called()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_absent_keys_stored_as_none_under_negative_ttl(self, _table, mock_connection_factory, mock_cache):
+        """Keys not returned by Snowflake are stored as None with the negative TTL."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[])
+        mock_connection_factory.return_value = ctx
+
+        result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+
+        assert result == {'course-v1:Org+Course+Run': None}
+        run_key = _passing_grade_cache_key('course-v1:Org+Course+Run')
+        mock_cache.set.assert_called_once_with(
+            run_key,
+            None,
+            timeout=DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT,
+        )
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_mixed_cache_hit_and_miss(self, _table, mock_connection_factory, mock_cache):
+        """Cached and fetched values are merged correctly."""
+        mock_cache.get_key.side_effect = get_key
+
+        cached_key = 'course-v1:Org+Cached+Run'
+        uncached_key = 'course-v1:Org+Uncached+Run'
+
+        def cache_side_effect(cache_key):
+            if cache_key == _passing_grade_cache_key(cached_key):
+                return MagicMock(is_found=True, value=0.8)
+            return MagicMock(is_found=False, value=None)
+        mock_cache.get.side_effect = cache_side_effect
+
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[(uncached_key, 0.55)])
+        mock_connection_factory.return_value = ctx
+
+        result = _grade_source().get_passing_grade_map([cached_key, uncached_key])
+
+        assert result == {cached_key: 0.8, uncached_key: 0.55}
+        mock_cache.set.assert_called_once_with(
+            _passing_grade_cache_key(uncached_key),
+            0.55,
+            timeout=DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT,
+        )
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_positive_values_use_24h_timeout(self, _table, mock_connection_factory, mock_cache):
+        """Positive cache writes must use the 24-hour TTL."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
+        mock_connection_factory.return_value = ctx
+
+        _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+
+        timeout_arg = mock_cache.set.call_args[1].get('timeout')
+        assert timeout_arg == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_single_key_cache_operations_used(self, _table, mock_connection_factory, mock_cache):
+        """Each missing key should be cached through the single-key cache API."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
+        mock_connection_factory.return_value = ctx
+
+        _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+
+        mock_cache.get.assert_called_once()
+        mock_cache.set.assert_called_once()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_large_key_set_uses_single_query(self, _table, mock_connection_factory, mock_cache):
+        """All keys must be fetched in one SQL statement regardless of batch size."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+
+        keys = [f'course-{i}' for i in range(1, 6)]
+        rows = [(k, round(0.1 * i, 1)) for i, k in enumerate(keys, 1)]
+        ctx, cursor = _mock_ctx_and_cursor(fetchall=rows)
+        mock_connection_factory.return_value = ctx
+
+        result = _grade_source().get_passing_grade_map(keys)
+
+        assert result == {k: round(0.1 * i, 1) for i, k in enumerate(keys, 1)}
+        assert cursor.execute.call_count == 1
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_duplicate_keys_deduplicated(self, _table, mock_connection_factory, mock_cache):
+        """Duplicate courserun keys must be deduplicated before querying."""
+        mock_cache.get_key.side_effect = get_key
+        mock_cache.get.return_value = MagicMock(is_found=False, value=None)
+
+        ctx, cursor = _mock_ctx_and_cursor(fetchall=[('course-1', 0.6)])
+        mock_connection_factory.return_value = ctx
+
+        result = _grade_source().get_passing_grade_map(['course-1', 'course-1', 'course-1'])
+
+        assert result == {'course-1': 0.6}
+        _, params = cursor.execute.call_args[0]
+        assert params.count('course-1') == 1
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_cursor_and_connection_closed_on_success(self, _table, mock_connection_factory):
+        ctx, cursor = _mock_ctx_and_cursor(fetchall=[])
+        mock_connection_factory.return_value = ctx
+
+        _grade_source()._fetch_passing_grades(['course-v1:Org+Course+Run'])
+
+        cursor.close.assert_called_once()
+        ctx.close.assert_called_once()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_cursor_and_connection_closed_on_execute_error(self, _table, mock_connection_factory):
+        ctx, cursor = _mock_ctx_and_cursor()
+        cursor.execute.side_effect = RuntimeError('Snowflake error')
+        mock_connection_factory.return_value = ctx
+
+        with pytest.raises(RuntimeError, match='Snowflake error'):
+            _grade_source()._fetch_passing_grades(['course-v1:Org+Course+Run'])
+
+        cursor.close.assert_called_once()
+        ctx.close.assert_called_once()
+
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
+    def test_logs_cache_and_fetch_observability(self, _table, mock_connection_factory, mock_cache, mock_logger):
+        """At least three LOGGER.info calls expected (requested/cached/missing + fetched stats)."""
+        mock_cache.get_key.side_effect = get_key
+
+        def cache_side_effect(cache_key):
+            if cache_key == _passing_grade_cache_key('course-1'):
+                return MagicMock(is_found=True, value=0.5)
+            return MagicMock(is_found=False, value=None)
+        mock_cache.get.side_effect = cache_side_effect
+
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-2', 0.6)])
+        mock_connection_factory.return_value = ctx
+
+        _grade_source().get_passing_grade_map(['course-1', 'course-2'])
+
+        assert mock_logger.info.call_count >= 3

--- a/enterprise_reporting/tests/utils.py
+++ b/enterprise_reporting/tests/utils.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import zlib
 from zipfile import ZipFile
 
 
@@ -42,5 +43,8 @@ def verify_compressed(self, delivery_files, files, original_file_size, password)
         assert len(content) == file['size']
 
         # Also verify file is not accessible with any other passwords i.e wrong passwords.
-        with self.assertRaises(RuntimeError):
+        # Different Python/zlib/libminizip combinations may raise different
+        # exceptions when decryption fails (RuntimeError or zlib.error). Accept
+        # either to keep the test robust across environments.
+        with self.assertRaises((RuntimeError, zlib.error)):
             zipfile.read(file['file'].name.split('/')[-1], b'wrong-password')


### PR DESCRIPTION
# [ENT-11788] Add Course Passing Grade Enrichment & Course Progress Caching to LPR

## Summary

This PR implements the backend enrichment layer in `edx-enterprise-data` to support a new **Course Passing Grade** column in the Learner Progress Report (LPR) in the Admin Portal. It also introduces a **per-pair caching strategy** for Course Progress data to eliminate redundant Snowflake queries.

> **Note:** The UI column placement and CSV download integration will be addressed in [ENT-11722](https://2u-internal.atlassian.net/browse/ENT-11722).

---

## Problem

Admins reviewing the Learner Progress Report currently lack visibility into the **required passing grade** for each course. Without this information, it is difficult to assess whether a learner's current progress is on track to meet the course's standard. This creates friction when Admins try to make informed decisions about learner outreach.

Additionally, Course Progress data was being fetched from Snowflake on every API request, causing unnecessary repeated queries for data that changes infrequently (roughly once per day).

---

## Solution

### 1. Course Passing Grade — New Snowflake Source (`SnowflakeCoursePassingGradeSource`)

- Fetches `LOWEST_PASSING_GRADE` from Snowflake's LMS course-overviews table:
  `PROD.LMS.COURSE_OVERVIEWS_COURSEOVERVIEW`
- Batched query per page of enrollments to minimise Snowflake round-trips
- Per-courserun-key caching with:
  - **Positive cache TTL**: `86400` seconds (24 hours) — configurable via `LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT`
  - **Negative cache TTL**: `3600` seconds (1 hour) — configurable via `LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT`
- Graceful degradation: if Snowflake is unavailable the field is omitted without breaking the LPR response

### 2. Course Progress Caching — Per-Pair Cache (`SnowflakeCourseProgressSource`)

- Cache is keyed on `(user_email, courserun_key)` — only the exact pairs requested by the current page are looked up or stored.
- Snowflake is queried only for cache-missing pairs using a parameterised `(USER_EMAIL, COURSERUN_KEY) IN (…)` filter together with the enterprise UUID — **never the full enterprise table**.
- Cache TTL: `300` seconds (5 minutes) — configurable via `LPR_COURSE_PROGRESS_CACHE_TIMEOUT`
- Caching follows the project-standard `TieredCache` wrapper (`enterprise_data/cache/__init__.py`).

### 3. Snowflake Connection Factory

- Optional `LPR_SNOWFLAKE_WAREHOUSE` and `LPR_SNOWFLAKE_ROLE` settings are forwarded to the Snowflake connector when present.
- Shared `_get_snowflake_connection()` module-level factory removes duplication between the two source classes.

---

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | A new `course_passing_grade` field is exposed in the LPR API response | ✅ This PR |
| 2 | The column is positioned to the left of "Course Progress" in Admin Portal | 🔜 ENT-11722 |
| 3 | The column displays the required passing grade sourced from Snowflake course overviews | ✅ This PR |
| 4 | The field is included in the LPR CSV download | 🔜 ENT-11722 |
| 5 | Course Progress data is cached per `(user_email, courserun_key)` pair to reduce Snowflake query frequency | ✅ This PR |

---

## Configuration Reference

### Required Settings

| Setting | Description |
|---------|-------------|
| `SNOWFLAKE_SERVICE_USER` | Snowflake service account username |
| `SNOWFLAKE_SERVICE_USER_PASSWORD` | Snowflake service account password |

### Optional Settings (with defaults)

| Setting | Default | Description |
|---------|---------|-------------|
| `SNOWFLAKE_ACCOUNT` | `'edx.us-east-1'` | Snowflake account identifier |
| `LPR_SNOWFLAKE_WAREHOUSE` | `None` | Snowflake virtual warehouse (omitted if unset) |
| `LPR_SNOWFLAKE_ROLE` | `None` | Snowflake role (omitted if unset) |
| `LPR_SNOWFLAKE_DATABASE` | `'PROD'` | Snowflake database for LPR internal table |
| `LPR_SNOWFLAKE_SCHEMA` | `'ENTERPRISE'` | Snowflake schema for LPR internal table |
| `LPR_SNOWFLAKE_INTERNAL_TABLE` | `'LEARNER_PROGRESS_REPORT_INTERNAL'` | Internal LPR table name |
| `LPR_COURSE_PROGRESS_CACHE_TIMEOUT` | `300` | Cache TTL for course progress (seconds) |
| `LPR_SNOWFLAKE_LMS_DATABASE` | `'PROD'` | Snowflake database for course overviews |
| `LPR_SNOWFLAKE_LMS_SCHEMA` | `'LMS'` | Snowflake schema for course overviews |
| `LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE` | `'COURSE_OVERVIEWS_COURSEOVERVIEW'` | Course overviews table name |
| `LPR_COURSE_PASSING_GRADE_CACHE_TIMEOUT` | `86400` | Positive cache TTL for passing grades (seconds) |
| `LPR_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT` | `3600` | Negative cache TTL for missing passing grades (seconds) |

---

## Files Changed

| File | Change |
|------|--------|
| `enterprise_data/api/v1/views/lpr_data_source_snowflake.py` | Added `SnowflakeCoursePassingGradeSource`; updated `SnowflakeCourseProgressSource` with per-pair caching and pair-filtered SQL; restored `LPR_SNOWFLAKE_WAREHOUSE` / `LPR_SNOWFLAKE_ROLE` support |
| `enterprise_data/api/v1/views/enterprise_learner.py` | Added `_enrich_course_passing_grade_rows()` enrichment call in `list()` |
| `enterprise_data/api/v1/serializers.py` | Added `course_passing_grade` field to enrollment serializer |
| `enterprise_data/cache/__init__.py` | Removed unused `get_many` / `set_many` helpers; kept single-key `get` / `set` wrapping `TieredCache` |
| `enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py` | Full test coverage for both source classes (34 tests) |
| `enterprise_data/tests/test_clients.py` | Removed erroneously added passing-grade methods; pylint fixes |


## Related Tickets

- **[ENT-11788](https://2u-internal.atlassian.net/browse/ENT-11788)** — Add cache to course-progress and add course passing grade enrichment *(this PR)*
- **[ENT-11722](https://2u-internal.atlassian.net/browse/ENT-11722)** — Add Course Passing Grade column to LPR UI and CSV in Admin Portal *(follow-up)*


Test screen shots using postgresql as datasource:
API Result:
<img width="1655" height="879" alt="image" src="https://github.com/user-attachments/assets/0c4c0cd4-40c0-47cc-ad00-2109e9e706f6" />
UI Screen:
<img width="1900" height="879" alt="image" src="https://github.com/user-attachments/assets/8cd51936-7824-4220-a7da-862c5e0a7854" />
