### PR TITLE
feat: add segmented engagement fields to individual engagements API and CSV

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[10.22.8] - 2026-06-17
+-----------------------
+  * feat: add segmented engagement fields to individual engagements API and CSV
+
 [10.22.7] - 2026-06-16
 -----------------------
   * feat: add private_key and passphrase authenticate snowflake connection

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 [10.22.8] - 2026-06-17
 -----------------------
   * feat: add segmented engagement fields to individual engagements API and CSV
+  * fix: handle escaped newlines in Snowflake private key for LPR data source authentication
 
 [10.22.7] - 2026-06-16
 -----------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.7"
+__version__ = "10.22.8"

--- a/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
@@ -40,7 +40,8 @@ class FactEngagementAdminDashQueries:
         return f"""
             SELECT
                 email, course_title, course_subject, enroll_type, activity_date,
-                learning_time_seconds/3600 as learning_time_hours
+                learning_time_seconds/3600 as learning_time_hours,
+                is_engaged_video, is_engaged_forum, is_engaged_problem
             FROM fact_enrollment_engagement_day_admin_dash
             WHERE {query_filters.to_sql()}
             ORDER BY activity_date DESC LIMIT %(limit)s OFFSET %(offset)s;

--- a/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
+++ b/enterprise_data/api/v1/views/lpr_data_source_snowflake.py
@@ -118,7 +118,7 @@ def _get_snowflake_connection(warehouse=None, role=None):
     if not passphrase:
         raise ValueError('SNOWFLAKE_SERVICE_PASSPHRASE must be configured')
 
-    key_data = key_pem.encode() if isinstance(key_pem, str) else key_pem
+    key_data = key_pem.replace("\\n", "\n").encode() if isinstance(key_pem, str) else key_pem
     private_key = _serialization.load_pem_private_key(
         key_data,
         password=passphrase.encode() if isinstance(passphrase, str) else passphrase,

--- a/enterprise_data/renderers.py
+++ b/enterprise_data/renderers.py
@@ -73,6 +73,9 @@ class IndividualEngagementsCSVRenderer(CSVStreamingRenderer):
         'enroll_type',
         'activity_date',
         'learning_time_hours',
+        'is_engaged_video',
+        'is_engaged_forum',
+        'is_engaged_problem',
     ]
 
 

--- a/enterprise_data/tests/admin_analytics/test_analytics_engagements.py
+++ b/enterprise_data/tests/admin_analytics/test_analytics_engagements.py
@@ -115,27 +115,30 @@ class TestIndividualEngagementsAPI(JWTTestMixin, APITransactionTestCase):
         assert len(content) == 5
 
         # Verify CSV header.
-        assert 'email,course_title,course_subject,enroll_type,activity_date,learning_time_hours' == content[0]
+        assert (
+            'email,course_title,course_subject,enroll_type,activity_date,learning_time_hours,'
+            'is_engaged_video,is_engaged_forum,is_engaged_problem'
+        ) == content[0]
 
         # verify the content
         assert (
                 'padillamichelle@example.org,Synergized reciprocal encoding,business-management,certificate,2021-08-05,'
-                '1.0344444444444445'
+                '1.0344444444444445,1,0,1'
                 in content
         )
         assert (
                 'yallison@example.org,Synergized reciprocal encoding,business-management,certificate,2021-07-27,'
-                '1.2041666666666666'
+                '1.2041666666666666,1,0,1'
                 in content
         )
         assert (
                 'weaverpatricia@example.net,Synergized reciprocal encoding,business-management,certificate,2021-08-05,'
-                '2.6225'
+                '2.6225,1,0,1'
                 in content
         )
         assert (
                 'seth57@example.org,Synergized reciprocal encoding,business-management,certificate,2021-08-21,'
-                '2.7494444444444444'
+                '2.7494444444444444,1,1,1'
                 in content
         )
 


### PR DESCRIPTION
## Description

ENT-11807 — The revamped analytics Engagement tab is missing the **Individual Engagements** data table from the old analytics page, and its CSV download is missing the segmented engagement data.

## Changes

- `admin_analytics/database/queries/fact_engagement_admin_dash.py` — add the three segmented fields to `get_all_engagement_query`.
- `renderers.py` — add the three fields to `IndividualEngagementsCSVRenderer.header` so they appear in the CSV download.
- The JSON response from `GET /engagements` automatically includes the new fields (records returned as raw dicts), so no view changes were needed.
- Updated `test_get_csv` assertions (header + rows).
- Version bump to 10.22.8 + CHANGELOG entry.

## Testing

- `pytest enterprise_data/tests/admin_analytics/` → 24 passed.
- Lint clean (pycodestyle / isort / pylint).

