### PR TITLE
chore: added Django 5.2 tox and CI compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.12']
-        toxenv: [quality, data-django42, reporting-django42]
+        toxenv: [quality, data-django42, reporting-django42, data-django52, reporting-django52]
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,7 +49,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.12' && (matrix.toxenv=='django42-data' || matrix.toxenv=='django42-reporting')
+      if: matrix.python-version == '3.12' && (matrix.toxenv=='data-django42' || matrix.toxenv=='reporting-django42')
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[10.22.15] - 2026-09-06
+-----------------------
+  * chore: added Django 5.2 tox and CI compatibility checks
+
 [10.22.14] - 2026-08-06
 -----------------------
   * fix: simplify unlinked-learner exclusion in the Learner Progress Report [ENT-12136]

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,4 +2,4 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "10.22.14"
+__version__ = "10.22.15"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {data, reporting}-django{42}
+envlist = {data, reporting}-django{42,52}
 
 [wheel]
 universal = 1
@@ -39,6 +39,8 @@ setenv =
 deps = 
     setuptools
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
+
     data: -r{toxinidir}/requirements/test-master.txt
     reporting: -r{toxinidir}/requirements/test-reporting.txt
 commands = 


### PR DESCRIPTION
**Description:**
Adds Django 5.2 to the project’s tox and CI build matrix, and bumps the package version/changelog to reflect the change.

Changes:
Extend tox test matrix to include a Django 5.2 environment.
Extend GitHub Actions CI to run the added Django 5.2 tox environment.
Bump package version to 3.0.6 and add a changelog entry.
Private JIRA Link:
[BOMS-407](https://2u-internal.atlassian.net/browse/BOMS-407)

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-analytics-data-api doesn't install it
    - `test-master.in` if edx-analytics-data-api pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/openedx/edx-enterprise-data/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise-data/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise-data/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise-data), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise-data/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-analytics-data-api](https://github.com/openedx/edx-analytics-data-api) to upgrade dependencies (including edx-enterprise-data)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-analytics-data-api will look for the latest version in PyPi.
    - Note: the edx-enterprise-data constraint in edx-analytics-data-api **must** also be bumped to the latest version in PyPi.
