### PR TITLE
feat: Add private key and passphrase for snowflake access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+[10.22.7] - 2026-06-16
+-----------------------
+  * feat: add private_key and passphrase authenticate snowflake connection
 
 [10.22.6] - 2026-06-15
 -----------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.6"
+__version__ = "10.22.7"

--- a/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
@@ -5,7 +5,7 @@ Classes
 -------
 SnowflakeCourseProgressSource
     Fetches COURSE_PROGRESS per ``(enterprise_customer_uuid, user_email, courserun_key)``
-    from ``LEARNER_PROGRESS_REPORT_INTERNAL``.  Results are cached per (enterprise, pair).
+    from ``LEARNER_PROGRESS_REPORT_EXTERNAL``.  Results are cached per (enterprise, pair).
 
 SnowflakeCoursePassingGradeSource
     Fetches LOWEST_PASSING_GRADE per ``courserun_key`` from
@@ -16,16 +16,18 @@ SnowflakeCoursePassingGradeSource
 Required Django settings
 ------------------------
   SNOWFLAKE_SERVICE_USER
-  SNOWFLAKE_SERVICE_USER_PASSWORD
+  SNOWFLAKE_SERVICE_PRIVKEY    PEM-encoded private key string
+  SNOWFLAKE_SERVICE_PASSPHRASE Passphrase to decrypt the private key
 
 Optional Django settings (with defaults)
 -----------------------------------------
   SNOWFLAKE_ACCOUNT                          = 'edx.us-east-1'
+  SNOWFLAKE_ROLE                             = 'ENTERPRISE_SERVICE_USER_ROLE'
   LPR_SNOWFLAKE_WAREHOUSE                    = None
   LPR_SNOWFLAKE_ROLE                         = None
   LPR_SNOWFLAKE_DATABASE                     = 'PROD'
   LPR_SNOWFLAKE_SCHEMA                       = 'ENTERPRISE'
-  LPR_SNOWFLAKE_INTERNAL_TABLE               = 'LEARNER_PROGRESS_REPORT_INTERNAL'
+  LPR_SNOWFLAKE_EXTERNAL_TABLE               = 'LEARNER_PROGRESS_REPORT_EXTERNAL'
   LPR_COURSE_PROGRESS_CACHE_TIMEOUT          = 300    (5 min)
   LPR_SNOWFLAKE_LMS_DATABASE                 = 'PROD'
   LPR_SNOWFLAKE_LMS_SCHEMA                   = 'LMS'
@@ -52,69 +54,91 @@ DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT = 60 * 60  # 1 hour
 SNOWFLAKE_QUERY_BATCH_SIZE = 500
 
 try:
-    import snowflake.connector as snowflake_connector
+    import snowflake.connector as _snowflake_connector
 except ImportError:  # pragma: no cover - depends on runtime extras
-    snowflake_connector = None
+    _snowflake_connector = None
     LOGGER.warning(
         '[course_progress] snowflake-connector-python is not installed. '
         'course_progress will be null. Add snowflake-connector-python to requirements/base.in.'
     )
 
-snowflake = SimpleNamespace(connector=snowflake_connector)
+_snowflake = SimpleNamespace(connector=_snowflake_connector)
+
+try:
+    from cryptography.hazmat.backends import default_backend as _default_backend
+    from cryptography.hazmat.primitives import serialization as _serialization
+except ImportError:  # pragma: no cover - optional dependency
+    _default_backend = None  # type: ignore[assignment]
+    _serialization = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
-# Shared connection factory
+# Module-level connection factory (private-key authentication)
 # ---------------------------------------------------------------------------
 
-def _get_snowflake_connection():
+def _get_snowflake_connection(warehouse=None, role=None):
     """
-    Open and return a Snowflake connection from Django settings.
+    Open and return a Snowflake connection using private-key authentication.
 
-    The returned ``SnowflakeConnection`` object supports the context-manager
-    protocol (``__enter__`` returns ``self``), so callers should use it inside
-    a ``with`` block::
+    Credentials are read from Django settings.  The returned
+    ``SnowflakeConnection`` supports the context-manager protocol::
 
-        with _get_snowflake_connection() as conn:
+        with _get_snowflake_connection(warehouse='MY_WH') as conn:
             with conn.cursor() as cur:
                 cur.execute(...)
 
-    Required settings: SNOWFLAKE_SERVICE_USER, SNOWFLAKE_SERVICE_USER_PASSWORD.
-    Optional settings: SNOWFLAKE_ACCOUNT (default ``'edx.us-east-1'``),
-    LPR_SNOWFLAKE_WAREHOUSE, LPR_SNOWFLAKE_ROLE.
+    Args:
+        warehouse (str | None): Snowflake virtual warehouse to activate.
+        role (str | None): Snowflake role to assume.  Defaults to
+            ``settings.SNOWFLAKE_ROLE`` (fallback: ``'ENTERPRISE_SERVICE_USER_ROLE'``),
+            then overridden by the LPR-specific ``LPR_SNOWFLAKE_ROLE`` setting
+            when passed from ``_snowflake_cursor``.
 
     Raises:
         ImportError: When snowflake-connector-python is not installed.
-        ValueError: When required credentials are absent from settings.
+        ValueError: When required credential settings are absent.
     """
-    if snowflake.connector is None:
+    if _snowflake.connector is None:
         raise ImportError(
             'snowflake-connector-python is required for Snowflake LPR access'
         )
 
     user = getattr(settings, 'SNOWFLAKE_SERVICE_USER', None)
-    password = getattr(settings, 'SNOWFLAKE_SERVICE_USER_PASSWORD', None)
+    key_pem = getattr(settings, 'SNOWFLAKE_SERVICE_PRIVKEY', None)
+    passphrase = getattr(settings, 'SNOWFLAKE_SERVICE_PASSPHRASE', None)
     account = getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
-    warehouse = getattr(settings, 'LPR_SNOWFLAKE_WAREHOUSE', None)
-    role = getattr(settings, 'LPR_SNOWFLAKE_ROLE', None)
+    default_role = getattr(settings, 'SNOWFLAKE_ROLE', 'ENTERPRISE_SERVICE_USER_ROLE')
 
-    if not user or not password:
-        LOGGER.error(
-            '[lpr] Snowflake credentials missing — '
-            'SNOWFLAKE_SERVICE_USER=%s SNOWFLAKE_SERVICE_USER_PASSWORD=%s.',
-            'SET' if user else 'NOT SET',
-            'SET' if password else 'NOT SET',
-        )
-        raise ValueError(
-            'SNOWFLAKE_SERVICE_USER and SNOWFLAKE_SERVICE_USER_PASSWORD must both be configured'
-        )
+    if not user:
+        LOGGER.error('Snowflake credentials missing — SNOWFLAKE_SERVICE_USER is not set.')
+        raise ValueError('SNOWFLAKE_SERVICE_USER must be configured')
+    if not key_pem:
+        LOGGER.error('Snowflake credentials missing — SNOWFLAKE_SERVICE_PRIVKEY is not set.')
+        raise ValueError('SNOWFLAKE_SERVICE_PRIVKEY must be configured')
+    if not passphrase:
+        raise ValueError('SNOWFLAKE_SERVICE_PASSPHRASE must be configured')
 
