### PR TITLE
fix: Fix is added to remove the unlinked users from LPR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[10.22.10] - 2026-07-16
+-----------------------
+  * fix: Remove unlinked users from Learner Progress Report
+
 [10.22.9] - 2026-06-17
 -----------------------
   * feat: Remove deprecated analytics filter

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.9"
+__version__ = "10.22.10"

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -101,7 +101,8 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         # always includes `course_progress` and `course_passing_grade`; real
         # values are merged in later from Snowflake during enrichment.
         enrollments = EnterpriseLearnerEnrollment.objects.filter(
-            enterprise_customer_uuid=enterprise_customer_uuid
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            enterprise_user__is_linked=True,
         ).extra(select={
             'course_progress': 'NULL',
             'course_passing_grade': 'NULL',
@@ -396,7 +397,10 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         """
         Returns number of enterprise users (enrolled AND not enrolled learners)
         """
-        return EnterpriseLearner.objects.filter(enterprise_customer_uuid=self.kwargs['enterprise_id'])
+        return EnterpriseLearner.objects.filter(
+            enterprise_customer_uuid=self.kwargs['enterprise_id'],
+            is_linked=True,
+        )
 
     def get_max_created_date(self, queryset):
         """

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -237,6 +237,60 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
         self.assertEqual(response.data['results'][0]['enrollment_id'], enrollment.enrollment_id)
         self.assertEqual(response.data['results'][0]['course_progress'], 0.87)
 
+    def test_list_excludes_enrollments_of_unlinked_learners(self):
+        """
+        Test that the enrollment list endpoint excludes enrollments belonging to unlinked learners.
+        """
+        linked_learner = EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_linked=True,
+        )
+        unlinked_learner = EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_linked=False,
+        )
+        linked_enrollment = EnterpriseLearnerEnrollmentFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_consent_granted=True,
+            enterprise_user_id=linked_learner.enterprise_user_id,
+        )
+        EnterpriseLearnerEnrollmentFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_consent_granted=True,
+            enterprise_user_id=unlinked_learner.enterprise_user_id,
+        )
+
+        url = reverse('v1:enterprise-learner-enrollment-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()['results']
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['enrollment_id'], linked_enrollment.enrollment_id)
+
+    def test_overview_number_of_users_excludes_unlinked_learners(self):
+        """
+        Test that `number_of_users` in the overview response only counts learners with `is_linked=True`.
+        """
+        EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_linked=True,
+        )
+        EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_linked=True,
+        )
+        EnterpriseLearnerFactory(
+            enterprise_customer_uuid=self.enterprise_id,
+            is_linked=False,
+        )
+
+        url = reverse('v1:enterprise-learner-enrollment-overview', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['number_of_users'], 2)
+
     @mock.patch('enterprise_data.api.v1.views.enterprise_learner.SnowflakeCourseProgressSource')
     def test_list_returns_200_when_snowflake_enrichment_fails(self, mock_source_cls):
         enterprise_learner = EnterpriseLearnerFactory(
@@ -334,7 +388,10 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
 
         result = viewset.get_queryset()
 
-        mock_filter.assert_called_once_with(enterprise_customer_uuid=self.enterprise_id)
+        mock_filter.assert_called_once_with(
+            enterprise_customer_uuid=self.enterprise_id,
+            enterprise_user__is_linked=True,
+        )
         enrollments.extra.assert_called_once_with(select={
             'course_progress': 'NULL',
             'course_passing_grade': 'NULL',

--- a/enterprise_data/tests/test_utils.py
+++ b/enterprise_data/tests/test_utils.py
@@ -135,7 +135,7 @@ class EnterpriseLearnerFactory(factory.django.DjangoModelFactory):
     lms_user_id = factory.lazy_attribute(
         lambda x: FAKER.random_int(min=1, max=999999)  # pylint: disable=no-member
     )
-    is_linked = FAKER.pybool()
+    is_linked = True
     user_username = factory.Sequence('robot{}'.format)
     user_email = factory.lazy_attribute(lambda x: FAKER.email())  # pylint: disable=no-member
     lms_user_created = FAKER.past_datetime(start_date='-60d')


### PR DESCRIPTION

JIRA ticket:https://2u-internal.atlassian.net/browse/ENT-10867
## Summary
Filters the Learner Progress Report (LPR) enrollment query to exclude unlinked learners (`enterprise_user__is_linked=True`), so only active/linked users are shown.

## Test plan
- [x] Updated `test_views.py` to assert the new filter is applied
- [x] `EnterpriseLearnerFactory.is_linked` now defaults to `True` (was random) so test data reflects real linked users
- [ ] Manually verified in devstack: seeded linked/unlinked learners for `test-enterprise`, confirmed unlinked ones no longer appear in LPR results
Test results:
<img width="1216" height="551" alt="image" src="https://github.com/user-attachments/assets/1b89b05c-eb91-4b57-8550-28673dbc7ea6" />
