### PR TITLE
fix: Align learning hours calculation between engagement metrics and …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[10.22.11] - 2026-07-22
+-----------------------
+  * fix: align engagement metrics learning-hours aggregation with leaderboard totals
+
 [10.22.10] - 2026-07-16
 -----------------------
   * fix: Remove unlinked users from Learner Progress Report

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.10"
+__version__ = "10.22.11"

--- a/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
+++ b/enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py
@@ -15,10 +15,19 @@ class FactEngagementAdminDashQueries:
         Get the query to fetch the learning hours and daily sessions.
         """
         return f"""
+            WITH learner_engagement AS (
+                SELECT
+                    email,
+                    ROUND(SUM(learning_time_seconds) / 60 / 60, 1) as learning_time_hours,
+                    SUM(is_engaged) as sessions
+                FROM fact_enrollment_engagement_day_admin_dash
+                WHERE {query_filters.to_sql()}
+                GROUP BY email
+            )
             SELECT
-                ROUND(SUM(learning_time_seconds) / 60 / 60, 1) as hours, SUM(is_engaged) as sessions
-            FROM fact_enrollment_engagement_day_admin_dash
-            WHERE {query_filters.to_sql()};
+                ROUND(SUM(learning_time_hours), 1) as hours,
+                SUM(sessions) as sessions
+            FROM learner_engagement;
         """
 
     @staticmethod

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -103,6 +103,16 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
             end_date='2021-12-31',
         )
 
+    def test_learning_hours_query_uses_learner_level_rollup(self):
+        """
+        Engagement hours should match leaderboard semantics by rolling up per learner first.
+        """
+        query = self.engagement_queries.get_learning_hours_and_daily_sessions_query(self.engagement_query_filters)
+
+        assert 'GROUP BY email' in query
+        assert 'ROUND(SUM(learning_time_seconds) / 60 / 60, 1) as learning_time_hours' in query
+        assert 'ROUND(SUM(learning_time_hours), 1) as hours' in query
+
     def _mock_run_query(self, query, *args, **kwargs):
         """
         mock implementation of run_query.

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -1,8 +1,8 @@
 """
 Test cases for enterprise_admin views
 """
-from datetime import datetime
 import sqlite3
+from datetime import datetime
 from unittest import mock
 
 import ddt
@@ -108,12 +108,12 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
         """
         Learning hours should be rounded for each learner before calculating
         the enterprise total.
-    
+
         Each learner has 1584 seconds, which is 0.44 hours and rounds to 0.4.
         Therefore, the final total should be 0.8 rather than 0.9.
         """
         connection = sqlite3.connect(':memory:')
-    
+
         try:
             connection.execute(
                 """
@@ -124,7 +124,7 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
                 )
                 """
             )
-    
+
             connection.executemany(
                 """
                 INSERT INTO fact_enrollment_engagement_day_admin_dash (
@@ -139,17 +139,17 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
                     ('learner2@example.com', 1584, 1),
                 ],
             )
-    
+
             query_filters = mock.Mock()
             query_filters.to_sql.return_value = '1 = 1'
-    
+
             query = (
                 self.engagement_queries
                 .get_learning_hours_and_daily_sessions_query(query_filters)
             )
-    
+
             result = connection.execute(query).fetchone()
-    
+
             assert result[0] == 0.8
             assert result[1] == 2
         finally:

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -2,6 +2,7 @@
 Test cases for enterprise_admin views
 """
 from datetime import datetime
+import sqlite3
 from unittest import mock
 
 import ddt
@@ -103,15 +104,56 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
             end_date='2021-12-31',
         )
 
-    def test_learning_hours_query_uses_learner_level_rollup(self):
+    def test_learning_hours_rounds_each_learner_before_summing(self):
         """
-        Engagement hours should match leaderboard semantics by rolling up per learner first.
+        Learning hours should be rounded for each learner before calculating
+        the enterprise total.
+    
+        Each learner has 1584 seconds, which is 0.44 hours and rounds to 0.4.
+        Therefore, the final total should be 0.8 rather than 0.9.
         """
-        query = self.engagement_queries.get_learning_hours_and_daily_sessions_query(self.engagement_query_filters)
-
-        assert 'GROUP BY email' in query
-        assert 'ROUND(SUM(learning_time_seconds) / 60 / 60, 1) as learning_time_hours' in query
-        assert 'ROUND(SUM(learning_time_hours), 1) as hours' in query
+        connection = sqlite3.connect(':memory:')
+    
+        try:
+            connection.execute(
+                """
+                CREATE TABLE fact_enrollment_engagement_day_admin_dash (
+                    email TEXT,
+                    learning_time_seconds REAL,
+                    is_engaged INTEGER
+                )
+                """
+            )
+    
+            connection.executemany(
+                """
+                INSERT INTO fact_enrollment_engagement_day_admin_dash (
+                    email,
+                    learning_time_seconds,
+                    is_engaged
+                )
+                VALUES (?, ?, ?)
+                """,
+                [
+                    ('learner1@example.com', 1584, 1),
+                    ('learner2@example.com', 1584, 1),
+                ],
+            )
+    
+            query_filters = mock.Mock()
+            query_filters.to_sql.return_value = '1 = 1'
+    
+            query = (
+                self.engagement_queries
+                .get_learning_hours_and_daily_sessions_query(query_filters)
+            )
+    
+            result = connection.execute(query).fetchone()
+    
+            assert result[0] == 0.8
+            assert result[1] == 2
+        finally:
+            connection.close()
 
     def _mock_run_query(self, query, *args, **kwargs):
         """

--- a/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
+++ b/enterprise_data/tests/api/v1/views/test_enterprise_admin.py
@@ -112,6 +112,7 @@ class TestEnterpriseAdminAnalyticsAggregatesView(JWTTestMixin, APITransactionTes
         Each learner has 1584 seconds, which is 0.44 hours and rounds to 0.4.
         Therefore, the final total should be 0.8 rather than 0.9.
         """
+        # TODO: ENT-12151 - Refactor this test to align with the shared raw SQL query test pattern.
         connection = sqlite3.connect(':memory:')
 
         try:


### PR DESCRIPTION
## Description
 
This PR aligns the Learning Hours calculation between the Engagement Metrics card and the Leaderboard as part of ENT-11979, ensuring both use the same aggregation logic and return consistent values.
 
## Changes
 
- Updated `enterprise_data/admin_analytics/database/queries/fact_engagement_admin_dash.py` to align the Learning Hours calculation with the leaderboard aggregation logic.
- Updated `enterprise_data/tests/api/v1/views/test_enterprise_admin.py` to validate the updated aggregation behavior.
- Verified that the Engagement Metrics card and Leaderboard now calculate Learning Hours consistently.
- Version bump to **10.22.10** and added the corresponding **CHANGELOG** entry.
 
 
### Jira
[ENT-11979](https://2u-internal.atlassian.net/browse/ENT-11979)

## Testing
 
- Ran pytest -q  → 7 passed.
- Ran tox -e quality
<img width="572" height="383" alt="image" src="https://github.com/user-attachments/assets/cfab17a8-64e1-429b-a07e-e1c8a851c8f9" />

