### PR TITLE
fix: simplify unlinked-learner exclusion in the Learner Progress Report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[10.22.14] - 2026-08-06
+-----------------------
+  * fix: simplify unlinked-learner exclusion in the Learner Progress Report [ENT-12136]
+
 [10.22.13] - 2026-08-03
 -----------------------
   * fix: keep non-DSC enrollments visible in the Learner Progress Report [ENT-12136]

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.13"
+__version__ = "10.22.14"

--- a/enterprise_data/api/v1/views/enterprise_learner.py
+++ b/enterprise_data/api/v1/views/enterprise_learner.py
@@ -102,8 +102,8 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSetMixin, viewsets.ReadOn
         # values are merged in later from Snowflake during enrichment.
         enrollments = EnterpriseLearnerEnrollment.objects.filter(
             enterprise_customer_uuid=enterprise_customer_uuid,
-        ).filter(
-            Q(enterprise_user__is_linked=True) | Q(enterprise_user__isnull=True, is_consent_granted=False)
+        ).exclude(
+            enterprise_user__is_linked=False,
         ).extra(select={
             'course_progress': 'NULL',
             'course_passing_grade': 'NULL',

--- a/enterprise_data/tests/api/v1/test_views.py
+++ b/enterprise_data/tests/api/v1/test_views.py
@@ -13,7 +13,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITransactionTestCase
 
-from django.db.models import Q
 from django.utils import timezone
 
 from enterprise_data.api.v1.serializers import EnterpriseOfferSerializer
@@ -440,22 +439,20 @@ class TestEnterpriseLearnerEnrollmentViewSet(JWTTestMixin, APITransactionTestCas
         with_placeholders = mock.Mock()
         filtered_enrollments = mock.Mock()
 
-        consent_filtered = mock.Mock()
+        linked_filtered = mock.Mock()
 
         viewset.kwargs = {'enterprise_id': self.enterprise_id}
         viewset.request = mock.Mock()
         mock_filter.return_value = enrollments
-        enrollments.filter.return_value = consent_filtered
-        consent_filtered.extra.return_value = with_placeholders
+        enrollments.exclude.return_value = linked_filtered
+        linked_filtered.extra.return_value = with_placeholders
         mock_apply_filters.return_value = filtered_enrollments
 
         result = viewset.get_queryset()
 
         mock_filter.assert_called_once_with(enterprise_customer_uuid=self.enterprise_id)
-        enrollments.filter.assert_called_once_with(
-            Q(enterprise_user__is_linked=True) | Q(enterprise_user__isnull=True, is_consent_granted=False)
-        )
-        consent_filtered.extra.assert_called_once_with(select={
+        enrollments.exclude.assert_called_once_with(enterprise_user__is_linked=False)
+        linked_filtered.extra.assert_called_once_with(select={
             'course_progress': 'NULL',
             'course_passing_grade': 'NULL',
         })


### PR DESCRIPTION
JIRA: https://2u-internal.atlassian.net/browse/ENT-12136

Summary
Follow-up to #703. Simplifies the queryset filter in `EnterpriseLearnerEnrollmentViewSet.get_queryset()`:

```python
 before
Q(enterprise_user__is_linked=True) | Q(enterprise_user__isnull=True, is_consent_granted=False)

 after
.exclude(enterprise_user__is_linked=False)
```

 Test plan
- Updated `test_get_queryset_adds_placeholder_metadata_columns` mock assertions for the `.exclude()` call.
- Existing `test_list_includes_non_consented_enrollments_with_no_enterprise_user` and `test_list_excludes_non_consented_enrollments_of_genuinely_unlinked_learners` (from #703) both still pass unchanged, confirming behavior is identical for the ticket's real scenarios.
- Full suite (302 tests) passes.