-    connect_kwargs = {'user': user, 'password': password, 'account': account}
+    key_data = key_pem.encode() if isinstance(key_pem, str) else key_pem
+    private_key = _serialization.load_pem_private_key(
+        key_data,
+        password=passphrase.encode() if isinstance(passphrase, str) else passphrase,
+        backend=_default_backend(),
+    )
+    private_key_bytes = private_key.private_bytes(
+        encoding=_serialization.Encoding.DER,
+        format=_serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=_serialization.NoEncryption(),
+    )
+
+    connect_kwargs = {
+        'user': user,
+        'account': account,
+        'private_key': private_key_bytes,
+        'role': role or default_role,
+    }
     if warehouse:
         connect_kwargs['warehouse'] = warehouse
-    if role:
-        connect_kwargs['role'] = role
-    return snowflake.connector.connect(**connect_kwargs)
+    return _snowflake.connector.connect(**connect_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +165,9 @@ class SnowflakeLPRBaseSource:
         Uses ``_get_snowflake_connection()`` (module-level) so that the
         connection factory can be independently mocked in tests.
         """
-        with _get_snowflake_connection() as connection:
+        warehouse = self._get_setting('LPR_SNOWFLAKE_WAREHOUSE', None)
+        role = self._get_setting('LPR_SNOWFLAKE_ROLE', None)
+        with _get_snowflake_connection(warehouse=warehouse, role=role) as connection:
             with connection.cursor() as cursor:
                 yield cursor
 
@@ -154,7 +180,7 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
     """
     Course progress data source backed by Snowflake.
 
-    Fetches COURSE_PROGRESS from ``LEARNER_PROGRESS_REPORT_INTERNAL`` filtered
+    Fetches COURSE_PROGRESS from ``LEARNER_PROGRESS_REPORT_EXTERNAL`` filtered
     by both ``enterprise_customer_uuid`` and the exact ``(user_email,
     courserun_key)`` pairs requested.  Results are cached per pair so that
     repeated page requests never re-query Snowflake for already-seen rows.
@@ -169,7 +195,7 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
         """Return the fully-qualified Snowflake table name for internal LPR data."""
         database = cls._get_setting('LPR_SNOWFLAKE_DATABASE', 'PROD')
         schema = cls._get_setting('LPR_SNOWFLAKE_SCHEMA', 'ENTERPRISE')
-        table = cls._get_setting('LPR_SNOWFLAKE_INTERNAL_TABLE', 'LEARNER_PROGRESS_REPORT_INTERNAL')
+        table = cls._get_setting('LPR_SNOWFLAKE_EXTERNAL_TABLE', 'LEARNER_PROGRESS_REPORT_EXTERNAL')
         return f'{database}.{schema}.{table}'
 
     @classmethod
@@ -380,7 +406,7 @@ class SnowflakeCourseProgressSource(SnowflakeLPRBaseSource):
             if not rows:
                 LOGGER.warning(
                     '[course_progress] Snowflake returned 0 rows for enterprise=%s pairs=%d (batch %d). '
-                    'Verify LEARNER_PROGRESS_REPORT_INTERNAL contains data for this enterprise.',
+                    'Verify LEARNER_PROGRESS_REPORT_EXTERNAL contains data for this enterprise.',
                     enterprise_customer_uuid, len(batch), batch_start,
                 )
             else:
@@ -474,14 +500,6 @@ class SnowflakeCoursePassingGradeSource(SnowflakeLPRBaseSource):
         under a shorter negative TTL to prevent repeated round-trips).  This
         differs from ``SnowflakeCourseProgressSource.get_course_progress_map``,
         which **omits** absent keys from the result entirely.
-
-        Security note: the cache key for passing grades is **not** enterprise-
-        scoped because ``LOWEST_PASSING_GRADE`` is a course-level attribute
-        identical across all enterprises.  Callers **must** only supply
-        courserun keys that were obtained from the requesting enterprise's
-        filtered enrollment queryset; passing attacker-influenced keys that
-        do not belong to the enterprise is not supported and would return
-        that course's threshold from cache or Snowflake.
 
         Args:
             courserun_keys (list[str]): Courserun keys to look up.

--- a/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
+++ b/enterprise_data/tests/lpr/test_lpr_data_source_snowflake.py
@@ -1,12 +1,15 @@
 """Tests for ``SnowflakeCourseProgressSource`` and ``SnowflakeCoursePassingGradeSource``."""
+
 # pylint: disable=protected-access
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from django.test import override_settings
 
