### PR TITLE
chore: bump version to resolve 10.22.11 conflict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,14 +13,13 @@ Change Log
 
 Unreleased
 
+[10.22.12] - 2026-07-30
+-----------------------
+  * fix: align engagement metrics learning-hours aggregation with leaderboard totals
+
 [10.22.11] - 2026-07-27
 -----------------------
   * chore: upgrade python requirements
-
-----------
-[10.22.11] - 2026-07-22
------------------------
-  * fix: align engagement metrics learning-hours aggregation with leaderboard totals
 
 [10.22.10] - 2026-07-16
 -----------------------

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.11"
+__version__ = "10.22.12"


### PR DESCRIPTION
Follow-up to https://github.com/openedx/edx-enterprise-data/pull/697, where version conflict with [10.22.11](https://github.com/openedx/edx-enterprise-data/releases/tag/10.22.11) was missed.