+import enterprise_data.api.v1.views.lpr_data_source_snowflake as _lpr_module
 from enterprise_data.api.v1.views.lpr_data_source_snowflake import (
     DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT,
     DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT,
@@ -21,16 +24,17 @@ from enterprise_data.cache import get_key
 # Shared constants
 # ---------------------------------------------------------------------------
 
-ENTERPRISE_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
-NORMALIZED_UUID = 'a1b2c3d4e5f67890abcdef1234567890'
+ENTERPRISE_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+NORMALIZED_UUID = "a1b2c3d4e5f67890abcdef1234567890"
 
-DEFAULT_TABLE = 'PROD.ENTERPRISE.LEARNER_PROGRESS_REPORT_INTERNAL'
-DEFAULT_OVERVIEWS_TABLE = 'PROD.LMS.COURSE_OVERVIEWS_COURSEOVERVIEW'
+DEFAULT_TABLE = "PROD.ENTERPRISE.LEARNER_PROGRESS_REPORT_EXTERNAL"
+DEFAULT_OVERVIEWS_TABLE = "PROD.LMS.COURSE_OVERVIEWS_COURSEOVERVIEW"
 
 
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def _source():
     """Return a fresh SnowflakeCourseProgressSource instance."""
@@ -52,12 +56,14 @@ def _mock_ctx_and_cursor(fetchall=None):
 
     def cursor_exit(*_):
         cursor.close()
+
     cursor.__enter__.side_effect = cursor_enter
     cursor.__exit__.side_effect = cursor_exit
 
     def execute(sql, params=None):
         cursor._last_sql = sql
         cursor._last_params = params
+
     cursor.execute.side_effect = execute
     ctx = MagicMock()
     ctx.cursor.return_value = cursor
@@ -67,6 +73,7 @@ def _mock_ctx_and_cursor(fetchall=None):
 
     def ctx_exit(*_):
         ctx.close()
+
     ctx.__enter__.side_effect = ctx_enter
     ctx.__exit__.side_effect = ctx_exit
     return ctx, cursor
@@ -75,9 +82,11 @@ def _mock_ctx_and_cursor(fetchall=None):
 def _progress_pair_cache_key(enterprise_customer_uuid, user_email, courserun_key):
     """Build the expected per-pair progress cache key."""
     return get_key(
-        'lpr_course_progress',
+        "lpr_course_progress",
         SnowflakeCourseProgressSource._internal_table(),
-        SnowflakeCourseProgressSource._normalized_enterprise_uuid(enterprise_customer_uuid),
+        SnowflakeCourseProgressSource._normalized_enterprise_uuid(
+            enterprise_customer_uuid
+        ),
         str(user_email).strip(),
         str(courserun_key).strip(),
     )
@@ -85,51 +94,13 @@ def _progress_pair_cache_key(enterprise_customer_uuid, user_email, courserun_key
 
 def _passing_grade_cache_key(courserun_key):
     """Build the expected passing-grade cache key, including the course overview table name for parity."""
-    return get_key('lpr_course_passing_grade', DEFAULT_OVERVIEWS_TABLE, courserun_key)
-
-
-# ===========================================================================
-# Module-level connection factory
-# ===========================================================================
-
-class TestGetSnowflakeConnection:
-    """Tests for the shared ``_get_snowflake_connection`` factory."""
-
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
-    def test_uses_required_credentials(self, mock_settings, mock_connector):
-        mock_settings.SNOWFLAKE_SERVICE_USER = 'user'
-        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = 'pass'
-        mock_settings.SNOWFLAKE_ACCOUNT = 'edx.us-east-1'
-        mock_settings.LPR_SNOWFLAKE_WAREHOUSE = None
-        mock_settings.LPR_SNOWFLAKE_ROLE = None
-        _get_snowflake_connection()
-        kwargs = mock_connector.connect.call_args[1]
-        assert kwargs['user'] == 'user'
-        assert kwargs['password'] == 'pass'
-        assert kwargs['account'] == 'edx.us-east-1'
-        assert 'warehouse' not in kwargs
-        assert 'role' not in kwargs
-
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake.connector')
-    def test_raises_when_credentials_missing(self, mock_connector, mock_settings):
-        mock_settings.SNOWFLAKE_SERVICE_USER = None
-        mock_settings.SNOWFLAKE_SERVICE_USER_PASSWORD = None
-        with pytest.raises(ValueError, match='SNOWFLAKE_SERVICE_USER'):
-            _get_snowflake_connection()
-        mock_connector.connect.assert_not_called()
-
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.snowflake')
-    def test_raises_import_error_when_connector_missing(self, mock_snowflake):
-        mock_snowflake.connector = None
-        with pytest.raises(ImportError, match='snowflake-connector-python'):
-            _get_snowflake_connection()
+    return get_key("lpr_course_passing_grade", DEFAULT_OVERVIEWS_TABLE, courserun_key)
 
 
 # ===========================================================================
 # SnowflakeCourseProgressSource — table / settings helpers
 # ===========================================================================
+
 
 class TestInternalTable:
     """Fully-qualified internal table resolution."""
@@ -137,17 +108,21 @@ class TestInternalTable:
     def test_default_internal_table(self):
         assert SnowflakeCourseProgressSource._internal_table() == DEFAULT_TABLE
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.settings")
     def test_custom_internal_table(self, mock_settings):
-        mock_settings.LPR_SNOWFLAKE_DATABASE = 'STAGING'
-        mock_settings.LPR_SNOWFLAKE_SCHEMA = 'REPORTING'
-        mock_settings.LPR_SNOWFLAKE_INTERNAL_TABLE = 'COURSE_PROGRESS'
-        assert SnowflakeCourseProgressSource._internal_table() == 'STAGING.REPORTING.COURSE_PROGRESS'
+        mock_settings.LPR_SNOWFLAKE_DATABASE = "STAGING"
+        mock_settings.LPR_SNOWFLAKE_SCHEMA = "REPORTING"
+        mock_settings.LPR_SNOWFLAKE_EXTERNAL_TABLE = "COURSE_PROGRESS"
+        assert (
+            SnowflakeCourseProgressSource._internal_table()
+            == "STAGING.REPORTING.COURSE_PROGRESS"
+        )
 
 
 # ===========================================================================
 # SnowflakeCourseProgressSource — cache configuration
 # ===========================================================================
+
 
 class TestCourseProgressCacheConfiguration:
     """Cache timeout and key construction for course progress."""
@@ -163,30 +138,31 @@ class TestCourseProgressCacheConfiguration:
     def test_pair_cache_key_includes_enterprise_table_email_and_courserun(self):
         key = SnowflakeCourseProgressSource._pair_cache_key(
             ENTERPRISE_UUID,
-            'alice@example.com',
-            'course-v1:org+X+1',
+            "alice@example.com",
+            "course-v1:org+X+1",
         )
         expected = get_key(
-            'lpr_course_progress',
+            "lpr_course_progress",
             SnowflakeCourseProgressSource._internal_table(),
             NORMALIZED_UUID,
-            'alice@example.com',
-            'course-v1:org+X+1',
+            "alice@example.com",
+            "course-v1:org+X+1",
         )
         assert key == expected
 
     def test_pair_cache_key_differs_across_enterprises(self):
         first = SnowflakeCourseProgressSource._pair_cache_key(
             ENTERPRISE_UUID,
-            'alice@example.com',
-            'course-v1:org+X+1',
+            "alice@example.com",
+            "course-v1:org+X+1",
         )
         second = SnowflakeCourseProgressSource._pair_cache_key(
-            '11111111-2222-3333-4444-555555555555',
-            'alice@example.com',
-            'course-v1:org+X+1',
+            "11111111-2222-3333-4444-555555555555",
+            "alice@example.com",
+            "course-v1:org+X+1",
         )
         assert first != second
+
 
 # ===========================================================================
 # SnowflakeCourseProgressSource — get_course_progress_map
@@ -202,16 +178,20 @@ class TestGetCourseProgressMap:
     def test_returns_empty_dict_when_all_rows_lack_required_fields(self):
         assert not _source().get_course_progress_map(
             ENTERPRISE_UUID,
-            [{'user_email': '', 'courserun_key': ''}],
+            [{"user_email": "", "courserun_key": ""}],
         )
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
     def test_full_cache_hit_skips_snowflake(self, mock_cache):
         """All pairs in cache → Snowflake must not be called."""
         mock_cache.get_key.side_effect = get_key
 
-        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
-        bob_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'course2')
+        alice_key = _progress_pair_cache_key(
+            ENTERPRISE_UUID, "alice@example.com", "course1"
+        )
+        bob_key = _progress_pair_cache_key(
+            ENTERPRISE_UUID, "bob@example.com", "course2"
+        )
 
         mock_cache.get_many.return_value = {
             alice_key: 0.8,
@@ -219,126 +199,153 @@ class TestGetCourseProgressMap:
         }
 
         enrollments = [
-            {'user_email': 'alice@example.com', 'courserun_key': 'course1'},
-            {'user_email': 'bob@example.com', 'courserun_key': 'course2'},
+            {"user_email": "alice@example.com", "courserun_key": "course1"},
+            {"user_email": "bob@example.com", "courserun_key": "course2"},
         ]
         result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
 
         assert result == {
-            ('alice@example.com', 'course1'): 0.8,
-            ('bob@example.com', 'course2'): 0.7,
+            ("alice@example.com", "course1"): 0.8,
+            ("bob@example.com", "course2"): 0.7,
         }
         mock_cache.set_many.assert_not_called()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch.object(SnowflakeCourseProgressSource, '_fetch_progress_for_pairs')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch.object(SnowflakeCourseProgressSource, "_fetch_progress_for_pairs")
     def test_cache_miss_fetches_pairs_from_snowflake(self, mock_fetch, mock_cache):
         """Cache miss fetches and caches only the missing pairs."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get_many.return_value = {}  # No cache hits
         mock_fetch.return_value = {
-            ('alice@example.com', 'run1'): 0.9,
-            ('bob@example.com', 'run2'): 0.7,
+            ("alice@example.com", "run1"): 0.9,
+            ("bob@example.com", "run2"): 0.7,
         }
 
         enrollments = [
-            {'user_email': 'alice@example.com', 'courserun_key': 'run1'},
-            {'user_email': 'bob@example.com', 'courserun_key': 'run2'},
+            {"user_email": "alice@example.com", "courserun_key": "run1"},
+            {"user_email": "bob@example.com", "courserun_key": "run2"},
         ]
         result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
 
         assert result == {
-            ('alice@example.com', 'run1'): 0.9,
-            ('bob@example.com', 'run2'): 0.7,
+            ("alice@example.com", "run1"): 0.9,
+            ("bob@example.com", "run2"): 0.7,
         }
         mock_fetch.assert_called_once_with(
             ENTERPRISE_UUID,
-            [('alice@example.com', 'run1'), ('bob@example.com', 'run2')],
+            [("alice@example.com", "run1"), ("bob@example.com", "run2")],
         )
         mock_cache.set_many.assert_called_once()
         call_args = mock_cache.set_many.call_args
         cache_writes = call_args[0][0]  # First positional argument
         assert len(cache_writes) == 2
-        assert cache_writes[_progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1')] == 0.9
-        assert cache_writes[_progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2')] == 0.7
-        assert call_args[1]['timeout'] == DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT
+        assert (
+            cache_writes[
+                _progress_pair_cache_key(ENTERPRISE_UUID, "alice@example.com", "run1")
+            ]
+            == 0.9
+        )
+        assert (
+            cache_writes[
+                _progress_pair_cache_key(ENTERPRISE_UUID, "bob@example.com", "run2")
+            ]
+            == 0.7
+        )
+        assert call_args[1]["timeout"] == DEFAULT_COURSE_PROGRESS_CACHE_TIMEOUT
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
     def test_cache_lookup_uses_enterprise_scoped_keys(self, mock_cache):
         """Cache reads must include the enterprise UUID to avoid cross-enterprise leakage."""
         mock_cache.get_key.side_effect = get_key
-        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'course1')
+        alice_key = _progress_pair_cache_key(
+            ENTERPRISE_UUID, "alice@example.com", "course1"
+        )
         mock_cache.get_many.return_value = {alice_key: 0.8}
 
         _source().get_course_progress_map(
             ENTERPRISE_UUID,
-            [{'user_email': 'alice@example.com', 'courserun_key': 'course1'}],
+            [{"user_email": "alice@example.com", "courserun_key": "course1"}],
         )
 
         mock_cache.get_many.assert_called_once()
-        call_args = mock_cache.get_many.call_args[0][0]  # First positional argument - list of keys
+        call_args = mock_cache.get_many.call_args[0][
+            0
+        ]  # First positional argument - list of keys
         assert alice_key in call_args
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
     def test_response_filters_to_requested_pairs_only(self, mock_cache):
         """Only the requested pairs are returned; extra cached pairs are excluded."""
         mock_cache.get_key.side_effect = get_key
         # alice is cached, bob is cached, carol is NOT requested
-        alice_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'alice@example.com', 'run1')
-        bob_key = _progress_pair_cache_key(ENTERPRISE_UUID, 'bob@example.com', 'run2')
+        alice_key = _progress_pair_cache_key(
+            ENTERPRISE_UUID, "alice@example.com", "run1"
+        )
+        bob_key = _progress_pair_cache_key(ENTERPRISE_UUID, "bob@example.com", "run2")
         mock_cache.get_many.return_value = {
             alice_key: 0.9,
             bob_key: 0.7,
         }
 
         enrollments = [
-            {'user_email': 'alice@example.com', 'courserun_key': 'run1'},
-            {'user_email': 'bob@example.com', 'courserun_key': 'run2'},
+            {"user_email": "alice@example.com", "courserun_key": "run1"},
+            {"user_email": "bob@example.com", "courserun_key": "run2"},
         ]
         result = _source().get_course_progress_map(ENTERPRISE_UUID, enrollments)
 
         assert result == {
-            ('alice@example.com', 'run1'): 0.9,
-            ('bob@example.com', 'run2'): 0.7,
+            ("alice@example.com", "run1"): 0.9,
+            ("bob@example.com", "run2"): 0.7,
         }
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
     def test_cursor_and_connection_closed_on_success(self, mock_connection_factory):
         """Both cursor and connection must be closed after a successful fetch."""
         ctx, cursor = _mock_ctx_and_cursor()
         mock_connection_factory.return_value = ctx
 
-        _source()._fetch_progress_for_pairs(ENTERPRISE_UUID, [('alice@example.com', 'run1')])
+        _source()._fetch_progress_for_pairs(
+            ENTERPRISE_UUID, [("alice@example.com", "run1")]
+        )
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    def test_cursor_and_connection_closed_on_execute_error(self, mock_connection_factory):
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    def test_cursor_and_connection_closed_on_execute_error(
+        self, mock_connection_factory
+    ):
         """Both cursor and connection must be closed even when execute raises."""
         ctx, cursor = _mock_ctx_and_cursor()
 
         def raise_execute(sql, params=None):
-            raise RuntimeError('Snowflake error')
+            raise RuntimeError("Snowflake error")
+
         cursor.execute.side_effect = raise_execute
         mock_connection_factory.return_value = ctx
 
-        with pytest.raises(RuntimeError, match='Snowflake error'):
-            _source()._fetch_progress_for_pairs(ENTERPRISE_UUID, [('alice@example.com', 'run1')])
+        with pytest.raises(RuntimeError, match="Snowflake error"):
+            _source()._fetch_progress_for_pairs(
+                ENTERPRISE_UUID, [("alice@example.com", "run1")]
+            )
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER")
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
     def test_cache_stats_are_logged(self, mock_cache, mock_logger):
         """_log_cache_stats must be invoked after every call."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get.return_value = MagicMock(is_found=False, value=None)
-        ctx, _ = _mock_ctx_and_cursor(fetchall=[('alice@example.com', 'run1', 0.9)])
-        path = 'enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection'
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[("alice@example.com", "run1", 0.9)])
+        path = "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
         with patch(path, return_value=ctx):
             _source().get_course_progress_map(
                 ENTERPRISE_UUID,
-                [{'user_email': 'alice@example.com', 'courserun_key': 'run1'}],
+                [{"user_email": "alice@example.com", "courserun_key": "run1"}],
             )
         assert mock_logger.info.call_count >= 1
 
@@ -347,23 +354,25 @@ class TestGetCourseProgressMap:
 # SnowflakeCoursePassingGradeSource — table / settings helpers
 # ===========================================================================
 
+
 class TestCourseOverviewsTable:
     """Fully-qualified course-overviews table resolution."""
 
     def test_default_course_overviews_table(self):
         assert _grade_source()._course_overviews_table() == DEFAULT_OVERVIEWS_TABLE
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.settings')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.settings")
     def test_custom_course_overviews_table(self, mock_settings):
-        mock_settings.LPR_SNOWFLAKE_LMS_DATABASE = 'STAGING'
-        mock_settings.LPR_SNOWFLAKE_LMS_SCHEMA = 'PUBLIC'
-        mock_settings.LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE = 'OVERVIEWS'
-        assert _grade_source()._course_overviews_table() == 'STAGING.PUBLIC.OVERVIEWS'
+        mock_settings.LPR_SNOWFLAKE_LMS_DATABASE = "STAGING"
+        mock_settings.LPR_SNOWFLAKE_LMS_SCHEMA = "PUBLIC"
+        mock_settings.LPR_SNOWFLAKE_COURSE_OVERVIEWS_TABLE = "OVERVIEWS"
+        assert _grade_source()._course_overviews_table() == "STAGING.PUBLIC.OVERVIEWS"
 
 
 # ===========================================================================
 # SnowflakeCoursePassingGradeSource — cache configuration
 # ===========================================================================
+
 
 class TestCoursePassingGradeCacheConfiguration:
     """Cache timeout values and key construction for passing grades."""
@@ -385,8 +394,10 @@ class TestCoursePassingGradeCacheConfiguration:
         assert _grade_source()._negative_cache_timeout() == 300
 
     def test_cache_key_includes_prefix_and_courserun(self):
-        key = SnowflakeCoursePassingGradeSource._cache_key('course-v1:Org+Run')
-        expected = get_key('lpr_course_passing_grade', DEFAULT_OVERVIEWS_TABLE, 'course-v1:Org+Run')
+        key = SnowflakeCoursePassingGradeSource._cache_key("course-v1:Org+Run")
+        expected = get_key(
+            "lpr_course_passing_grade", DEFAULT_OVERVIEWS_TABLE, "course-v1:Org+Run"
+        )
         assert key == expected
 
 
@@ -394,28 +405,37 @@ class TestCoursePassingGradeCacheConfiguration:
 # SnowflakeCoursePassingGradeSource — get_passing_grade_map
 # ===========================================================================
 
+
 class TestGetPassingGradeMap:
     """Behaviour of the main public method."""
 
     def test_returns_empty_dict_for_empty_input(self):
         assert not _grade_source().get_passing_grade_map([])
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
     def test_full_cache_hit_skips_snowflake(self, mock_cache):
         """All courseruns cached → Snowflake must not be called."""
         mock_cache.get_key.side_effect = get_key
-        gr_key = _passing_grade_cache_key('course-v1:Org+Course+Run')
+        gr_key = _passing_grade_cache_key("course-v1:Org+Course+Run")
         mock_cache.get_many.return_value = {gr_key: 0.6}
 
-        result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+        result = _grade_source().get_passing_grade_map(["course-v1:Org+Course+Run"])
 
-        assert result == {'course-v1:Org+Course+Run': 0.6}
+        assert result == {"course-v1:Org+Course+Run": 0.6}
         mock_cache.set_many.assert_not_called()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_absent_keys_stored_as_none_under_negative_ttl(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_absent_keys_stored_as_none_under_negative_ttl(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """Keys not returned by Snowflake are stored as None with the negative TTL."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get_many.return_value = {}  # Cache miss
@@ -423,25 +443,36 @@ class TestGetPassingGradeMap:
         ctx, _ = _mock_ctx_and_cursor(fetchall=[])
         mock_connection_factory.return_value = ctx
 
-        result = _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+        result = _grade_source().get_passing_grade_map(["course-v1:Org+Course+Run"])
 
-        assert result == {'course-v1:Org+Course+Run': None}
+        assert result == {"course-v1:Org+Course+Run": None}
         mock_cache.set_many.assert_called_once()
         call_args = mock_cache.set_many.call_args
         cache_writes = call_args[0][0]  # First positional argument
-        run_key = _passing_grade_cache_key('course-v1:Org+Course+Run')
+        run_key = _passing_grade_cache_key("course-v1:Org+Course+Run")
         assert cache_writes[run_key] is None
-        assert call_args[1]['timeout'] == DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT
+        assert (
+            call_args[1]["timeout"]
+            == DEFAULT_COURSE_PASSING_GRADE_NEGATIVE_CACHE_TIMEOUT
+        )
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_mixed_cache_hit_and_miss(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_mixed_cache_hit_and_miss(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """Cached and fetched values are merged correctly."""
         mock_cache.get_key.side_effect = get_key
 
-        cached_key = 'course-v1:Org+Cached+Run'
-        uncached_key = 'course-v1:Org+Uncached+Run'
+        cached_key = "course-v1:Org+Cached+Run"
+        uncached_key = "course-v1:Org+Uncached+Run"
 
         cached_cache_key = _passing_grade_cache_key(cached_key)
         uncached_cache_key = _passing_grade_cache_key(uncached_key)
@@ -458,50 +489,74 @@ class TestGetPassingGradeMap:
         call_args = mock_cache.set_many.call_args
         cache_writes = call_args[0][0]  # First positional argument
         assert cache_writes[uncached_cache_key] == 0.55
-        assert call_args[1]['timeout'] == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
+        assert call_args[1]["timeout"] == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_positive_values_use_24h_timeout(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_positive_values_use_24h_timeout(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """Positive cache writes must use the 24-hour TTL."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get_many.return_value = {}  # Cache miss
 
-        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[("course-v1:Org+Course+Run", 0.7)])
         mock_connection_factory.return_value = ctx
 
-        _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+        _grade_source().get_passing_grade_map(["course-v1:Org+Course+Run"])
 
         mock_cache.set_many.assert_called_once()
-        timeout_arg = mock_cache.set_many.call_args[1].get('timeout')
+        timeout_arg = mock_cache.set_many.call_args[1].get("timeout")
         assert timeout_arg == DEFAULT_COURSE_PASSING_GRADE_CACHE_TIMEOUT
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_single_key_cache_operations_used(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_single_key_cache_operations_used(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """Each missing key should be cached through the batch cache API."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get_many.return_value = {}  # Cache miss
 
-        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-v1:Org+Course+Run', 0.7)])
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[("course-v1:Org+Course+Run", 0.7)])
         mock_connection_factory.return_value = ctx
 
-        _grade_source().get_passing_grade_map(['course-v1:Org+Course+Run'])
+        _grade_source().get_passing_grade_map(["course-v1:Org+Course+Run"])
 
         mock_cache.get_many.assert_called_once()
         mock_cache.set_many.assert_called_once()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_large_key_set_uses_single_query(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_large_key_set_uses_single_query(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """All keys must be fetched in one SQL statement regardless of batch size."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get.return_value = MagicMock(is_found=False, value=None)
 
-        keys = [f'course-{i}' for i in range(1, 6)]
+        keys = [f"course-{i}" for i in range(1, 6)]
         rows = [(k, round(0.1 * i, 1)) for i, k in enumerate(keys, 1)]
         ctx, cursor = _mock_ctx_and_cursor(fetchall=rows)
         mock_connection_factory.return_value = ctx
@@ -511,64 +566,195 @@ class TestGetPassingGradeMap:
         assert result == {k: round(0.1 * i, 1) for i, k in enumerate(keys, 1)}
         assert cursor.execute.call_count == 1
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_duplicate_keys_deduplicated(self, _table, mock_connection_factory, mock_cache):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_duplicate_keys_deduplicated(
+        self, _table, mock_connection_factory, mock_cache
+    ):
         """Duplicate courserun keys must be deduplicated before querying."""
         mock_cache.get_key.side_effect = get_key
         mock_cache.get.return_value = MagicMock(is_found=False, value=None)
 
-        ctx, cursor = _mock_ctx_and_cursor(fetchall=[('course-1', 0.6)])
+        ctx, cursor = _mock_ctx_and_cursor(fetchall=[("course-1", 0.6)])
         mock_connection_factory.return_value = ctx
 
-        result = _grade_source().get_passing_grade_map(['course-1', 'course-1', 'course-1'])
+        result = _grade_source().get_passing_grade_map(
+            ["course-1", "course-1", "course-1"]
+        )
 
-        assert result == {'course-1': 0.6}
+        assert result == {"course-1": 0.6}
         _, params = cursor.execute.call_args[0]
-        assert params.count('course-1') == 1
+        assert params.count("course-1") == 1
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_cursor_and_connection_closed_on_success(self, _table, mock_connection_factory):
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_cursor_and_connection_closed_on_success(
+        self, _table, mock_connection_factory
+    ):
         ctx, cursor = _mock_ctx_and_cursor(fetchall=[])
         mock_connection_factory.return_value = ctx
 
-        _grade_source()._fetch_passing_grades(['course-v1:Org+Course+Run'])
+        _grade_source()._fetch_passing_grades(["course-v1:Org+Course+Run"])
 
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_cursor_and_connection_closed_on_execute_error(self, _table, mock_connection_factory):
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_cursor_and_connection_closed_on_execute_error(
+        self, _table, mock_connection_factory
+    ):
         ctx, cursor = _mock_ctx_and_cursor()
-        cursor.execute.side_effect = RuntimeError('Snowflake error')
+        cursor.execute.side_effect = RuntimeError("Snowflake error")
         mock_connection_factory.return_value = ctx
 
-        with pytest.raises(RuntimeError, match='Snowflake error'):
-            _grade_source()._fetch_passing_grades(['course-v1:Org+Course+Run'])
+        with pytest.raises(RuntimeError, match="Snowflake error"):
+            _grade_source()._fetch_passing_grades(["course-v1:Org+Course+Run"])
 
         cursor.close.assert_called_once()
         ctx.close.assert_called_once()
 
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake.cache')
-    @patch('enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection')
-    @patch.object(SnowflakeCoursePassingGradeSource, '_course_overviews_table', return_value=DEFAULT_OVERVIEWS_TABLE)
-    def test_logs_cache_and_fetch_observability(self, _table, mock_connection_factory, mock_cache, mock_logger):
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.LOGGER")
+    @patch("enterprise_data.api.v1.views.lpr_data_source_snowflake.cache")
+    @patch(
+        "enterprise_data.api.v1.views.lpr_data_source_snowflake._get_snowflake_connection"
+    )
+    @patch.object(
+        SnowflakeCoursePassingGradeSource,
+        "_course_overviews_table",
+        return_value=DEFAULT_OVERVIEWS_TABLE,
+    )
+    def test_logs_cache_and_fetch_observability(
+        self, _table, mock_connection_factory, mock_cache, mock_logger
+    ):
         """At least three LOGGER.info calls expected (requested/cached/missing + fetched stats)."""
         mock_cache.get_key.side_effect = get_key
 
         def cache_side_effect(cache_key):
-            if cache_key == _passing_grade_cache_key('course-1'):
+            if cache_key == _passing_grade_cache_key("course-1"):
                 return MagicMock(is_found=True, value=0.5)
             return MagicMock(is_found=False, value=None)
+
         mock_cache.get.side_effect = cache_side_effect
 
-        ctx, _ = _mock_ctx_and_cursor(fetchall=[('course-2', 0.6)])
+        ctx, _ = _mock_ctx_and_cursor(fetchall=[("course-2", 0.6)])
         mock_connection_factory.return_value = ctx
 
-        _grade_source().get_passing_grade_map(['course-1', 'course-2'])
+        _grade_source().get_passing_grade_map(["course-1", "course-2"])
 
         assert mock_logger.info.call_count >= 3
+
+
+# ===========================================================================
+# _get_snowflake_connection — credential validation and key loading
+# ===========================================================================
+
+
+class TestGetSnowflakeConnection:
+    """Tests for the module-level private-key connection factory."""
+
+    # _mock_connector is set in the autouse fixture (pytest fixture pattern).
+    # pylint: disable=attribute-defined-outside-init
+
+    @pytest.fixture(autouse=True)
+    def _patch_crypto_and_connector(self, monkeypatch):
+        """Patch crypto libs and Snowflake connector so the real function can be called."""
+        self._mock_connector = MagicMock()
+        monkeypatch.setattr(_lpr_module, "_snowflake", SimpleNamespace(connector=self._mock_connector))
+
+        mock_key = MagicMock()
+        mock_key.private_bytes.return_value = b"DER_BYTES"
+        mock_ser = MagicMock()
+        mock_ser.load_pem_private_key.return_value = mock_key
+        monkeypatch.setattr(_lpr_module, "_serialization", mock_ser)
+        monkeypatch.setattr(_lpr_module, "_default_backend", MagicMock(return_value="backend"))
+
+    @pytest.mark.parametrize(
+        "overrides,missing_field",
+        [
+            ({"SNOWFLAKE_SERVICE_USER": ""}, "SNOWFLAKE_SERVICE_USER"),
+            ({"SNOWFLAKE_SERVICE_PRIVKEY": ""}, "SNOWFLAKE_SERVICE_PRIVKEY"),
+            ({"SNOWFLAKE_SERVICE_PASSPHRASE": ""}, "SNOWFLAKE_SERVICE_PASSPHRASE"),
+        ],
+    )
+    def test_raises_on_missing_credentials(self, overrides, missing_field):
+        """ValueError is raised when any required credential setting is absent."""
+        base = {
+            "SNOWFLAKE_SERVICE_USER": "svc",
+            "SNOWFLAKE_SERVICE_PRIVKEY": "pem",
+            "SNOWFLAKE_SERVICE_PASSPHRASE": "pass",
+        }
+        base.update(overrides)
+        with override_settings(**base):
+            with pytest.raises(ValueError, match=missing_field):
+                _get_snowflake_connection()
+
+    def test_loads_pem_key_and_connects(self):
+        """Happy path: loads PEM key, converts to DER, calls connector.connect."""
+        with override_settings(
+            SNOWFLAKE_SERVICE_USER="svc_user",
+            SNOWFLAKE_SERVICE_PRIVKEY="-----BEGIN ENCRYPTED PRIVATE KEY-----\nfake",
+            SNOWFLAKE_SERVICE_PASSPHRASE="s3cr3t",
+            SNOWFLAKE_ACCOUNT="myaccount",
+            SNOWFLAKE_ROLE="MY_ROLE",
+        ):
+            _get_snowflake_connection()
+        self._mock_connector.connect.assert_called_once_with(
+            user="svc_user",
+            account="myaccount",
+            private_key=b"DER_BYTES",
+            role="MY_ROLE",
+        )
+
+    def test_warehouse_passed_when_provided(self):
+        """warehouse kwarg is forwarded to connector.connect when non-None."""
+        with override_settings(
+            SNOWFLAKE_SERVICE_USER="u",
+            SNOWFLAKE_SERVICE_PRIVKEY="pem",
+            SNOWFLAKE_SERVICE_PASSPHRASE="p",
+        ):
+            _get_snowflake_connection(warehouse="MY_WH")
+        call_kwargs = self._mock_connector.connect.call_args[1]
+        assert call_kwargs.get("warehouse") == "MY_WH"
+
+    def test_warehouse_omitted_when_none(self):
+        """No ``warehouse`` key in connector.connect kwargs when warehouse=None."""
+        with override_settings(
+            SNOWFLAKE_SERVICE_USER="u",
+            SNOWFLAKE_SERVICE_PRIVKEY="pem",
+            SNOWFLAKE_SERVICE_PASSPHRASE="p",
+        ):
+            _get_snowflake_connection(warehouse=None)
+        call_kwargs = self._mock_connector.connect.call_args[1]
+        assert "warehouse" not in call_kwargs
+
+    def test_role_override_forwarded(self):
+        """Explicit role kwarg overrides the settings default."""
+        with override_settings(
+            SNOWFLAKE_SERVICE_USER="u",
+            SNOWFLAKE_SERVICE_PRIVKEY="pem",
+            SNOWFLAKE_SERVICE_PASSPHRASE="p",
+            SNOWFLAKE_ROLE="DEFAULT_ROLE",
+        ):
+            _get_snowflake_connection(role="CUSTOM_ROLE")
+        call_kwargs = self._mock_connector.connect.call_args[1]
+        assert call_kwargs["role"] == "CUSTOM_ROLE"

--- a/enterprise_reporting/clients/snowflake.py
+++ b/enterprise_reporting/clients/snowflake.py
@@ -3,34 +3,86 @@ Client for connecting to a Snowflake database.
 """
 
 import datetime
-import os
-from logging import getLogger
+import logging
+from types import SimpleNamespace
 
-from snowflake import connector
+from django.conf import settings
 
-LOGGER = getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
+
+try:
+    import snowflake.connector as _snowflake_connector
+except ImportError:  # pragma: no cover
+    _snowflake_connector = None
+
+_snowflake = SimpleNamespace(connector=_snowflake_connector)
+
+try:
+    from cryptography.hazmat.backends import default_backend as _default_backend
+    from cryptography.hazmat.primitives import serialization as _serialization
+except ImportError:  # pragma: no cover
+    _default_backend = None  # type: ignore[assignment]
+    _serialization = None  # type: ignore[assignment]
+
+
+def _get_snowflake_connection():
+    """
+    Open and return a Snowflake connection using private-key authentication.
+
+    Credentials are read from Django settings.  Required settings:
+    ``SNOWFLAKE_SERVICE_USER``, ``SNOWFLAKE_SERVICE_PRIVKEY``,
+    ``SNOWFLAKE_SERVICE_PASSPHRASE``.
+
+    Raises:
+        ImportError: When snowflake-connector-python is not installed.
+        ValueError: When required credential settings are absent.
+    """
+    if _snowflake.connector is None:
+        raise ImportError('snowflake-connector-python is required')
+
+    user = getattr(settings, 'SNOWFLAKE_SERVICE_USER', None)
+    key_pem = getattr(settings, 'SNOWFLAKE_SERVICE_PRIVKEY', None)
+    passphrase = getattr(settings, 'SNOWFLAKE_SERVICE_PASSPHRASE', None)
+    account = getattr(settings, 'SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
+    role = getattr(settings, 'SNOWFLAKE_ROLE', 'ENTERPRISE_SERVICE_USER_ROLE')
+
+    if not user:
+        raise ValueError('SNOWFLAKE_SERVICE_USER must be configured')
+    if not key_pem:
+        raise ValueError('SNOWFLAKE_SERVICE_PRIVKEY must be configured')
+    if not passphrase:
+        raise ValueError('SNOWFLAKE_SERVICE_PASSPHRASE must be configured')
+
+    key_data = key_pem.encode() if isinstance(key_pem, str) else key_pem
+    private_key = _serialization.load_pem_private_key(
+        key_data,
+        password=passphrase.encode() if isinstance(passphrase, str) else passphrase,
+        backend=_default_backend(),
+    )
+    private_key_bytes = private_key.private_bytes(
+        encoding=_serialization.Encoding.DER,
+        format=_serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=_serialization.NoEncryption(),
+    )
+    return _snowflake.connector.connect(
+        user=user,
+        account=account,
+        private_key=private_key_bytes,
+        role=role,
+    )
 
 
 class SnowflakeClient:
     """
-    Client for connecting to Snowflake.
+    Client for connecting to Snowflake using private-key authentication.
+
+    Credentials (private-key PEM and passphrase) are read from Django settings
+    by the module-level ``_get_snowflake_connection`` factory.  Required settings:
+    ``SNOWFLAKE_SERVICE_USER``, ``SNOWFLAKE_SERVICE_PRIVKEY``,
+    ``SNOWFLAKE_SERVICE_PASSPHRASE``.
     """
 
-    def __init__(self, username=None, password=None, account=None):
-        """
-        Instantiate a new client using the Django settings to determine the Snowflake credentials.
-        If there are none configured, throw an exception.
-        """
-        username = username or os.environ['SNOWFLAKE_USERNAME']
-        password = password or os.environ['SNOWFLAKE_PASSWORD']
-        account = account or os.environ['SNOWFLAKE_ACCOUNT']
-
-        self.connection_info = {
-            'user': username,
-            'password': password,
-            'account': account,
-        }
-
+    def __init__(self):
         self.connection = None
         self.cursor = None
 
@@ -38,7 +90,7 @@ class SnowflakeClient:
         """
         Open a connection to Snowflake.
         """
-        self.connection = connector.connect(**self.connection_info)
+        self.connection = _get_snowflake_connection()
         self.cursor = self.connection.cursor()
 
     def close_connection(self):

--- a/enterprise_reporting/tests/test_clients.py
+++ b/enterprise_reporting/tests/test_clients.py
@@ -2,13 +2,13 @@
 Tests for clients in enterprise_reporting.
 """
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import urljoin
 
 import responses
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from enterprise_reporting.clients.enterprise import EnterpriseAPIClient, EnterpriseCatalogAPIClient
 
@@ -212,3 +212,120 @@ class TestEnterpriseCatalogAPIClient(TestCase):
             results = self.client.get_content_metadata(request_catalogs)
         except Exception as e:
             self.assertEqual(str(e), expected_error_message)
+
+
+class TestGetSnowflakeConnectionReporting(TestCase):
+    """Tests for the module-level _get_snowflake_connection in enterprise_reporting."""
+
+    _MODULE = 'enterprise_reporting.clients.snowflake'
+
+    def _patch_snowflake(self, connector=None):
+        """Return a context manager that replaces the module-level _snowflake namespace."""
+        from types import SimpleNamespace
+        mock_connector = connector or MagicMock()
+        mock_conn = MagicMock()
+        mock_connector.connect.return_value = mock_conn
+        ns = SimpleNamespace(connector=mock_connector)
+        return patch(f'{self._MODULE}._snowflake', ns), mock_connector, mock_conn
+
+    @patch(f'{_MODULE}._serialization')
+    @patch(f'{_MODULE}._default_backend')
+    @override_settings(
+        SNOWFLAKE_SERVICE_USER='svc_user',
+        SNOWFLAKE_SERVICE_PRIVKEY='-----BEGIN ENCRYPTED PRIVATE KEY-----\nfake\n-----END ENCRYPTED PRIVATE KEY-----',
+        SNOWFLAKE_SERVICE_PASSPHRASE='s3cr3t',
+        SNOWFLAKE_ACCOUNT='myaccount',
+        SNOWFLAKE_ROLE='MY_ROLE',
+    )
+    def test_connects_with_private_key(self, mock_backend, mock_serialization):
+        """_get_snowflake_connection loads the PEM key and calls connector.connect."""
+        from enterprise_reporting.clients.snowflake import _get_snowflake_connection
+        mock_key = MagicMock()
+        mock_serialization.load_pem_private_key.return_value = mock_key
+        mock_key.private_bytes.return_value = b'DER_BYTES'
+        mock_connector = MagicMock()
+        patcher, _, _ = self._patch_snowflake(connector=mock_connector)
+        with patcher:
+            _get_snowflake_connection()
+        mock_connector.connect.assert_called_once_with(
+            user='svc_user',
+            account='myaccount',
+            private_key=b'DER_BYTES',
+            role='MY_ROLE',
+        )
+
+    @override_settings(SNOWFLAKE_SERVICE_USER='', SNOWFLAKE_SERVICE_PRIVKEY='k', SNOWFLAKE_SERVICE_PASSPHRASE='p')
+    def test_raises_when_user_missing(self):
+        from enterprise_reporting.clients.snowflake import _get_snowflake_connection
+        with self.assertRaises(ValueError, msg='SNOWFLAKE_SERVICE_USER must be configured'):
+            _get_snowflake_connection()
+
+    @override_settings(SNOWFLAKE_SERVICE_USER='u', SNOWFLAKE_SERVICE_PRIVKEY='', SNOWFLAKE_SERVICE_PASSPHRASE='p')
+    def test_raises_when_privkey_missing(self):
+        from enterprise_reporting.clients.snowflake import _get_snowflake_connection
+        with self.assertRaises(ValueError, msg='SNOWFLAKE_SERVICE_PRIVKEY must be configured'):
+            _get_snowflake_connection()
+
+    @override_settings(SNOWFLAKE_SERVICE_USER='u', SNOWFLAKE_SERVICE_PRIVKEY='k', SNOWFLAKE_SERVICE_PASSPHRASE='')
+    def test_raises_when_passphrase_missing(self):
+        from enterprise_reporting.clients.snowflake import _get_snowflake_connection
+        with self.assertRaises(ValueError, msg='SNOWFLAKE_SERVICE_PASSPHRASE must be configured'):
+            _get_snowflake_connection()
+
+
+class TestSnowflakeClient(TestCase):
+    """Tests for the Snowflake client used in enterprise_reporting."""
+
+    _PATCH = 'enterprise_reporting.clients.snowflake._get_snowflake_connection'
+
+    def _make_connection(self, rows=None):
+        """Return a mock Snowflake connection whose cursor yields *rows*."""
+        cursor = MagicMock()
+        cursor.execute.return_value = iter(rows or [])
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        return conn, cursor
+
+    @patch(_PATCH)
+    def test_connect_opens_connection_and_cursor(self, mock_factory):
+        """connect() stores connection and cursor on the instance."""
+        from enterprise_reporting.clients.snowflake import SnowflakeClient
+        conn, cursor = self._make_connection()
+        mock_factory.return_value = conn
+
+        client = SnowflakeClient()
+        client.connect()
+
+        mock_factory.assert_called_once_with()
+        assert client.connection is conn
+        assert client.cursor is cursor
+
+    @patch(_PATCH)
+    def test_close_connection_closes_cursor_and_connection(self, mock_factory):
+        """close_connection() closes both and resets them to None."""
+        from enterprise_reporting.clients.snowflake import SnowflakeClient
+        conn, cursor = self._make_connection()
+        mock_factory.return_value = conn
+
+        client = SnowflakeClient()
+        client.connect()
+        client.close_connection()
+
+        cursor.close.assert_called_once()
+        conn.close.assert_called_once()
+        assert client.connection is None
+        assert client.cursor is None
+
+    @patch(_PATCH)
+    def test_stream_results_yields_formatted_rows(self, mock_factory):
+        """stream_results() formats datetime values and passes others through."""
+        from enterprise_reporting.clients.snowflake import SnowflakeClient
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        conn, cursor = self._make_connection(rows=[(dt, 'hello', 42)])
+        mock_factory.return_value = conn
+
+        client = SnowflakeClient()
+        client.connect()
+        rows = list(client.stream_results('SELECT 1'))
+
+        assert rows == [['2024-01-15 10:30:00', 'hello', 42]]


### PR DESCRIPTION
ENT-11788 — Migrate Snowflake Authentication to Private Key + Passphrase

Summary
This PR migrates Snowflake authentication for ENTERPRISE_SERVICE_USER from username/password to private-key + passphrase (PKCS8/DER) across all connection points.

It also introduces a shared connection factory to centralize credential handling and eliminate duplication.
Updated table from learne_ progress_report_internal to learne_ progress_report_external .

Refactoring
- Single source of truth for Snowflake connections
- Removed inline auth from lpr_data_source_snowflake.py
- Updated SnowflakeClient in enterprise_reporting



Config Changes
- Removed: SNOWFLAKE_SERVICE_USER_PASSWORD
- Added: SNOWFLAKE_SERVICE_PRIVKEY
- Added: SNOWFLAKE_SERVICE_PASSPHRASE
- Unchanged: SNOWFLAKE_SERVICE_USER, SNOWFLAKE_ACCOUNT

Testing
All unit tests pass with mocks (no Snowflake/AWS required)

Test Plan
- Unit tests passing
- Code quality checks clean
- Manual validation complete
- Validate course_progress and course_passing_grade in staging

Impact
- Improved security (no password auth)
- Reduced duplication
- No disruption expected to LPR or reporting

Next Steps
- Deploy to staging and production
- Validate authentication in Snowflake query history
- Confirm with Data Platform team
Test results:
<img width="1215" height="368" alt="image" src="https://github.com/user-attachments/assets/bb15d6ae-48f6-463d-bfc3-2aa5c2b5b8e0" />
